### PR TITLE
chore(repo): setup local publishing with verdaccio

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -8,6 +8,20 @@ uplinks:
     maxage: 60m
 
 packages:
+  'thymian':
+    # give all users (including non-authenticated users) full access
+    # because it is a local registry
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '@thymian/*':
+    # give all users (including non-authenticated users) full access
+    # because it is a local registry
+    access: $all
+    publish: $all
+    unpublish: $all
+
   '**':
     # give all users (including non-authenticated users) full access
     # because it is a local registry

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 You want to try out Thymian? Run the following commands in the specific order:
 
-* `npm i`
-* `nx build cli`
-* `npx tsx shared/test-utils/src/example-app/server.ts`
-* `cd cli`
-* `./bin/run.js run -o @thymian/openapi.filePath=../shared/test-utils/src/example-app/example-app.openapi.yaml -p test/fixtures/my-thymian-plugin.js`
+- `npm i`
+- `nx build cli`
+- `npx tsx shared/test-utils/src/example-app/server.ts`
+- `cd cli`
+- `./bin/run.js run -o @thymian/openapi.filePath=../shared/test-utils/src/example-app/example-app.openapi.yaml -p test/fixtures/my-thymian-plugin.js`
+
+# local publish
+
+1. Start verdaccio: `npm run local-registry`
+2. Publish to local registry: `npx nx release publish --registry http://localhost:4873` or `npm run local-publish`

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -1,14 +1,24 @@
 #!/usr/bin/env node
 
+import path from 'node:path';
+
 import { getPluginNames, oclif } from '@thymian/cli-common';
 
+const thymianPath = import.meta.url.includes('node_modules')
+  ? path.join(process.cwd(), 'node_modules', 'thymian')
+  : import.meta.url;
+
+const pluginsPath = import.meta.url.includes('node_modules')
+  ? thymianPath
+  : process.cwd();
+
 await oclif.execute({
-  dir: import.meta.url,
+  dir: thymianPath,
   loadOptions: {
     pluginAdditions: {
       core: await getPluginNames(),
-      path: process.cwd(),
+      path: pluginsPath,
     },
-    root: import.meta.url,
+    root: thymianPath,
   },
 });

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -23,6 +23,7 @@ export default {
         'sampler',
         'test-utils',
         'repo',
+        'release',
       ],
     ],
     'scope-empty': [2, 'never'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22197,7 +22197,7 @@
         "@fastify/swagger": "^9.5.1",
         "@fastify/swagger-ui": "^5.2.3",
         "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
-        "@thymian/core": "0.0.1",
+        "@thymian/core": "^0",
         "etag": "^1.8.1",
         "fastify": "^5.4.0",
         "fastify-plugin": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "format:check": "nx run-many -t format:check",
     "build": "nx run-many -t build --exclude @thymian/source",
     "lint": "nx affected:lint",
-    "prepare": "husky"
+    "prepare": "husky",
+    "local-registry": "nx local-registry",
+    "local-publish": "nx release publish --registry http://localhost:4873"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [

--- a/shared/test-utils/package.json
+++ b/shared/test-utils/package.json
@@ -19,7 +19,7 @@
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
     "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
-    "@thymian/core": "0.0.1",
+    "@thymian/core": "^0",
     "etag": "^1.8.1",
     "fastify": "^5.4.0",
     "fastify-plugin": "^5.0.1",


### PR DESCRIPTION
## Pull Request Overview

This PR sets up local publishing capabilities using Verdaccio for the Thymian monorepo, enabling developers to test package publishing locally before releasing to the public registry.

- Adds npm scripts for running a local registry and publishing packages locally
- Configures Verdaccio to allow publishing of Thymian packages without authentication
- Updates documentation with instructions for local publishing workflow