### PR TITLE
fix swagger detection and change peer dependencies to real ones

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -26,13 +26,11 @@
     "graphology": "^0.26.0",
     "path-to-regexp": "^8.2.0",
     "rxjs": "^7.8.2",
-    "semver": "^7.7.1"
+    "semver": "^7.7.1",
+    "@thymian/http-status-codes": "^0"
   },
   "devDependencies": {
     "@types/semver": "^7.7.0",
     "graphology-types": "^0.24.8"
-  },
-  "peerDependencies": {
-    "@thymian/http-status-codes": "^0"
   }
 }

--- a/libs/cli-common/package.json
+++ b/libs/cli-common/package.json
@@ -24,9 +24,7 @@
     "@inquirer/prompts": "^7.6.0",
     "tslib": "^2.3.0",
     "yaml": "^2.8.0",
-    "@oclif/core": "^4.3.3"
-  },
-  "peerDependencies": {
+    "@oclif/core": "^4.3.3",
     "@thymian/core": "^0"
   }
 }

--- a/libs/http-testing/package.json
+++ b/libs/http-testing/package.json
@@ -21,9 +21,7 @@
   "dependencies": {
     "ajv-formats": "^3.0.1",
     "secure-json-parse": "^4.0.0",
-    "url-template": "^3.1.1"
-  },
-  "peerDependencies": {
+    "url-template": "^3.1.1",
     "@thymian/core": "^0",
     "@thymian/http-filter": "^0.0.1",
     "rxjs": "^7.8.2",

--- a/libs/rfc-9110-rules/package.json
+++ b/libs/rfc-9110-rules/package.json
@@ -17,7 +17,7 @@
     "dist",
     "!**/*.tsbuildinfo"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "@thymian/core": "^0",
     "@thymian/http-filter": "^0",
     "@thymian/http-linter": "^0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "test": "nx run-many -t test",
     "format:check": "nx run-many -t format:check",
-    "build": "nx run-many -t build --exclude @thymian/source",
+    "build": "nx run-many -t build",
     "lint": "nx affected:lint",
     "prepare": "husky",
     "local-registry": "nx local-registry",
-    "local-publish": "nx release publish --registry http://localhost:4873"
+    "local-publish": "npm run build && nx release publish --registry http://localhost:4873"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [

--- a/plugins/cli-reporter/package.json
+++ b/plugins/cli-reporter/package.json
@@ -19,9 +19,7 @@
   ],
   "dependencies": {
     "chalk": "4.1.2",
-    "console-table-printer": "^2.14.6"
-  },
-  "peerDependencies": {
+    "console-table-printer": "^2.14.6",
     "@thymian/core": "^0"
   }
 }

--- a/plugins/format-validator/package.json
+++ b/plugins/format-validator/package.json
@@ -17,7 +17,7 @@
     "dist",
     "!**/*.tsbuildinfo"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "@thymian/cli-common": "0.0.1",
     "@thymian/core": "0.0.1",
     "@thymian/http-testing": "0.0.1",

--- a/plugins/http-linter/package.json
+++ b/plugins/http-linter/package.json
@@ -21,9 +21,7 @@
     "better-sqlite3": "^12.2.0",
     "fuse.js": "^7.1.0",
     "tinyglobby": "^0.2.14",
-    "tslib": "^2.3.0"
-  },
-  "peerDependencies": {
+    "tslib": "^2.3.0",
     "@thymian/cli-common": "^0",
     "@thymian/core": "^0",
     "@thymian/http-filter": "^0",

--- a/plugins/openapi/package.json
+++ b/plugins/openapi/package.json
@@ -16,9 +16,7 @@
     "@scalar/openapi-parser": "^0.20.4",
     "jsonc-parser": "^3.2.0",
     "tinyglobby": "^0.2.14",
-    "traverse": "^0.6.11"
-  },
-  "peerDependencies": {
+    "traverse": "^0.6.11",
     "@thymian/cli-common": "^0",
     "@thymian/core": "^0",
     "@thymian/http-status-codes": "^0",

--- a/plugins/openapi/src/cli/init-hook.ts
+++ b/plugins/openapi/src/cli/init-hook.ts
@@ -14,10 +14,8 @@ import { openApiPlugin, type OpenApiPluginOptions } from '../index.js';
 export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
   const found: string[] = [];
 
-  const matches = await glob({
-    patterns: '**/*.{json,yaml,yml}',
+  const matches = await glob('**/*.{json,yaml,yml}', {
     cwd,
-    deep: 5,
   });
 
   for (const match of matches) {

--- a/plugins/openapi/src/cli/init-hook.ts
+++ b/plugins/openapi/src/cli/init-hook.ts
@@ -29,8 +29,8 @@ export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
 
     for await (const line of rl) {
       if (
-        /^\s*swagger\s*:\s*("?2\.0\.0"?)/i.test(line) ||
-        /^\s*openapi\s*:\s*("?3\.[01]\.[01234]"?)/i.test(line)
+        /^\s*"?swagger"?\s*:\s*("?2\.0\.0"?)/i.test(line) ||
+        /^\s*"?openapi"?\s*:\s*("?3\.[01]\.[01234]"?)/i.test(line)
       ) {
         found.push(match);
         break;

--- a/plugins/request-dispatcher/package.json
+++ b/plugins/request-dispatcher/package.json
@@ -18,9 +18,7 @@
   },
   "dependencies": {
     "async-mutex": "^0.5.0",
-    "undici": "^6.21.2"
-  },
-  "peerDependencies": {
+    "undici": "^6.21.2",
     "@thymian/core": "^0"
   }
 }

--- a/plugins/sampler/package.json
+++ b/plugins/sampler/package.json
@@ -21,9 +21,7 @@
     "lru-cache": "^11.1.0",
     "openapi-sampler": "^1.6.1",
     "sharp": "^0.34.1",
-    "tslib": "^2.3.0"
-  },
-  "peerDependencies": {
+    "tslib": "^2.3.0",
     "@thymian/core": "^0",
     "@thymian/cli-common": "^0"
   },


### PR DESCRIPTION
This pull request updates how dependencies are managed in several `package.json` files across the monorepo. The main change is moving various internal packages from `peerDependencies` to `dependencies`, ensuring that required packages are installed automatically rather than relying on consumers to provide them. Additionally, there are minor improvements to build scripts and OpenAPI file detection logic.
