### PR TITLE
fix(core): emit core.close before rejecting for error event

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@
 /coverage
 /.nx/cache
 /.nx/workspace-data
-/core/src/thymian.ts
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 /coverage
 /.nx/cache
 /.nx/workspace-data
+/core/src/thymian.ts

--- a/core/src/thymian.ts
+++ b/core/src/thymian.ts
@@ -1,19 +1,20 @@
 import { Subject } from 'rxjs';
 import semver from 'semver';
 
-// prettier-ignore
 import packageJson from '../package.json' with { type: 'json' };
 import { validate } from './ajv.js';
 import { corePlugin } from './core-plugin.js';
 import { ThymianEmitter } from './emitter/index.js';
-import {  ThymianFormat } from './format/index.js';
+import { ThymianFormat } from './format/index.js';
 import type { Logger } from './logger/logger.js';
 import { NoopLogger } from './logger/noop.logger.js';
 import { ThymianBaseError } from './thymian.error.js';
 import type { ThymianPlugin } from './thymian-plugin.js';
 import { timeoutPromise } from './utils.js';
 
-export type RegisteredPlugin<T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>> = {
+export type RegisteredPlugin<
+  T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
+> = {
   plugin: ThymianPlugin<T>;
   options: T;
 };
@@ -21,10 +22,10 @@ export type RegisteredPlugin<T extends Record<PropertyKey, unknown> = Record<Pro
 export class PluginRegistrationError extends ThymianBaseError {}
 
 export type ThymianOptions = {
-  timeout: number
-  traceEvents: boolean,
-  cwd: string
-}
+  timeout: number;
+  traceEvents: boolean;
+  cwd: string;
+};
 
 export class Thymian {
   readonly plugins: RegisteredPlugin[] = [];
@@ -37,35 +38,49 @@ export class Thymian {
 
   public static readonly VERSION = packageJson.version;
 
-  constructor(private readonly logger: Logger = new NoopLogger(), options: Partial<ThymianOptions> = {}) {
+  constructor(
+    private readonly logger: Logger = new NoopLogger(),
+    options: Partial<ThymianOptions> = {},
+  ) {
     this.options = {
       timeout: 5000,
       traceEvents: false,
       cwd: process.cwd(),
-      ...options
-    }
+      ...options,
+    };
 
-
-    const emitterLogger = this.options.traceEvents ? logger.child('@thymian/core', true) : new NoopLogger()
-    this.emitter = new ThymianEmitter(emitterLogger, {
-      completed: new Set(),
-      errors: new Subject(),
-      events: new Subject(),
-      listeners: new Map(),
-      responses: new Subject(),
-      source: '@thymian/core',
-    }, {
-      traceEvents: this.options.traceEvents,
-      timeout: this.options.timeout,
-    });
+    const emitterLogger = this.options.traceEvents
+      ? logger.child('@thymian/core', true)
+      : new NoopLogger();
+    this.emitter = new ThymianEmitter(
+      emitterLogger,
+      {
+        completed: new Set(),
+        errors: new Subject(),
+        events: new Subject(),
+        listeners: new Map(),
+        responses: new Subject(),
+        source: '@thymian/core',
+      },
+      {
+        traceEvents: this.options.traceEvents,
+        timeout: this.options.timeout,
+      },
+    );
   }
 
-  register<T extends Record<PropertyKey, unknown>>(plugin: ThymianPlugin<T>, options?: T): this {
+  register<T extends Record<PropertyKey, unknown>>(
+    plugin: ThymianPlugin<T>,
+    options?: T,
+  ): this {
     if (!semver.satisfies(Thymian.VERSION, plugin.version)) {
       throw new PluginRegistrationError(
-        `@thymian/core version ${Thymian.VERSION} does not match plugin version constraints ${plugin.version} from plugin "${plugin.name}".`, {
-          suggestions: [`Install the matching plugin version for thymian version ${Thymian.VERSION}.`]
-        }
+        `@thymian/core version ${Thymian.VERSION} does not match plugin version constraints ${plugin.version} from plugin "${plugin.name}".`,
+        {
+          suggestions: [
+            `Install the matching plugin version for thymian version ${Thymian.VERSION}.`,
+          ],
+        },
       );
     }
 
@@ -74,7 +89,7 @@ export class Thymian {
 
       if (!validOptions) {
         throw new PluginRegistrationError(
-          `Invalid options for plugin "${plugin.name}".`
+          `Invalid options for plugin "${plugin.name}".`,
         );
       }
     }
@@ -100,19 +115,23 @@ export class Thymian {
     this.#ready = true;
   }
 
-  run<T>(fn: (emitter: ThymianEmitter, logger: Logger) => Promise<T> | T): Promise<T> {
+  run<T>(
+    fn: (emitter: ThymianEmitter, logger: Logger) => Promise<T> | T,
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
-      const tryCloseThymian = (err: unknown)=> {
+      const tryCloseThymian = (err: unknown) => {
         this.logger.debug('Try closing Thymian...');
 
-        this.close().then(() => {
-          this.logger.debug('Thymian closed.');
-          reject(err)
-        }).catch((e) => {
-          this.logger.error('Error while closing Thymian.', e);
-          reject(err)
-        })
-      }
+        this.close()
+          .then(() => {
+            this.logger.debug('Thymian closed.');
+            reject(err);
+          })
+          .catch((e) => {
+            this.logger.error('Error while closing Thymian.', e);
+            reject(err);
+          });
+      };
 
       this.emitter.onError((event) => {
         if (event.error.options.severity === 'error') {
@@ -131,46 +150,62 @@ export class Thymian {
 
         await this.close();
 
-        return result
+        return result;
       })()
         .then(resolve)
         .catch((err) => {
-          tryCloseThymian(err)
+          tryCloseThymian(err);
         });
-    })
+    });
   }
 
-
   async close(): Promise<void> {
-     await this.emitter.emitAction('core.close');
+    await this.emitter.emitAction('core.close');
   }
 
   async loadFormat(): Promise<ThymianFormat> {
-    const formats = await this.emitter.emitAction('core.load-format', undefined, {
-      timeout: 2000,
-      strategy: 'collect'
-    })
+    const formats = await this.emitter.emitAction(
+      'core.load-format',
+      undefined,
+      {
+        timeout: 2000,
+        strategy: 'collect',
+      },
+    );
 
-    const format = formats.length === 0
-      ? new ThymianFormat()
-      // we know that formats.length >= 1
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      : formats.slice(1).reduce((acc, curr) => acc.merge(ThymianFormat.import(curr)), ThymianFormat.import(formats[0]!))
+    const format =
+      formats.length === 0
+        ? new ThymianFormat()
+        : // we know that formats.length >= 1
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          formats
+            .slice(1)
+            .reduce(
+              (acc, curr) => acc.merge(ThymianFormat.import(curr)),
+              ThymianFormat.import(formats[0]!),
+            );
 
-    this.logger.debug(`Merged Thymian format includes ${format.graph.order} nodes and ${format.graph.size} edges.`)
+    this.logger.debug(
+      `Merged Thymian format includes ${format.graph.order} nodes and ${format.graph.size} edges.`,
+    );
 
-    return format
+    return format;
   }
 
   private async loadRegisteredPlugins(): Promise<void> {
-    await this.registerPlugin({ plugin: corePlugin, options: { cwd: this.options.cwd } })
+    await this.registerPlugin({
+      plugin: corePlugin,
+      options: { cwd: this.options.cwd },
+    });
 
     for (const plugin of this.plugins) {
       await this.registerPlugin(plugin);
     }
   }
 
-  private async registerPlugin(registeredPlugin: RegisteredPlugin): Promise<void> {
+  private async registerPlugin(
+    registeredPlugin: RegisteredPlugin,
+  ): Promise<void> {
     this.emitter.emit('core.register', {
       name: registeredPlugin.plugin.name,
       events: registeredPlugin.plugin.events ?? {},
@@ -178,14 +213,21 @@ export class Thymian {
     });
 
     await timeoutPromise(
-      registeredPlugin.plugin.plugin(this.emitter.child(registeredPlugin.plugin.name), this.logger.child(registeredPlugin.plugin.name), { ...registeredPlugin.options, cwd: this.options.cwd }),
+      registeredPlugin.plugin.plugin(
+        this.emitter.child(registeredPlugin.plugin.name),
+        this.logger.child(registeredPlugin.plugin.name),
+        { ...registeredPlugin.options, cwd: this.options.cwd },
+      ),
       this.options.timeout,
-      new PluginRegistrationError(`Timeout while registering plugin "${registeredPlugin.plugin.name}".`, {
-        suggestions: [
-          'Increase plugin timeout duration. Using the Thymian CLI try using "--timeout" to set custom timeout (default 5000ms).',
-          'Check your plugin registration logic.'
-        ]
-      })
+      new PluginRegistrationError(
+        `Timeout while registering plugin "${registeredPlugin.plugin.name}".`,
+        {
+          suggestions: [
+            'Increase plugin timeout duration. Using the Thymian CLI try using "--timeout" to set custom timeout (default 5000ms).',
+            'Check your plugin registration logic.',
+          ],
+        },
+      ),
     );
   }
 }

--- a/core/src/thymian.ts
+++ b/core/src/thymian.ts
@@ -102,15 +102,21 @@ export class Thymian {
 
   run<T>(fn: (emitter: ThymianEmitter, logger: Logger) => Promise<T> | T): Promise<T> {
     return new Promise((resolve, reject) => {
-      const tryClose = (err: unknown)=> {
+      const tryCloseThymian = (err: unknown)=> {
         this.logger.debug('Try closing Thymian...');
 
-        this.close().then(() => reject(err));
+        this.close().then(() => {
+          this.logger.debug('Thymian closed.');
+          reject(err)
+        }).catch((e) => {
+          this.logger.error('Error while closing Thymian.', e);
+          reject(err)
+        })
       }
 
       this.emitter.onError((event) => {
         if (event.error.options.severity === 'error') {
-          tryClose(event.error);
+          tryCloseThymian(event.error);
         } else if (event.error.options.severity === 'warn') {
           this.logger.warn(event.error.message);
         } else {
@@ -129,7 +135,7 @@ export class Thymian {
       })()
         .then(resolve)
         .catch((err) => {
-          tryClose(err)
+          tryCloseThymian(err)
         });
     })
   }

--- a/core/src/thymian.ts
+++ b/core/src/thymian.ts
@@ -1,6 +1,7 @@
 import { Subject } from 'rxjs';
 import semver from 'semver';
 
+// prettier-ignore
 import packageJson from '../package.json' with { type: 'json' };
 import { validate } from './ajv.js';
 import { corePlugin } from './core-plugin.js';
@@ -101,9 +102,15 @@ export class Thymian {
 
   run<T>(fn: (emitter: ThymianEmitter, logger: Logger) => Promise<T> | T): Promise<T> {
     return new Promise((resolve, reject) => {
+      const tryClose = (err: unknown)=> {
+        this.logger.debug('Try closing Thymian...');
+
+        this.close().then(() => reject(err));
+      }
+
       this.emitter.onError((event) => {
         if (event.error.options.severity === 'error') {
-          reject(event.error);
+          tryClose(event.error);
         } else if (event.error.options.severity === 'warn') {
           this.logger.warn(event.error.message);
         } else {
@@ -122,9 +129,7 @@ export class Thymian {
       })()
         .then(resolve)
         .catch((err) => {
-          this.logger.debug('Try closing Thymian...');
-
-          this.close().then(() => reject(err));
+          tryClose(err)
         });
     })
   }

--- a/core/test/thymian.test.ts
+++ b/core/test/thymian.test.ts
@@ -6,6 +6,7 @@ import {
   Thymian,
   ThymianFormat,
   type ThymianPlugin,
+  ThymianPluginFn,
 } from '../src/index.js';
 
 declare module '../src/events/index.js' {
@@ -28,6 +29,16 @@ const plugin: ThymianPlugin = {
   version: '',
   plugin: () => Promise.resolve(),
 };
+
+function createPluginFor(
+  plugin: ThymianPluginFn<{ cwd: string }>
+): ThymianPlugin {
+  return {
+    name: '',
+    version: '',
+    plugin,
+  };
+}
 
 describe('Thymian', () => {
   let thymian: Thymian;
@@ -109,5 +120,50 @@ describe('Thymian', () => {
         version: '1.x',
       })
     ).toThrowError(PluginRegistrationError);
+  });
+
+  it('should call close action before rejecting promise for error event', async () => {
+    const closedSpy = vitest.fn();
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.close', (_, ctx) => {
+          setTimeout(() => {
+            closedSpy();
+            ctx.reply();
+          }, 1000);
+        });
+      })
+    );
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.run', (_, ctx) => {
+          emitter.emitError({
+            message: 'Error event!',
+            name: 'MyError',
+            options: {
+              severity: 'error',
+            },
+          });
+
+          ctx.reply({ pluginName: '', status: 'success' });
+        });
+      })
+    );
+
+    try {
+      await thymian.run(async () => {
+        await thymian.emitter.emitAction(
+          'core.run',
+          new ThymianFormat().export()
+        );
+      });
+    } catch (err) {
+      expect(closedSpy).toHaveBeenCalled();
+      expect(err).toMatchObject({
+        message: 'Error event!',
+      });
+    }
   });
 });

--- a/core/test/thymian.test.ts
+++ b/core/test/thymian.test.ts
@@ -128,10 +128,8 @@ describe('Thymian', () => {
     thymian.register(
       createPluginFor(async (emitter) => {
         emitter.onAction('core.close', (_, ctx) => {
-          setTimeout(() => {
-            closedSpy();
-            ctx.reply();
-          }, 1000);
+          closedSpy();
+          ctx.reply();
         });
       })
     );
@@ -159,6 +157,7 @@ describe('Thymian', () => {
           new ThymianFormat().export()
         );
       });
+      expect.fail('Thymian should have rejected the promise.');
     } catch (err) {
       expect(closedSpy).toHaveBeenCalled();
       expect(err).toMatchObject({

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "jsonc-eslint-parser": "^2.1.0",
         "lint-staged": "^16.1.6",
         "nx": "21.5.3",
-        "prettier": "^2.6.2",
+        "prettier": "^3.6.2",
         "tslib": "^2.3.0",
         "typescript": "5.9.2",
         "typescript-eslint": "8.44.0",
@@ -18568,16 +18568,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jsonc-eslint-parser": "^2.1.0",
     "lint-staged": "^16.1.6",
     "nx": "21.5.3",
-    "prettier": "^2.6.2",
+    "prettier": "^3.6.2",
     "tslib": "^2.3.0",
     "typescript": "5.9.2",
     "typescript-eslint": "8.44.0",


### PR DESCRIPTION
This PR ensures that the close action is called and awaitesd before the promise is rejected. This `thymian.ts` file must be ignored for `prettier` because the `with { type: 'json' }` is not supported in version <3.