### PR TITLE
feat(core): generate Thymian format from HTTP transactions

### DIFF
--- a/core/src/format/edges/has-sample.edge.ts
+++ b/core/src/format/edges/has-sample.edge.ts
@@ -1,0 +1,5 @@
+import type { ThymianBaseEdge } from './edge.js';
+
+export interface HasSample extends ThymianBaseEdge {
+  type: 'has-sample';
+}

--- a/core/src/format/edges/sample-http-transaction.edge.ts
+++ b/core/src/format/edges/sample-http-transaction.edge.ts
@@ -1,0 +1,6 @@
+// sample request -> sample response
+import type { ThymianBaseEdge } from './edge.js';
+
+export interface SampleHttpTransaction extends ThymianBaseEdge {
+  type: 'sample-http-transaction';
+}

--- a/core/src/format/nodes/sample-http-request.node.ts
+++ b/core/src/format/nodes/sample-http-request.node.ts
@@ -1,0 +1,7 @@
+import type { HttpRequest } from '../../http.js';
+import type { ThymianBaseNode } from './node.js';
+
+export interface SampleHttpRequest extends ThymianBaseNode {
+  type: 'sample-http-request';
+  sample: HttpRequest;
+}

--- a/core/src/format/nodes/sample-http-response.node.ts
+++ b/core/src/format/nodes/sample-http-response.node.ts
@@ -1,0 +1,7 @@
+import type { HttpResponse } from '../../http.js';
+import type { ThymianBaseNode } from './node.js';
+
+export interface SampleHttpResponse extends ThymianBaseNode {
+  type: 'sample-http-response';
+  sample: HttpResponse;
+}

--- a/core/src/format/thymian-format.ts
+++ b/core/src/format/thymian-format.ts
@@ -14,17 +14,27 @@ import {
   capitalizeFirstChar,
   equalsIgnoreCase,
   getContentType,
+  httpRequestToLabel,
+  httpResponseToLabel,
   normalizeUrl,
   type PartialBy,
   thymianRequestToOrigin,
 } from '../utils.js';
 import { matchObjects, type StringAndNumberProperties } from '../utils.js';
+import type { HasSample } from './edges/has-sample.edge.js';
 import type { HttpLink } from './edges/http-link.edge.js';
 import type { HttpTransaction } from './edges/http-transaction.edge.js';
 import type { IsSecuredWith } from './edges/is-secured-with.edge.js';
+import type { SampleHttpTransaction } from './edges/sample-http-transaction.edge.js';
 import type { ThymianHttpRequest } from './nodes/http-request.node.js';
 import type { ThymianHttpResponse } from './nodes/http-response.node.js';
+import type { SampleHttpRequest } from './nodes/sample-http-request.node.js';
+import type { SampleHttpResponse } from './nodes/sample-http-response.node.js';
 import type { SecurityScheme } from './nodes/security-scheme.node.js';
+import {
+  httpRequestToThymianHttpRequest,
+  httpResponseToThymianHttpResponse,
+} from './utils.js';
 
 export type MatchResult = {
   reqId: string;
@@ -49,12 +59,16 @@ export interface ThymianNodes {
   'http-request': ThymianHttpRequest;
   'http-response': ThymianHttpResponse;
   'security-scheme': SecurityScheme;
+  'sample-http-request': SampleHttpRequest;
+  'sample-http-response': SampleHttpResponse;
 }
 
 export interface ThymianEdges {
   'http-link': HttpLink;
   'http-transaction': HttpTransaction;
   'is-secured': IsSecuredWith;
+  'sample-http-transaction': SampleHttpTransaction;
+  'has-sample': HasSample;
 }
 
 export type ThymianHttpTransaction = {
@@ -446,6 +460,36 @@ export class ThymianFormat {
     return this.getNode<ThymianNodes[Type]>(nodeId);
   }
 
+  addSampleHttpRequest(request: HttpRequest): string {
+    return this.addNode({
+      type: 'sample-http-request',
+      label: httpRequestToLabel(request),
+      sample: request,
+    });
+  }
+
+  addSampleHttpResponse(response: HttpResponse): string {
+    return this.addNode({
+      type: 'sample-http-response',
+      label: httpResponseToLabel(response),
+      sample: response,
+    });
+  }
+
+  addSampleHttpTransaction(
+    request: HttpRequest,
+    response: HttpResponse
+  ): [string, string, string] {
+    const reqId = this.addSampleHttpRequest(request);
+    const resId = this.addSampleHttpResponse(response);
+    const transactionId = this.addEdge(reqId, reqId, {
+      type: 'sample-http-transaction',
+      label: `Sample HTTP Transaction`,
+    });
+
+    return [reqId, resId, transactionId];
+  }
+
   export(): SerializedThymianFormat {
     return this.graph.export();
   }
@@ -458,6 +502,33 @@ export class ThymianFormat {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   merge(format: ThymianFormat): ThymianFormat {
     return this;
+  }
+
+  static fromHttpTransactions(
+    transactions: [HttpRequest, HttpResponse][]
+  ): ThymianFormat {
+    const format = new ThymianFormat();
+
+    for (const [req, res] of transactions) {
+      const thymianReq = httpRequestToThymianHttpRequest(req);
+      const thymianRes = httpResponseToThymianHttpResponse(res);
+
+      const [sampleReqId, sampleResId] = format.addSampleHttpTransaction(
+        req,
+        res
+      );
+
+      const [reqId, resId] = format.addHttpTransaction(thymianReq, thymianRes);
+
+      format.addEdge(reqId, sampleReqId, {
+        type: 'has-sample',
+      });
+      format.addEdge(resId, sampleResId, {
+        type: 'has-sample',
+      });
+    }
+
+    return format;
   }
 
   static import(graph: SerializedThymianFormat): ThymianFormat {

--- a/core/src/format/utils.ts
+++ b/core/src/format/utils.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_HEADER_SERIALIZATION_STYLE } from '../constants.js';
+import type { HttpRequest, HttpResponse } from '../http.js';
+import {
+  equalsIgnoreCase,
+  getContentType,
+  getHeader,
+  type PartialBy,
+} from '../utils.js';
+import type { ThymianHttpRequest } from './nodes/http-request.node.js';
+import type { ThymianHttpResponse } from './nodes/http-response.node.js';
+import type { Parameter } from './parameter.js';
+import type { SerializationStyle } from './serialization-style/index.js';
+
+export function extractSchemaForValue(
+  value: string
+): 'string' | 'integer' | 'number' | 'boolean' {
+  if (!isNaN(parseInt(value))) {
+    return 'integer';
+  }
+
+  if (!isNaN(parseFloat(value))) {
+    return 'number';
+  }
+
+  if (value === 'true' || value === 'false') {
+    return 'boolean';
+  }
+
+  return 'string';
+}
+
+export function valueToParameter(
+  value: string | string[] | undefined,
+  style: SerializationStyle
+): Parameter | undefined {
+  if (Array.isArray(value)) {
+    return {
+      required: true,
+      schema: {
+        type: extractSchemaForValue(value[0] ?? ''),
+        examples: value,
+      },
+      style,
+    };
+  }
+
+  if (typeof value === 'string') {
+    return {
+      required: false,
+      schema: {
+        type: extractSchemaForValue(value),
+        examples: [value],
+      },
+      style,
+    };
+  }
+
+  return undefined;
+}
+
+export function parameterValuesToParameters(
+  values: Record<string, string | string[] | undefined>,
+  style: SerializationStyle
+): Record<string, Parameter> {
+  return Object.entries(values).reduce((acc, [key, value]) => {
+    if (equalsIgnoreCase(key, 'content-type')) return acc;
+
+    const parameter = valueToParameter(value, style);
+
+    if (!parameter) return acc;
+
+    acc[key] = parameter;
+
+    return acc;
+  }, {} as Record<string, Parameter>);
+}
+
+export function httpRequestToThymianHttpRequest(
+  request: HttpRequest
+): PartialBy<ThymianHttpRequest, 'label'> {
+  const url = new URL(request.path, request.origin);
+
+  return {
+    host: url.host,
+    mediaType: getContentType(request.headers),
+    method: request.method,
+    path: request.path,
+    port: parseInt(url.port) || (url.protocol === 'https:' ? 443 : 80),
+    protocol: url.protocol === 'https:' ? 'https' : 'http',
+    type: 'http-request',
+    cookies: {},
+    headers: parameterValuesToParameters(
+      request.headers ?? {},
+      DEFAULT_HEADER_SERIALIZATION_STYLE
+    ),
+    pathParameters: {},
+    queryParameters: {},
+  };
+}
+
+export function httpResponseToThymianHttpResponse(
+  response: HttpResponse
+): ThymianHttpResponse {
+  const thymianHttpResponse: ThymianHttpResponse = {
+    type: 'http-response',
+    label: '',
+    statusCode: response.statusCode,
+    mediaType: getContentType(response.headers),
+    headers: parameterValuesToParameters(
+      response.headers ?? {},
+      DEFAULT_HEADER_SERIALIZATION_STYLE
+    ),
+  };
+
+  if (response.body) {
+    thymianHttpResponse.schema = {
+      type: 'string',
+      examples: [response.body],
+    };
+  }
+
+  return thymianHttpResponse;
+}

--- a/core/src/thymian.error.ts
+++ b/core/src/thymian.error.ts
@@ -32,6 +32,8 @@ export function isThymianError(value: unknown): value is ThymianError {
 }
 
 export class ThymianBaseError extends Error implements ThymianError {
+  override cause?: unknown;
+
   public readonly options: PartialExceptFor<ThymianErrorOptions, 'severity'>;
   constructor(
     message: string,

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -8,6 +8,7 @@ import type {
   ThymianHttpRequest,
   ThymianHttpResponse,
 } from './format/index.js';
+import type { HttpRequest, HttpResponse } from './http.js';
 
 export function timeoutPromise<T>(
   promise: Promise<T>,
@@ -189,6 +190,25 @@ export function normalizeUrl(urlString: string): string {
   }
 
   return url.toString();
+}
+
+export function httpRequestToLabel(request: HttpRequest): string {
+  return `${request.method.toUpperCase()} ${new URL(
+    request.path,
+    request.origin
+  ).toString()}`;
+}
+
+export function httpResponseToLabel(response: HttpResponse): string {
+  const contentType = getHeader(response.headers, 'content-type');
+  const mediaType =
+    (Array.isArray(contentType) ? contentType[0] : contentType) ?? '';
+
+  return `${response.statusCode} ${
+    isValidHttpStatusCode(response.statusCode)
+      ? httpStatusCodeToPhrase[response.statusCode]
+      : ''
+  } ${mediaType}`;
 }
 
 export * from 'chalk';

--- a/core/test/format/thymian-format.test.ts
+++ b/core/test/format/thymian-format.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { HttpRequest, HttpResponse, ThymianFormat } from '../../src';
+
+describe('ThymianFormat', () => {
+  describe('fromHttpTransactions', () => {
+    it('should create a valid ThymianFormat graph for given HTTP transactions', () => {
+      const transactions: [HttpRequest, HttpResponse][] = [
+        [
+          { origin: 'https://api.example.com', path: '/users', method: 'GET' },
+          {
+            statusCode: 200,
+            headers: {},
+            body: '[]',
+            trailers: {},
+            duration: 50,
+          },
+        ],
+        [
+          { origin: 'https://api.example.com', path: '/posts', method: 'POST' },
+          {
+            statusCode: 201,
+            headers: {},
+            body: '{}',
+            trailers: {},
+            duration: 75,
+          },
+        ],
+      ];
+
+      const thymianFormat = ThymianFormat.fromHttpTransactions(transactions);
+      expect(thymianFormat).toBeInstanceOf(ThymianFormat);
+
+      const httpTransactions = thymianFormat.getThymianHttpTransactions();
+      expect(httpTransactions.length).toBe(2);
+    });
+
+    it('should handle invalid transactions gracefully', () => {
+      const transactions = [
+        // Missing response in a transaction
+        [
+          { origin: 'https://api.example.com', path: '/users', method: 'GET' },
+          null,
+        ],
+      ];
+
+      expect(() =>
+        ThymianFormat.fromHttpTransactions(
+          transactions as [HttpRequest, HttpResponse][]
+        )
+      ).toThrow();
+    });
+  });
+});

--- a/core/test/format/utils.test.ts
+++ b/core/test/format/utils.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  HttpRequest,
+  HttpResponse,
+  ThymianHttpRequest,
+  ThymianHttpResponse,
+} from '../../src';
+import {
+  httpRequestToThymianHttpRequest,
+  httpResponseToThymianHttpResponse,
+} from '../../src/format/utils';
+
+describe('httpRequestToThymianHttpRequest', () => {
+  it('should convert a basic HttpRequest to ThymianHttpRequest', () => {
+    const request: HttpRequest = {
+      origin: 'http://example.com',
+      path: '/test',
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json',
+      },
+    };
+
+    const result = httpRequestToThymianHttpRequest(request);
+
+    expect(result).toEqual<Partial<ThymianHttpRequest>>({
+      host: 'example.com',
+      method: 'GET',
+      path: '/test',
+      mediaType: 'application/json',
+      port: 80,
+      protocol: 'http',
+      type: 'http-request',
+      cookies: {},
+      headers: {},
+      pathParameters: {},
+      queryParameters: {},
+    });
+  });
+
+  it('should handle missing headers and default values correctly', () => {
+    const request: HttpRequest = {
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'POST',
+    };
+
+    const result = httpRequestToThymianHttpRequest(request);
+
+    expect(result).toEqual<Partial<ThymianHttpRequest>>({
+      host: 'example.com',
+      method: 'POST',
+      path: '/test',
+      mediaType: '',
+      port: 443,
+      protocol: 'https',
+      type: 'http-request',
+      cookies: {},
+      headers: {},
+      pathParameters: {},
+      queryParameters: {},
+    });
+  });
+
+  it('should handle array headers correctly', () => {
+    const request: HttpRequest = {
+      origin: 'http://example.com',
+      path: '/test',
+      method: 'GET',
+      headers: {
+        'x-custom-header': ['value1', 'value2'],
+      },
+    };
+
+    const result = httpRequestToThymianHttpRequest(request);
+
+    expect(result.headers).toEqual({
+      'x-custom-header': {
+        required: true,
+        style: {
+          explode: false,
+          style: 'simple',
+        },
+        schema: {
+          type: 'string',
+          examples: ['value1', 'value2'],
+        },
+      },
+    });
+  });
+
+  it('should parse port from origin if specified', () => {
+    const request: HttpRequest = {
+      origin: 'http://example.com:3000',
+      path: '/test',
+      method: 'GET',
+    };
+
+    const result = httpRequestToThymianHttpRequest(request);
+
+    expect(result.port).toBe(3000);
+  });
+
+  it('should default port to 80 for http and 443 for https when not specified', () => {
+    const httpRequest: HttpRequest = {
+      origin: 'http://example.com',
+      path: '/test',
+      method: 'GET',
+    };
+
+    const httpsRequest: HttpRequest = {
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'GET',
+    };
+
+    const httpResult = httpRequestToThymianHttpRequest(httpRequest);
+    const httpsResult = httpRequestToThymianHttpRequest(httpsRequest);
+
+    expect(httpResult.port).toBe(80);
+    expect(httpsResult.port).toBe(443);
+  });
+});
+
+describe('httpResponseToThymianHttpResponse', () => {
+  it('should convert a basic HttpResponse to ThymianHttpResponse', () => {
+    const response: HttpResponse = {
+      statusCode: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: '{"key":"value"}',
+      trailers: {},
+      duration: 50,
+    };
+
+    const result = httpResponseToThymianHttpResponse(response);
+
+    expect(result).toEqual<Partial<ThymianHttpResponse>>({
+      type: 'http-response',
+      statusCode: 200,
+      label: '',
+      mediaType: 'application/json',
+      schema: {
+        type: 'string',
+        examples: ['{"key":"value"}'],
+      },
+      headers: {},
+    });
+  });
+
+  it('should handle missing headers and body gracefully', () => {
+    const response: HttpResponse = {
+      statusCode: 404,
+      headers: {},
+      trailers: {},
+      duration: 100,
+    };
+
+    const result = httpResponseToThymianHttpResponse(response);
+
+    expect(result).toEqual<Partial<ThymianHttpResponse>>({
+      type: 'http-response',
+      statusCode: 404,
+      mediaType: '',
+      label: '',
+      headers: {},
+    });
+  });
+
+  it('should handle array headers correctly', () => {
+    const response: HttpResponse = {
+      statusCode: 200,
+      headers: {
+        'x-multiple-values': ['value1', 'value2'],
+      },
+      trailers: {},
+      duration: 30,
+    };
+
+    const result = httpResponseToThymianHttpResponse(response);
+
+    expect(result.headers).toEqual({
+      'x-multiple-values': {
+        required: true,
+        style: {
+          explode: false,
+          style: 'simple',
+        },
+        schema: {
+          type: 'string',
+          examples: ['value1', 'value2'],
+        },
+      },
+    });
+  });
+
+  it('should parse a response with a body correctly', () => {
+    const response: HttpResponse = {
+      statusCode: 500,
+      headers: {
+        'content-type': 'text/plain',
+      },
+      body: 'Internal Server Error',
+      trailers: {},
+      duration: 500,
+    };
+
+    const result = httpResponseToThymianHttpResponse(response);
+
+    expect(result.schema).toEqual({
+      type: 'string',
+      examples: ['Internal Server Error'],
+    });
+  });
+});


### PR DESCRIPTION
This feature makes it possible to create a `ThymianFormat` instance from any list of HTTP Transactions. The requests and responses the format is created from are also part of the Thymian format within so-called "Sample" nodes.