### PR TITLE
fix format of all files and enforce it in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
       - name: run linter
         run: npx nx affected -t lint
+      - name: run formatter check
+        run: npx nx format:check --all
 
   main:
     strategy:

--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -22,7 +22,7 @@ export default [
             '@oclif/plugin-version',
             '@thymian/rfc-9110-rules',
             '@thymian/http-linter',
-            '@thymian/sampler'
+            '@thymian/sampler',
           ],
         },
       ],

--- a/cli/src/commands/config/show.ts
+++ b/cli/src/commands/config/show.ts
@@ -30,7 +30,7 @@ export default class ShowConfig extends BaseCliRunCommand<typeof ShowConfig> {
             boolean: 'cyan',
             null: 'redBright',
           },
-        })
+        }),
       );
     }
   }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -59,14 +59,14 @@ export default class Init extends Command {
         delete this.thymianConfig.plugins[pluginName];
 
         this.debug(
-          `Plugin "${pluginName}" is not added to Thymian configuration.`
+          `Plugin "${pluginName}" is not added to Thymian configuration.`,
         );
       }
     }
 
     const configFilePath = join(
       flags.cwd,
-      `${flags['config-file']}${flags.yaml ? '.yaml' : '.json'}`
+      `${flags['config-file']}${flags.yaml ? '.yaml' : '.json'}`,
     );
 
     try {
@@ -78,7 +78,7 @@ export default class Init extends Command {
       this.debug('Error writing configuration file: ' + e);
       this.error(
         `Configuration file "${configFilePath}" already exists. Please remove it before initializing Thymian.`,
-        { exit: 1 }
+        { exit: 1 },
       );
     }
 

--- a/cli/src/commands/plugins/list.ts
+++ b/cli/src/commands/plugins/list.ts
@@ -11,9 +11,9 @@ export default class List extends BaseCliRunCommand<typeof List> {
       this.log(
         this.thymian.plugins
           .map((plugin) =>
-            ux.colorize(this.config?.theme?.topic, plugin.plugin.name)
+            ux.colorize(this.config?.theme?.topic, plugin.plugin.name),
           )
-          .join(EOL)
+          .join(EOL),
       );
     });
   }

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -16,7 +16,7 @@ export default class Run extends BaseCliRunCommand<typeof Run> {
 
     if (errorResult) {
       this.logger.debug(
-        `Plugin ${errorResult.pluginName} returned erroneous result.`
+        `Plugin ${errorResult.pluginName} returned erroneous result.`,
       );
       this.exit(1);
     }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "files": [],
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts",
-  ],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
   "references": [
     {
       "path": "../plugins/sampler"

--- a/core/src/core-plugin.ts
+++ b/core/src/core-plugin.ts
@@ -2,7 +2,10 @@ import type { JSONSchemaType } from 'ajv/dist/2020.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 import { loadFormatActionSchema, runActionSchema } from './actions/index.js';
-import { RegisterPluginEventSchema,thymianReportSchema } from './events/index.js';
+import {
+  RegisterPluginEventSchema,
+  thymianReportSchema,
+} from './events/index.js';
 import type { ThymianPlugin } from './thymian-plugin.js';
 
 export const VoidSchema = {} as JSONSchemaType<void>;
@@ -10,7 +13,7 @@ export const VoidSchema = {} as JSONSchemaType<void>;
 export const corePlugin: ThymianPlugin = {
   name: '@thymian/core',
   plugin(): Promise<void> {
-    return Promise.resolve()
+    return Promise.resolve();
   },
   version: packageJson.version,
   actions: {
@@ -25,18 +28,18 @@ export const corePlugin: ThymianPlugin = {
       },
       'core.load-format': {
         event: {} as JSONSchemaType<never>,
-        response:
-          loadFormatActionSchema,
+        response: loadFormatActionSchema,
       },
       'core.run': {
         event: loadFormatActionSchema,
-        response: runActionSchema
-      }
-    }
+        response: runActionSchema,
+      },
+    },
   },
   events: {
     provides: {
-      'core.register': RegisterPluginEventSchema as unknown as JSONSchemaType<unknown>,
+      'core.register':
+        RegisterPluginEventSchema as unknown as JSONSchemaType<unknown>,
       'core.report': thymianReportSchema as unknown as JSONSchemaType<unknown>,
     },
   },

--- a/core/src/emitter/thymian-emitter.ts
+++ b/core/src/emitter/thymian-emitter.ts
@@ -43,12 +43,12 @@ export type ActionContext<Name extends ThymianActionName> = {
 };
 
 export type EventHandler<Event extends ThymianEventName> = (
-  payload: EventPayload<Event>
+  payload: EventPayload<Event>,
 ) => Promise<void> | void;
 
 export type ActionHandler<Name extends ThymianActionName> = (
   payload: ActionEventPayload<Name>,
-  ctx: ActionContext<Name>
+  ctx: ActionContext<Name>,
 ) => Promise<void> | void;
 
 export type ThymianEmitterOptions = {
@@ -63,7 +63,7 @@ export type EmitActionOptions = {
 
 export type EmitActionArgs<
   Name extends ThymianActionName,
-  Options extends Partial<EmitActionOptions>
+  Options extends Partial<EmitActionOptions>,
 > = ThymianActions[Name]['event'] extends void | undefined | null | never
   ? [name: Name, payload?: undefined, options?: Options]
   : [name: Name, payload: ThymianActions[Name]['event'], options?: Options];
@@ -102,7 +102,7 @@ export class ThymianEmitter {
   constructor(
     private readonly logger: Logger,
     state: EmitterState,
-    options: Partial<ThymianEmitterOptions> = {}
+    options: Partial<ThymianEmitterOptions> = {},
   ) {
     this.options = {
       timeout: 1000,
@@ -127,7 +127,7 @@ export class ThymianEmitter {
 
   on<Name extends ThymianEventName>(
     name: Name,
-    handler: EventHandler<Name>
+    handler: EventHandler<Name>,
   ): void {
     this.#events
       .pipe(filter(isEventWithName(name)))
@@ -162,7 +162,7 @@ export class ThymianEmitter {
             this.#errors.next({
               error: new ThymianBaseError(
                 `Error while calling event handler for event "${event.name}" from "${event.source}".`,
-                { cause: e }
+                { cause: e },
               ),
               name,
               timestamp: Date.now(),
@@ -177,7 +177,7 @@ export class ThymianEmitter {
 
   emit<Name extends ThymianEventName>(
     name: Name,
-    payload: EventPayload<Name>
+    payload: EventPayload<Name>,
   ): void {
     this.#events.next({
       id: randomUUID(),
@@ -200,7 +200,7 @@ export class ThymianEmitter {
     } else {
       error = new ThymianBaseError(
         `Error while emitting error event from "${this.source}".`,
-        { cause: err }
+        { cause: err },
       );
     }
 
@@ -215,7 +215,7 @@ export class ThymianEmitter {
 
   onAction<Name extends ThymianActionName>(
     name: Name,
-    handler: ActionHandler<Name>
+    handler: ActionHandler<Name>,
   ): void {
     this.#listeners.set(name, (this.#listeners.get(name) ?? 0) + 1);
 
@@ -254,7 +254,7 @@ export class ThymianEmitter {
             this.#errors.next({
               error: new ThymianBaseError(
                 `Error while calling action handler for action "${event.name}" from "${event.source}".`,
-                { cause: e }
+                { cause: e },
               ),
               name,
               correlationId: event.id,
@@ -269,7 +269,7 @@ export class ThymianEmitter {
 
   async emitAction<
     Name extends ThymianActionName,
-    Options extends Partial<EmitActionOptions> = { strategy: 'collect' }
+    Options extends Partial<EmitActionOptions> = { strategy: 'collect' },
   >(
     ...args: EmitActionArgs<Name, Options>
   ): Promise<
@@ -299,7 +299,7 @@ export class ThymianEmitter {
       this.#responses.pipe(filter(isResponseOf(name, event.id))),
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
-      this.#errors.pipe(filter(isResponseOf(name, event.id)))
+      this.#errors.pipe(filter(isResponseOf(name, event.id))),
     ).pipe(takeUntil(timer(opts.timeout)), take(takeNum), toArray());
 
     queueMicrotask(() => {
@@ -312,7 +312,7 @@ export class ThymianEmitter {
     )[];
 
     const errors = results.filter((r) =>
-      Object.hasOwn(r, 'error')
+      Object.hasOwn(r, 'error'),
     ) as ThymianErrorEvent<Name>[];
 
     if (errors.length > 0 && typeof errors[0] !== 'undefined') {
@@ -321,7 +321,9 @@ export class ThymianEmitter {
           errors.length > 1 ? 's' : ''
         } from ${errors
           .map((err) => `"${err.source}"`)
-          .join(', ')} while waiting for response event(s) for event "${name}".`
+          .join(
+            ', ',
+          )} while waiting for response event(s) for event "${name}".`,
       );
 
       const { error } = errors[0];
@@ -335,7 +337,7 @@ export class ThymianEmitter {
 
     if (opts.strategy !== 'first' && results.length !== numOfListeners) {
       this.logger.debug(
-        `Expected ${numOfListeners} response events for event "${name}" but got ${results.length}.`
+        `Expected ${numOfListeners} response events for event "${name}" but got ${results.length}.`,
       );
     }
 
@@ -376,13 +378,13 @@ export class ThymianEmitter {
         ...this.options,
         // we only have to listen to all events once
         traceEvents: false,
-      }
+      },
     );
   }
 
   private createActionContext<Name extends ThymianActionName>(
     name: Name,
-    correlationId: string
+    correlationId: string,
   ): ActionContext<Name> {
     return {
       error: (error) => {
@@ -413,7 +415,7 @@ export class ThymianEmitter {
           this.#errors.next({
             error: new ThymianBaseError(
               `Error while calling action handler for action "${name}".`,
-              { cause: error }
+              { cause: error },
             ),
             name,
             correlationId,
@@ -446,15 +448,15 @@ export class ThymianEmitter {
         | ThymianEvent<ThymianEventName>
         | ThymianActionEvent<ThymianActionName>
         | ThymianResponseEvent<ThymianActionName>
-        | ThymianErrorEvent<ErrorName>
+        | ThymianErrorEvent<ErrorName>,
     ) => {
       this.logger.trace(
         `${chalk.bold(event.source)} with ${type} ${chalk.bold(
-          event.name
+          event.name,
         )} at ${new Date(event.timestamp)
           .toISOString()
           .replace('T', ' ')
-          .replace('Z', '')}`
+          .replace('Z', '')}`,
       );
     };
   }

--- a/core/src/emitter/utils.ts
+++ b/core/src/emitter/utils.ts
@@ -7,28 +7,28 @@ import type {
 import type { ThymianEvent } from './events.js';
 
 export function isEventWithName<Name extends ThymianEventName>(
-  name: Name
+  name: Name,
 ): (
-  event: ThymianEvent<ThymianEventName> | ThymianActionEvent<ThymianActionName>
+  event: ThymianEvent<ThymianEventName> | ThymianActionEvent<ThymianActionName>,
 ) => event is ThymianEvent<Name> {
   return function (
     event:
       | ThymianEvent<ThymianEventName>
-      | ThymianActionEvent<ThymianActionName>
+      | ThymianActionEvent<ThymianActionName>,
   ): event is ThymianEvent<Name> {
     return event.name === name; // && !Object.hasOwn(event, 'correlationId'); TODO: is the correlationId needed?
   };
 }
 
 export function isActionEventWithName<Name extends ThymianActionName>(
-  name: Name
+  name: Name,
 ): (
-  event: ThymianEvent<ThymianEventName> | ThymianActionEvent<ThymianActionName>
+  event: ThymianEvent<ThymianEventName> | ThymianActionEvent<ThymianActionName>,
 ) => event is ThymianActionEvent<Name> {
   return function (
     event:
       | ThymianEvent<ThymianEventName>
-      | ThymianActionEvent<ThymianActionName>
+      | ThymianActionEvent<ThymianActionName>,
   ): event is ThymianActionEvent<Name> {
     return event.name === name;
   };
@@ -36,12 +36,12 @@ export function isActionEventWithName<Name extends ThymianActionName>(
 
 export function isResponseOf<Name extends ThymianActionName>(
   name: Name,
-  cid: string
+  cid: string,
 ): (
-  event: ThymianResponseEvent<ThymianActionName>
+  event: ThymianResponseEvent<ThymianActionName>,
 ) => event is ThymianResponseEvent<Name> {
   return function (
-    event: ThymianResponseEvent<ThymianActionName>
+    event: ThymianResponseEvent<ThymianActionName>,
   ): event is ThymianResponseEvent<Name> {
     return event.name === name && event.correlationId === cid;
   };

--- a/core/src/format/thymian-format.ts
+++ b/core/src/format/thymian-format.ts
@@ -43,14 +43,14 @@ export type MatchResult = {
 
 export function isNodeType<T extends ThymianNodeType>(
   node: ThymianNode,
-  type: T
+  type: T,
 ): node is ThymianNodes[T] {
   return node.type === type;
 }
 
 export function isEdgeType<T extends ThymianEdgeType>(
   edge: ThymianEdge,
-  type: T
+  type: T,
 ): edge is ThymianEdges[T] {
   return edge.type === type;
 }
@@ -91,7 +91,7 @@ export type ThymianGraph = MultiDirectedGraph<ThymianNode, ThymianEdge>;
 export type SerializedThymianFormat = SerializedGraph<ThymianNode, ThymianEdge>;
 
 export function thymianHttpRequestToLabel(
-  req: PartialBy<ThymianHttpRequest, 'label'>
+  req: PartialBy<ThymianHttpRequest, 'label'>,
 ): string {
   const label = `${req.method.toUpperCase()} ${req.protocol}://${req.host}:${
     req.port
@@ -101,7 +101,7 @@ export function thymianHttpRequestToLabel(
 }
 
 export function thymianHttpResponseToLabel(
-  res: PartialBy<ThymianHttpResponse, 'label'>
+  res: PartialBy<ThymianHttpResponse, 'label'>,
 ): string {
   const statusCode = res.statusCode;
   const phrase = isValidHttpStatusCode(statusCode)
@@ -123,7 +123,7 @@ export class ThymianFormat {
   addEdge(
     source: string,
     target: string,
-    edge: PartialBy<ThymianEdge, 'label'>
+    edge: PartialBy<ThymianEdge, 'label'>,
   ): string {
     return this.graph.addEdge(source, target, {
       label: edge.type,
@@ -134,7 +134,7 @@ export class ThymianFormat {
   addHttpLink(
     source: string,
     target: string,
-    edge: PartialBy<HttpLink, 'type' | 'label'>
+    edge: PartialBy<HttpLink, 'type' | 'label'>,
   ): string {
     const res = this.getNode<ThymianHttpResponse>(source);
     const req = this.getNode<ThymianHttpRequest>(target);
@@ -146,7 +146,7 @@ export class ThymianFormat {
     }
 
     const label = `${thymianHttpResponseToLabel(
-      res
+      res,
     )} \u2192 ${thymianHttpRequestToLabel(req)}`;
 
     return this.addEdge(source, target, {
@@ -159,13 +159,13 @@ export class ThymianFormat {
   addResponseToRequest(
     requestId: string,
     response: PartialBy<ThymianHttpResponse, 'label'>,
-    transaction: Partial<HttpTransaction> = {}
+    transaction: Partial<HttpTransaction> = {},
   ): [string, string] {
     const req = this.getNode<ThymianHttpRequest>(requestId);
 
     if (!req) {
       throw new Error(
-        `Invalid request ID${requestId}. Cannot add response to request.`
+        `Invalid request ID${requestId}. Cannot add response to request.`,
       );
     }
 
@@ -173,7 +173,7 @@ export class ThymianFormat {
 
     const resId = this.addResponse(
       { ...response, label: resLabel },
-      this.hash(req.label + resLabel)
+      this.hash(req.label + resLabel),
     );
 
     return [
@@ -188,7 +188,7 @@ export class ThymianFormat {
 
   addHttpTransaction(
     request: PartialBy<ThymianHttpRequest, 'label'>,
-    response: PartialBy<ThymianHttpResponse, 'label'>
+    response: PartialBy<ThymianHttpResponse, 'label'>,
   ): [string, string, string] {
     const reqLabel = thymianHttpRequestToLabel(request);
     const resLabel = thymianHttpResponseToLabel(response);
@@ -201,7 +201,7 @@ export class ThymianFormat {
 
     const resId = this.addResponse(
       { ...response, label: resLabel },
-      this.hash(reqLabel + resLabel)
+      this.hash(reqLabel + resLabel),
     );
 
     return [
@@ -240,13 +240,13 @@ export class ThymianFormat {
         ...request,
         type: 'http-request',
       },
-      this.hash(label)
+      this.hash(label),
     );
   }
 
   private addResponse(
     response: PartialBy<ThymianHttpResponse, 'label'>,
-    id?: string
+    id?: string,
   ): string {
     const label = thymianHttpResponseToLabel(response);
 
@@ -256,7 +256,7 @@ export class ThymianFormat {
         ...response,
         type: 'http-response',
       },
-      id
+      id,
     );
   }
 
@@ -274,13 +274,13 @@ export class ThymianFormat {
 
   findNodeByExtension(
     extensionName: string,
-    values: Record<PropertyKey, string | number | boolean>
+    values: Record<PropertyKey, string | number | boolean>,
   ): ThymianNode | undefined {
     const id = this.graph.findNode(
       (id, attributes) =>
         attributes.extensions &&
         extensionName in attributes.extensions &&
-        matchObjects(attributes.extensions[extensionName], values)
+        matchObjects(attributes.extensions[extensionName], values),
     );
 
     return this.graph.getNodeAttributes(id);
@@ -288,7 +288,7 @@ export class ThymianFormat {
 
   requestIsSecured(reqId: string): boolean {
     return !!this.graph.findOutEdge(reqId, (_, edge) =>
-      isEdgeType(edge, 'is-secured')
+      isEdgeType(edge, 'is-secured'),
     );
   }
 
@@ -300,7 +300,7 @@ export class ThymianFormat {
           const transactionId = this.graph.findEdge(
             reqId,
             id,
-            (_, edge) => edge.type === 'http-transaction'
+            (_, edge) => edge.type === 'http-transaction',
           );
 
           if (!transactionId) {
@@ -312,13 +312,13 @@ export class ThymianFormat {
 
         return acc;
       },
-      [] as [string, ThymianHttpResponse, string][]
+      [] as [string, ThymianHttpResponse, string][],
     );
   }
 
   getNeighboursOfType<Type extends ThymianNodeType>(
     id: string,
-    type: Type
+    type: Type,
   ): [string, ThymianNodes[Type]][] {
     return this.graph.reduceNeighbors(
       id,
@@ -329,13 +329,13 @@ export class ThymianFormat {
 
         return acc;
       },
-      [] as [string, ThymianNodes[Type]][]
+      [] as [string, ThymianNodes[Type]][],
     );
   }
 
   getNodesByExtension(
     extensionName: string,
-    values: Record<PropertyKey, string | number | boolean>
+    values: Record<PropertyKey, string | number | boolean>,
   ): ThymianNode[] {
     return this.graph.reduceNodes((acc, _, attributes) => {
       if (
@@ -350,13 +350,16 @@ export class ThymianFormat {
   }
 
   getHttpTransactions(): [string, string, string][] {
-    return this.graph.reduceEdges((transactions, id, edge, source, target) => {
-      if (edge.type === 'http-transaction') {
-        transactions.push([source, target, id]);
-      }
+    return this.graph.reduceEdges(
+      (transactions, id, edge, source, target) => {
+        if (edge.type === 'http-transaction') {
+          transactions.push([source, target, id]);
+        }
 
-      return transactions;
-    }, [] as [string, string, string][]);
+        return transactions;
+      },
+      [] as [string, string, string][],
+    );
   }
 
   getThymianHttpTransactions(): ThymianHttpTransaction[] {
@@ -375,13 +378,13 @@ export class ThymianFormat {
 
         return transactions;
       },
-      [] as ThymianHttpTransaction[]
+      [] as ThymianHttpTransaction[],
     );
   }
 
   matchTransaction(
     req: HttpRequest,
-    res: HttpResponse
+    res: HttpResponse,
   ): [string, string, string] | undefined {
     const edgeId = this.graph.findEdge(
       (id, edge, sourceId, targetId, source, target) => {
@@ -404,7 +407,7 @@ export class ThymianFormat {
           equalsIgnoreCase(reqMediaType, thymianReq.mediaType) &&
           equalsIgnoreCase(resMediaType, thymianRes.mediaType)
         );
-      }
+      },
     );
 
     if (!edgeId) {
@@ -425,32 +428,35 @@ export class ThymianFormat {
 
     const pathname = urlObj.pathname;
 
-    return this.graph.reduceNodes((result, id, node) => {
-      if (isNodeType(node, 'http-request')) {
-        const path = node.path.replaceAll(/{([^}]+)}/gi, ':$1');
+    return this.graph.reduceNodes(
+      (result, id, node) => {
+        if (isNodeType(node, 'http-request')) {
+          const path = node.path.replaceAll(/{([^}]+)}/gi, ':$1');
 
-        const matchFn = match(path);
+          const matchFn = match(path);
 
-        const r = matchFn(pathname);
+          const r = matchFn(pathname);
 
-        if (r) {
-          result = {
-            reqId: id,
-            parameters: r.params,
-          };
+          if (r) {
+            result = {
+              reqId: id,
+              parameters: r.params,
+            };
+          }
         }
-      }
 
-      return result;
-    }, undefined as MatchResult | undefined);
+        return result;
+      },
+      undefined as MatchResult | undefined,
+    );
   }
 
   findNode<Type extends ThymianNodeType>(
     type: Type,
-    properties: StringAndNumberProperties<ThymianNodes[Type]>
+    properties: StringAndNumberProperties<ThymianNodes[Type]>,
   ): ThymianNodes[Type] | undefined {
     const nodeId = this.graph.findNode(
-      (id, node) => isNodeType(node, type) && matchObjects(node, properties)
+      (id, node) => isNodeType(node, type) && matchObjects(node, properties),
     );
 
     if (typeof nodeId === 'undefined') {
@@ -478,7 +484,7 @@ export class ThymianFormat {
 
   addSampleHttpTransaction(
     request: HttpRequest,
-    response: HttpResponse
+    response: HttpResponse,
   ): [string, string, string] {
     const reqId = this.addSampleHttpRequest(request);
     const resId = this.addSampleHttpResponse(response);
@@ -505,7 +511,7 @@ export class ThymianFormat {
   }
 
   static fromHttpTransactions(
-    transactions: [HttpRequest, HttpResponse][]
+    transactions: [HttpRequest, HttpResponse][],
   ): ThymianFormat {
     const format = new ThymianFormat();
 
@@ -515,7 +521,7 @@ export class ThymianFormat {
 
       const [sampleReqId, sampleResId] = format.addSampleHttpTransaction(
         req,
-        res
+        res,
       );
 
       const [reqId, resId] = format.addHttpTransaction(thymianReq, thymianRes);
@@ -533,7 +539,7 @@ export class ThymianFormat {
 
   static import(graph: SerializedThymianFormat): ThymianFormat {
     return new ThymianFormat(
-      new MultiDirectedGraph<ThymianNode, ThymianEdge>().import(graph)
+      new MultiDirectedGraph<ThymianNode, ThymianEdge>().import(graph),
     );
   }
 

--- a/core/src/format/utils.ts
+++ b/core/src/format/utils.ts
@@ -12,7 +12,7 @@ import type { Parameter } from './parameter.js';
 import type { SerializationStyle } from './serialization-style/index.js';
 
 export function extractSchemaForValue(
-  value: string
+  value: string,
 ): 'string' | 'integer' | 'number' | 'boolean' {
   if (!isNaN(parseInt(value))) {
     return 'integer';
@@ -31,7 +31,7 @@ export function extractSchemaForValue(
 
 export function valueToParameter(
   value: string | string[] | undefined,
-  style: SerializationStyle
+  style: SerializationStyle,
 ): Parameter | undefined {
   if (Array.isArray(value)) {
     return {
@@ -60,23 +60,26 @@ export function valueToParameter(
 
 export function parameterValuesToParameters(
   values: Record<string, string | string[] | undefined>,
-  style: SerializationStyle
+  style: SerializationStyle,
 ): Record<string, Parameter> {
-  return Object.entries(values).reduce((acc, [key, value]) => {
-    if (equalsIgnoreCase(key, 'content-type')) return acc;
+  return Object.entries(values).reduce(
+    (acc, [key, value]) => {
+      if (equalsIgnoreCase(key, 'content-type')) return acc;
 
-    const parameter = valueToParameter(value, style);
+      const parameter = valueToParameter(value, style);
 
-    if (!parameter) return acc;
+      if (!parameter) return acc;
 
-    acc[key] = parameter;
+      acc[key] = parameter;
 
-    return acc;
-  }, {} as Record<string, Parameter>);
+      return acc;
+    },
+    {} as Record<string, Parameter>,
+  );
 }
 
 export function httpRequestToThymianHttpRequest(
-  request: HttpRequest
+  request: HttpRequest,
 ): PartialBy<ThymianHttpRequest, 'label'> {
   const url = new URL(request.path, request.origin);
 
@@ -91,7 +94,7 @@ export function httpRequestToThymianHttpRequest(
     cookies: {},
     headers: parameterValuesToParameters(
       request.headers ?? {},
-      DEFAULT_HEADER_SERIALIZATION_STYLE
+      DEFAULT_HEADER_SERIALIZATION_STYLE,
     ),
     pathParameters: {},
     queryParameters: {},
@@ -99,7 +102,7 @@ export function httpRequestToThymianHttpRequest(
 }
 
 export function httpResponseToThymianHttpResponse(
-  response: HttpResponse
+  response: HttpResponse,
 ): ThymianHttpResponse {
   const thymianHttpResponse: ThymianHttpResponse = {
     type: 'http-response',
@@ -108,7 +111,7 @@ export function httpResponseToThymianHttpResponse(
     mediaType: getContentType(response.headers),
     headers: parameterValuesToParameters(
       response.headers ?? {},
-      DEFAULT_HEADER_SERIALIZATION_STYLE
+      DEFAULT_HEADER_SERIALIZATION_STYLE,
     ),
   };
 

--- a/core/src/logger/text.logger.ts
+++ b/core/src/logger/text.logger.ts
@@ -18,8 +18,8 @@ export class TextLogger implements Logger {
       console.debug(
         `${chalk.grey(`TRACE`)} [${this.now()}] [${this.namespace}]: ${format(
           formatter,
-          ...args
-        )}`
+          ...args,
+        )}`,
       );
     }
   }
@@ -27,8 +27,8 @@ export class TextLogger implements Logger {
     console.warn(
       `${chalk.yellow(`WARN`)} [${this.now()}] [${this.namespace}]: ${format(
         formatter,
-        ...args
-      )}`
+        ...args,
+      )}`,
     );
   }
 
@@ -37,8 +37,8 @@ export class TextLogger implements Logger {
       console.debug(
         `${chalk.blue(`DEBUG`)} [${this.now()}] [${this.namespace}]: ${format(
           formatter,
-          ...args
-        )}`
+          ...args,
+        )}`,
       );
     }
   }
@@ -46,16 +46,16 @@ export class TextLogger implements Logger {
     console.log(
       `${chalk.green(`INFO`)} [${this.now()}] [${this.namespace}]: ${format(
         formatter,
-        ...args
-      )}`
+        ...args,
+      )}`,
     );
   }
   error(formatter: unknown, ...args: unknown[]): void {
     console.error(
       `${chalk.red(`ERROR`)} [${this.now()}] [${this.namespace}]: ${format(
         formatter,
-        ...args
-      )}`
+        ...args,
+      )}`,
     );
   }
   out(output: unknown): void {

--- a/core/src/thymian-plugin.ts
+++ b/core/src/thymian-plugin.ts
@@ -6,10 +6,12 @@ import type { ThymianEventName, ThymianEvents } from './events/index.js';
 import type { Logger } from './logger/logger.js';
 import { isRecord } from './utils.js';
 
-export type ThymianPluginFn<Options extends Record<PropertyKey, unknown> & { cwd: string }> = (
+export type ThymianPluginFn<
+  Options extends Record<PropertyKey, unknown> & { cwd: string },
+> = (
   emitter: ThymianEmitter,
   logger: Logger,
-  options: Options
+  options: Options,
 ) => Promise<void>;
 
 export type ThymianPluginEvents = {
@@ -42,7 +44,9 @@ export type ThymianPluginActions = {
   listensOn?: ThymianActionName[];
 };
 
-export type ThymianPlugin<Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>> = {
+export type ThymianPlugin<
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
+> = {
   plugin: ThymianPluginFn<Options & { cwd: string }>;
   options?: JSONSchemaType<Options>;
   name: string;

--- a/core/src/thymian.error.ts
+++ b/core/src/thymian.error.ts
@@ -39,7 +39,7 @@ export class ThymianBaseError extends Error implements ThymianError {
     message: string,
     options: Partial<ThymianErrorOptions> & { cause?: unknown } & {
       severity?: ThymianErrorSeverity;
-    } = {}
+    } = {},
   ) {
     super(message);
     if (options.cause) {

--- a/core/src/thymian.ts
+++ b/core/src/thymian.ts
@@ -177,7 +177,7 @@ export class Thymian {
       formats.length === 0
         ? new ThymianFormat()
         : // we know that formats.length >= 1
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
           formats
             .slice(1)
             .reduce(

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -13,7 +13,7 @@ import type { HttpRequest, HttpResponse } from './http.js';
 export function timeoutPromise<T>(
   promise: Promise<T>,
   toWait = 5000,
-  err?: Error
+  err?: Error,
 ): Promise<T> {
   let timoutId: NodeJS.Timeout;
 
@@ -22,14 +22,14 @@ export function timeoutPromise<T>(
     new Promise((_, reject) => {
       timoutId = setTimeout(
         () => reject(err ?? new Error(`Promise timed out after ${toWait} ms.`)),
-        toWait
+        toWait,
       );
     }),
   ]).finally(() => clearTimeout(timoutId));
 }
 
 export function isRecord(
-  value: unknown
+  value: unknown,
 ): value is Record<PropertyKey, unknown> {
   return typeof value === 'object' && !Array.isArray(value) && value !== null;
 }
@@ -74,12 +74,12 @@ export function zipArrays<A, B>(as: A[], bs: B[]): [A, B][] {
 
 export function getHeader(
   headers: Record<string, string | string[] | undefined> = {},
-  headerName: string
+  headerName: string,
 ): string | string[] | undefined {
   const headerNames = Object.keys(headers);
 
   const found = headerNames.find(
-    (name) => name.toLowerCase() === headerName.toLowerCase()
+    (name) => name.toLowerCase() === headerName.toLowerCase(),
   );
 
   if (found) {
@@ -92,12 +92,12 @@ export function getHeader(
 export function setHeader(
   headers: Record<string, unknown>,
   headerName: string,
-  value: unknown
+  value: unknown,
 ): Record<string, unknown> {
   const headerNames = Object.keys(headers);
 
   const found = headerNames.find(
-    (name) => name.toLowerCase() === headerName.toLowerCase()
+    (name) => name.toLowerCase() === headerName.toLowerCase(),
   ) as keyof typeof headers;
 
   if (found) {
@@ -131,16 +131,16 @@ export function thymianResponseToString(res: ThymianHttpResponse): string {
 
 export function thymianHttpTransactionToString(
   req: ThymianHttpRequest,
-  res: ThymianHttpResponse
+  res: ThymianHttpResponse,
 ): string {
   return `${thymianRequestToString(req)} \u2192 ${thymianResponseToString(
-    res
+    res,
   )}`;
 }
 
 export function equalsIgnoreCase(a: string, ...b: string[]): boolean {
   return b.some(
-    (str) => a.localeCompare(str, undefined, { sensitivity: 'accent' }) === 0
+    (str) => a.localeCompare(str, undefined, { sensitivity: 'accent' }) === 0,
   );
 }
 
@@ -160,7 +160,7 @@ export function thymianRequestToOrigin(req: ThymianHttpRequest): string {
 
 export function getContentType(
   headers: Record<string, string | string[] | undefined> = {},
-  defaultValue = ''
+  defaultValue = '',
 ): string {
   const contentType = getHeader(headers, 'content-type');
 
@@ -195,7 +195,7 @@ export function normalizeUrl(urlString: string): string {
 export function httpRequestToLabel(request: HttpRequest): string {
   return `${request.method.toUpperCase()} ${new URL(
     request.path,
-    request.origin
+    request.origin,
   ).toString()}`;
 }
 

--- a/core/test/format/thymian-format.test.ts
+++ b/core/test/format/thymian-format.test.ts
@@ -46,8 +46,8 @@ describe('ThymianFormat', () => {
 
       expect(() =>
         ThymianFormat.fromHttpTransactions(
-          transactions as [HttpRequest, HttpResponse][]
-        )
+          transactions as [HttpRequest, HttpResponse][],
+        ),
       ).toThrow();
     });
   });

--- a/core/test/logger/text.logger.test.ts
+++ b/core/test/logger/text.logger.test.ts
@@ -39,7 +39,9 @@ describe('TextLogger', () => {
     logger.info('should be printed');
 
     expect(consoleMock).toHaveBeenCalledWith(
-      expect.stringMatching(/INFO \[.*\] \[My cool logger\]: should be printed/)
+      expect.stringMatching(
+        /INFO \[.*\] \[My cool logger\]: should be printed/,
+      ),
     );
   });
 

--- a/core/test/thymian.test.ts
+++ b/core/test/thymian.test.ts
@@ -31,7 +31,7 @@ const plugin: ThymianPlugin = {
 };
 
 function createPluginFor(
-  plugin: ThymianPluginFn<{ cwd: string }>
+  plugin: ThymianPluginFn<{ cwd: string }>,
 ): ThymianPlugin {
   return {
     name: '',
@@ -97,13 +97,13 @@ describe('Thymian', () => {
       },
       {
         event: 'event',
-      }
+      },
     );
 
     await thymian.run(async () => {
       await thymian.emitter.emitAction(
         'core.run',
-        new ThymianFormat().export()
+        new ThymianFormat().export(),
       );
     });
 
@@ -118,7 +118,7 @@ describe('Thymian', () => {
         name: '@thymian/test-plugin',
         plugin: () => Promise.resolve(),
         version: '1.x',
-      })
+      }),
     ).toThrowError(PluginRegistrationError);
   });
 
@@ -131,7 +131,7 @@ describe('Thymian', () => {
           closedSpy();
           ctx.reply();
         });
-      })
+      }),
     );
 
     thymian.register(
@@ -147,14 +147,14 @@ describe('Thymian', () => {
 
           ctx.reply({ pluginName: '', status: 'success' });
         });
-      })
+      }),
     );
 
     try {
       await thymian.run(async () => {
         await thymian.emitter.emitAction(
           'core.run',
-          new ThymianFormat().export()
+          new ThymianFormat().export(),
         );
       });
       expect.fail('Thymian should have rejected the promise.');

--- a/libs/cli-common/src/base-cli-run-command.ts
+++ b/libs/cli-common/src/base-cli-run-command.ts
@@ -29,7 +29,7 @@ export type CommandArgs<T extends typeof Command> = Interfaces.InferredArgs<
 >;
 
 export abstract class BaseCliRunCommand<
-  T extends typeof Command
+  T extends typeof Command,
 > extends Command {
   static override enableJsonFlag = true;
 
@@ -98,7 +98,7 @@ export abstract class BaseCliRunCommand<
     this.args = args as CommandArgs<T>;
     this.logger = new TextLogger(
       '@thymian/cli',
-      this.flags.verbose || !!settings.debug
+      this.flags.verbose || !!settings.debug,
     );
     this.thymian = new Thymian(this.logger.child('@thymian/core'), {
       timeout: this.flags.timeout,
@@ -169,7 +169,7 @@ export abstract class BaseCliRunCommand<
 
       if (!match) {
         throw new CLIError(
-          `Expected option flag with format <pluginName>.<property>=<value>, but got: ${option}`
+          `Expected option flag with format <pluginName>.<property>=<value>, but got: ${option}`,
         );
       }
 
@@ -177,7 +177,7 @@ export abstract class BaseCliRunCommand<
 
       if (!pluginName || !property || !value) {
         throw new CLIError(
-          `Expected option flag with format <pluginName>.<property>=<value>, but got option with pluginName "${pluginName}", property "${property}" and value ${value}.`
+          `Expected option flag with format <pluginName>.<property>=<value>, but got option with pluginName "${pluginName}", property "${property}" and value ${value}.`,
         );
       }
 
@@ -193,7 +193,7 @@ export abstract class BaseCliRunCommand<
 
   protected async loadPluginModule(
     nameOrPath: string,
-    isRelativePath = false
+    isRelativePath = false,
   ): Promise<ThymianPlugin> {
     const options = this.thymianConfig.plugins[nameOrPath] ?? {};
     const location =
@@ -213,7 +213,7 @@ export abstract class BaseCliRunCommand<
       throw new CLIError(
         `File "${
           options.path ?? nameOrPath
-        }" does not default export a valid Thymian plugin.`
+        }" does not default export a valid Thymian plugin.`,
       );
     }
 
@@ -222,11 +222,11 @@ export abstract class BaseCliRunCommand<
 
   protected async registerPlugin(
     nameOrPath: string,
-    isRelativePath = false
+    isRelativePath = false,
   ): Promise<void> {
     const pluginModule = await this.loadPluginModule(
       nameOrPath,
-      isRelativePath
+      isRelativePath,
     );
 
     const config = this.thymianConfig.plugins[pluginModule.name] ?? {};

--- a/libs/cli-common/src/get-config.ts
+++ b/libs/cli-common/src/get-config.ts
@@ -11,7 +11,7 @@ import thymianSchema from './thymian-config-schema.json' with { type: 'json' };
 
 export async function getConfig(
   file: string,
-  cwd = process.cwd()
+  cwd = process.cwd(),
 ): Promise<ThymianConfig> {
   const fullPath = path.join(cwd, file);
 
@@ -26,10 +26,9 @@ export async function getConfig(
 
   if (ext === '.json') {
     try {
-      config = JSON.parse(fileContent)
+      config = JSON.parse(fileContent);
     } catch (e) {
       throw new Error(`Invalid JSON file at path ${fullPath}.`);
-
     }
   } else if (ext === '.yaml' || ext === '.yml') {
     try {
@@ -38,10 +37,14 @@ export async function getConfig(
       throw new Error(`Invalid yaml file at path ${fullPath}.`);
     }
   } else {
-    throw new Error(`Unsupported file extension "${ext}" for Thymian configuration.`);
+    throw new Error(
+      `Unsupported file extension "${ext}" for Thymian configuration.`,
+    );
   }
 
-  if (!validate(thymianSchema as unknown as JSONSchemaType<ThymianConfig>, config)) {
+  if (
+    !validate(thymianSchema as unknown as JSONSchemaType<ThymianConfig>, config)
+  ) {
     throw new Error('Invalid Thymian config.');
   }
 

--- a/libs/cli-common/src/option-flag.ts
+++ b/libs/cli-common/src/option-flag.ts
@@ -11,7 +11,7 @@ export const optionFlag = Flags.custom<string>({
   parse: async (input: string) => {
     if (!optionRegexp.test(input)) {
       throw new Errors.CLIError(
-        `Invalid option format: ${input}. Use format <pluginName>.<property>=<value>.`
+        `Invalid option format: ${input}. Use format <pluginName>.<property>=<value>.`,
       );
     }
 

--- a/libs/cli-common/src/plugin-hook.ts
+++ b/libs/cli-common/src/plugin-hook.ts
@@ -15,7 +15,7 @@ export type ThymianPluginInitOptions = {
 };
 
 export type ThymianPluginInitResult<
-  T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>
+  T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > = {
   pluginName: string;
   configuration: ThymianPluginConfiguration<T>;
@@ -23,5 +23,5 @@ export type ThymianPluginInitResult<
 };
 
 export type ThymianPluginInitHook<
-  T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>
+  T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > = (options: ThymianPluginInitOptions) => Promise<ThymianPluginInitResult<T>>;

--- a/libs/cli-common/src/read-plugins.ts
+++ b/libs/cli-common/src/read-plugins.ts
@@ -3,7 +3,7 @@ import { parseArgs } from 'node:util';
 import { getConfig } from './get-config.js';
 
 export async function getPluginNames(
-  args: string[] = process.argv.slice(2)
+  args: string[] = process.argv.slice(2),
 ): Promise<string[]> {
   const options = {
     config: {

--- a/libs/cli-common/src/thymian-config.ts
+++ b/libs/cli-common/src/thymian-config.ts
@@ -1,5 +1,5 @@
 export interface ThymianPluginConfiguration<
-  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > {
   path?: string;
   verbose?: boolean;

--- a/libs/cli-common/test/promise-queue.test.ts
+++ b/libs/cli-common/test/promise-queue.test.ts
@@ -48,13 +48,13 @@ describe('PromiseQueue', () => {
         await setTimeout(1000);
         logs.push(2);
         return 'a';
-      })
+      }),
     );
     vals.push(
       await queue.add(async () => {
         logs.push(4);
         return 'b';
-      })
+      }),
     );
 
     expect(vals).toStrictEqual(['a', 'b']);
@@ -93,7 +93,7 @@ describe('PromiseQueue', () => {
     expect(
       await queue.add(async () => {
         return 100;
-      })
+      }),
     ).toEqual(100);
   });
 });

--- a/libs/http-filter/eslint.config.mjs
+++ b/libs/http-filter/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['tslib']
+          ignoredDependencies: ['tslib'],
         },
       ],
     },

--- a/libs/http-filter/src/index.ts
+++ b/libs/http-filter/src/index.ts
@@ -5,8 +5,8 @@ type OmitIndexSignature<T> = {
   [K in keyof T as string extends K
     ? never
     : number extends K
-    ? never
-    : K]: T[K];
+      ? never
+      : K]: T[K];
 };
 
 // from https://github.com/fastify/fastify/blob/c277b9f0ec27356de6551d7777117bd739057e99/types/utils.d.ts#L98
@@ -101,7 +101,7 @@ export const path = (path?: string): RequestFilterExpression => ({
 
 export const responseHeader = (
   header?: HttpHeader,
-  value?: unknown
+  value?: unknown,
 ): ResponseFilterExpression => ({
   type: 'responseHeader',
   kind: 'response',
@@ -111,7 +111,7 @@ export const responseHeader = (
 
 export const responseTrailer = (
   trailer?: string,
-  value?: unknown
+  value?: unknown,
 ): ResponseFilterExpression => ({
   type: 'responseTrailer',
   kind: 'response',
@@ -121,7 +121,7 @@ export const responseTrailer = (
 
 export const requestHeader = (
   header: HttpHeader,
-  value?: unknown
+  value?: unknown,
 ): RequestFilterExpression => ({
   type: 'requestHeader',
   kind: 'request',
@@ -137,7 +137,7 @@ export const statusCode = (code?: number): ResponseFilterExpression => ({
 
 export const statusCodeRange = (
   start: number,
-  end: number
+  end: number,
 ): ResponseFilterExpression => ({
   kind: 'response',
   type: 'statusCodeRange',
@@ -179,7 +179,7 @@ export const xor = (
 });
 
 export const authorization = (
-  isAuthorized = true
+  isAuthorized = true,
 ): RequestFilterExpression => ({
   type: 'isAuthorized',
   kind: 'request',
@@ -187,7 +187,7 @@ export const authorization = (
 });
 
 export const responseWith = (
-  filter: HttpFilterExpression
+  filter: HttpFilterExpression,
 ): RequestFilterExpression => ({
   type: 'hasResponse',
   kind: 'request',
@@ -219,7 +219,7 @@ export const port = (port?: number): RequestFilterExpression => ({
 });
 
 export const requestMediaType = (
-  mediaType: string
+  mediaType: string,
 ): RequestFilterExpression => ({
   type: 'requestMediaType',
   kind: 'request',
@@ -227,7 +227,7 @@ export const requestMediaType = (
 });
 
 export const responseMediaType = (
-  mediaType: string
+  mediaType: string,
 ): ResponseFilterExpression => ({
   type: 'responseMediaType',
   kind: 'response',
@@ -236,7 +236,7 @@ export const responseMediaType = (
 
 export const queryParameter = (
   name?: string,
-  value?: unknown
+  value?: unknown,
 ): RequestFilterExpression => ({
   type: 'queryParam',
   kind: 'request',

--- a/libs/http-status-codes/src/1xx/informational.phrases.ts
+++ b/libs/http-status-codes/src/1xx/informational.phrases.ts
@@ -8,7 +8,7 @@ export const informationalPhrases = [
 export type InformationalPhrase = (typeof informationalPhrases)[number];
 
 export function isValidInformationalPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is InformationalPhrase {
   return informationalPhrases.includes(phrase as InformationalPhrase);
 }

--- a/libs/http-status-codes/src/1xx/informational.status-codes.ts
+++ b/libs/http-status-codes/src/1xx/informational.status-codes.ts
@@ -3,7 +3,7 @@ export const informationalStatusCodes = [100, 101, 102, 103] as const;
 export type InformationalStatusCode = (typeof informationalStatusCodes)[number];
 
 export function isValidInformationalStatusCode(
-  code: number
+  code: number,
 ): code is InformationalStatusCode {
   return informationalStatusCodes.includes(code as InformationalStatusCode);
 }

--- a/libs/http-status-codes/src/2xx/successful.phrases.ts
+++ b/libs/http-status-codes/src/2xx/successful.phrases.ts
@@ -13,7 +13,7 @@ export const successfulPhrases = [
 export type SuccessfulPhrase = (typeof successfulPhrases)[number];
 
 export function isValidSuccessfulPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is SuccessfulPhrase {
   return successfulPhrases.includes(phrase as SuccessfulPhrase);
 }

--- a/libs/http-status-codes/src/2xx/successful.status-codes.ts
+++ b/libs/http-status-codes/src/2xx/successful.status-codes.ts
@@ -5,7 +5,7 @@ export const successfulStatusCodes = [
 export type SuccessfulStatusCode = (typeof successfulStatusCodes)[number];
 
 export function isValidSuccessfulStatusCode(
-  code: number
+  code: number,
 ): code is SuccessfulStatusCode {
   return successfulStatusCodes.includes(code as SuccessfulStatusCode);
 }

--- a/libs/http-status-codes/src/3xx/redirection.phrases.ts
+++ b/libs/http-status-codes/src/3xx/redirection.phrases.ts
@@ -11,7 +11,7 @@ export const redirectionPhrases = [
 export type RedirectionPhrase = (typeof redirectionPhrases)[number];
 
 export function isValidRedirectionPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is RedirectionPhrase {
   return redirectionPhrases.includes(phrase as RedirectionPhrase);
 }

--- a/libs/http-status-codes/src/3xx/redirection.status-codes.ts
+++ b/libs/http-status-codes/src/3xx/redirection.status-codes.ts
@@ -5,7 +5,7 @@ export const redirectionStatusCodes = [
 export type RedirectionStatusCode = (typeof redirectionStatusCodes)[number];
 
 export function isValidRedirectionStatusCode(
-  code: number
+  code: number,
 ): code is RedirectionStatusCode {
   return redirectionStatusCodes.includes(code as RedirectionStatusCode);
 }

--- a/libs/http-status-codes/src/4xx/client-error.phrases.ts
+++ b/libs/http-status-codes/src/4xx/client-error.phrases.ts
@@ -32,7 +32,7 @@ export const clientErrorPhrases = [
 export type ClientErrorPhrase = (typeof clientErrorPhrases)[number];
 
 export function isValidClientErrorPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is ClientErrorPhrase {
   return clientErrorPhrases.includes(phrase as ClientErrorPhrase);
 }

--- a/libs/http-status-codes/src/4xx/client-error.status-codes.ts
+++ b/libs/http-status-codes/src/4xx/client-error.status-codes.ts
@@ -6,7 +6,7 @@ export const clientErrorStatusCodes = [
 export type ClientErrorStatusCode = (typeof clientErrorStatusCodes)[number];
 
 export function isValidClientErrorStatusCode(
-  code: number
+  code: number,
 ): code is ClientErrorStatusCode {
   return clientErrorStatusCodes.includes(code as ClientErrorStatusCode);
 }

--- a/libs/http-status-codes/src/5xx/server-error.phrases.ts
+++ b/libs/http-status-codes/src/5xx/server-error.phrases.ts
@@ -15,7 +15,7 @@ export const serverErrorPhrases = [
 export type ServerErrorPhrase = (typeof serverErrorPhrases)[number];
 
 export function isValidServerErrorPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is ServerErrorPhrase {
   return serverErrorPhrases.includes(phrase as ServerErrorPhrase);
 }

--- a/libs/http-status-codes/src/5xx/server-error.status-codes.ts
+++ b/libs/http-status-codes/src/5xx/server-error.status-codes.ts
@@ -5,7 +5,7 @@ export const serverErrorStatusCodes = [
 export type ServerErrorStatusCode = (typeof serverErrorStatusCodes)[number];
 
 export function isValidServerErrorStatusCode(
-  code: number
+  code: number,
 ): code is ServerErrorStatusCode {
   return serverErrorStatusCodes.includes(code as ServerErrorStatusCode);
 }

--- a/libs/http-status-codes/src/http-status-code-ranges.ts
+++ b/libs/http-status-codes/src/http-status-code-ranges.ts
@@ -15,14 +15,14 @@ export const httpStatusCodeRanges = {
 export type HttpStatusCodeRange = keyof typeof httpStatusCodeRanges;
 
 export function isHttpStatusCodeRange(
-  statusCode: string
+  statusCode: string,
 ): statusCode is HttpStatusCodeRange {
   return /^[12345]XX$/.test(statusCode);
 }
 
 export function statusCodeMatchesRange(
   statusCode: number | string,
-  range: HttpStatusCodeRange
+  range: HttpStatusCodeRange,
 ): boolean {
   return !!httpStatusCodeRanges[range].find((code) => code === +statusCode);
 }

--- a/libs/http-status-codes/src/validate.ts
+++ b/libs/http-status-codes/src/validate.ts
@@ -41,7 +41,7 @@ export function isValidHttpStatusCode(code: unknown): code is HttpStatusCode {
 }
 
 export function isValidHttpStatusPhrase(
-  phrase: string
+  phrase: string,
 ): phrase is HttpStatusPhrase {
   return (
     isValidInformationalPhrase(phrase) ||

--- a/libs/http-testing/README.md
+++ b/libs/http-testing/README.md
@@ -13,24 +13,23 @@ const express = require('express');
 
 const app = express();
 
-app.get('/user', function(req, res) {
+app.get('/user', function (req, res) {
   res.status(200).header('Cache-Control', 'private, max-age=42').json({ name: 'alan turing' });
 });
 
 request(app)
   .get('/user')
   .expect(200)
-  .then(response => {
+  .then((response) => {
     expect(response.headers['Cache-Control']).toBeDefined();
-  })
-
+  });
 ```
 
-While this is the common approach to write tests, it does not scale well. Imagine a situation in which you are responsible 
-for multiple services and each of these services has an arbitrary number of GET endpoints for which you want to test 
+While this is the common approach to write tests, it does not scale well. Imagine a situation in which you are responsible
+for multiple services and each of these services has an arbitrary number of GET endpoints for which you want to test
 that the Cache-Control header is set. With the approach above you would have to write a lot of tests.
 
-🛟 __@thymian/http-testing to the rescue__ 🛟
+🛟 **@thymian/http-testing to the rescue** 🛟
 
 `@thymian/http-testing` is working on an abstraction layer above of concrete tests. Instead working with specific HTTP
 APIs, it lets you define tests based on the `Thymian format` (which can be found in @thymian/core). And since every API
@@ -38,38 +37,37 @@ description could be transformed into the Thymian format, the defined tests are 
 see this in action.
 
 ```js
-httpTest('every GET response should contain a Cache-Control header', transactions =>
+httpTest('every GET response should contain a Cache-Control header', (transactions) =>
   transactions.pipe(
-    filter(req => req.method === 'GET'),
+    filter((req) => req.method === 'GET'),
     mapToTestCase(),
     generateRequest(),
     runRequests(),
     expectStatusCode(200),
-    expectHeaders(headers => {
-      assert.ok(headers['Cache-Control'])
-    })
+    expectHeaders((headers) => {
+      assert.ok(headers['Cache-Control']);
+    }),
   ),
-)
+);
 ```
 
 As you can see the test definition does not include any path oder API specific information.
 
 ## How does this work?
 
-To say it in the most complicated way: With `@thymian/http-testing` you won't define your tests imperatively but 
-declaratively. You don't describe __how__ to call and test HTTP API endpoints but sets of endpoints end their expected properties.
-This is modeled through the usage of [RxJS](https://rxjs.dev/). While this library is mainly used to implement the asynchronous event 
+To say it in the most complicated way: With `@thymian/http-testing` you won't define your tests imperatively but
+declaratively. You don't describe **how** to call and test HTTP API endpoints but sets of endpoints end their expected properties.
+This is modeled through the usage of [RxJS](https://rxjs.dev/). While this library is mainly used to implement the asynchronous event
 processing, especially in frontend projects (think about mouse click events), we use the capabilities of RxJS to
 implement a declarative testing approach. RxJS provides a way to write code in a declarative, functional and pure
 way. We use its powerful collection of operators to implement our approach as a pipeline. Thereby the initial value of
 the pipeline is always the list of available HTTP transaction given through the corresponding API description. While
 you are totally free to do whatever you want in this pipeline, the result of it must be a collection of passed, skipped
 or failed test cases. To define and run these test cases `@thymian/http-testing` provides a number of operators
-additional to the built-in ones from RxJS itself. 
+additional to the built-in ones from RxJS itself.
 
     +-------------------+     +------+             +------+     +------------+
     | HTTP Transactions | --> | Step | --> ... --> | Step | --> | Test Cases |
     +-------------------+     +------+             +------+     +------------+
 
 To align with the approach of RxJS, the list of HTTP transactions is an [Observable](https://rxjs.dev/guide/observable).
-

--- a/libs/http-testing/eslint.config.mjs
+++ b/libs/http-testing/eslint.config.mjs
@@ -10,7 +10,6 @@ export default [
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
           ignoredDependencies: ['vitest', 'fastify'],
-
         },
       ],
     },

--- a/libs/http-testing/src/http-test/create-hook-runner.ts
+++ b/libs/http-testing/src/http-test/create-hook-runner.ts
@@ -40,7 +40,7 @@ declare module '@thymian/core' {
 const dm = deepmerge();
 
 export function createHookRunner(
-  emitter: ThymianEmitter
+  emitter: ThymianEmitter,
 ): HttpTestContext['runHook'] {
   // TODO
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/libs/http-testing/src/http-test/create-http-test-context.ts
+++ b/libs/http-testing/src/http-test/create-http-test-context.ts
@@ -6,15 +6,15 @@ import type {
 import type { PipelineItem } from './http-test-pipeline.js';
 
 export function createHttpTestContext<
-  Locals extends HttpTestContextLocals = HttpTestContextLocals
+  Locals extends HttpTestContextLocals = HttpTestContextLocals,
 >(
-  context: Omit<HttpTestContext<Locals>, 'skip' | 'fail'>
+  context: Omit<HttpTestContext<Locals>, 'skip' | 'fail'>,
 ): HttpTestContext<Locals> {
   return {
     ...context,
     skip<Steps extends HttpTestCaseStep[]>(
       testCase: HttpTestCase<Steps>,
-      reason?: string
+      reason?: string,
     ): PipelineItem<HttpTestCase<Steps>, Locals> {
       testCase.status = 'skipped';
       testCase.reason = reason;
@@ -27,7 +27,7 @@ export function createHttpTestContext<
     },
     fail<Steps extends HttpTestCaseStep[]>(
       testCase: HttpTestCase<Steps>,
-      reason?: string
+      reason?: string,
     ): PipelineItem<HttpTestCase<Steps>, Locals> {
       testCase.status = 'failed';
       testCase.reason = reason;

--- a/libs/http-testing/src/http-test/http-test-case.ts
+++ b/libs/http-testing/src/http-test/http-test-case.ts
@@ -8,7 +8,8 @@ import type {
 import type { HttpTestCaseResult } from './http-test-case-result.js';
 
 export interface GroupedHttpTestCaseStep<
-  Transactions extends HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[]
+  Transactions extends
+    HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[],
 > extends HttpTestCaseStep<
     {
       key: string;
@@ -20,7 +21,8 @@ export interface GroupedHttpTestCaseStep<
 }
 
 export interface SingleHttpTestCaseStep<
-  Transactions extends HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[]
+  Transactions extends
+    HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[],
 > extends HttpTestCaseStep<ThymianHttpTransaction, Transactions> {
   type: 'single';
 }
@@ -39,7 +41,8 @@ export type HttpTestCaseStepTransaction = {
 
 export interface HttpTestCaseStep<
   Source = unknown,
-  Transactions extends HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[]
+  Transactions extends
+    HttpTestCaseStepTransaction[] = HttpTestCaseStepTransaction[],
 > {
   type: 'single' | 'grouped' | 'custom';
   source: Source;
@@ -49,7 +52,7 @@ export interface HttpTestCaseStep<
 export type HttpTestCaseStatus = 'running' | 'skipped' | 'failed' | 'passed';
 
 export type HttpTestCase<
-  Steps extends HttpTestCaseStep[] = HttpTestCaseStep[]
+  Steps extends HttpTestCaseStep[] = HttpTestCaseStep[],
 > = {
   start: number;
   end?: number;

--- a/libs/http-testing/src/http-test/http-test-context.ts
+++ b/libs/http-testing/src/http-test/http-test-context.ts
@@ -19,7 +19,7 @@ export type GenerateRequestsOptions = {
 export type HttpTestContextLocals = Record<PropertyKey, unknown>;
 
 export interface HttpTestContext<
-  Locals extends HttpTestContextLocals = HttpTestContextLocals
+  Locals extends HttpTestContextLocals = HttpTestContextLocals,
 > {
   format: ThymianFormat;
 
@@ -28,23 +28,23 @@ export interface HttpTestContext<
   locals: Locals;
 
   sampleRequest(
-    transaction: ThymianHttpTransaction
+    transaction: ThymianHttpTransaction,
   ): Promise<HttpRequestTemplate>;
 
   runRequest(req: HttpRequest): Promise<HttpResponse>;
 
   runHook<Hook extends keyof HttpTestHooks>(
     name: Hook,
-    payload: HttpTestHooks[Hook]['arg']
+    payload: HttpTestHooks[Hook]['arg'],
   ): Promise<HttpTestHooks[Hook]['return']>;
 
   skip<Steps extends HttpTestCaseStep[]>(
     testCase: HttpTestCase<Steps>,
-    reason?: string
+    reason?: string,
   ): PipelineItem<HttpTestCase<Steps>, Locals>;
 
   fail<Steps extends HttpTestCaseStep[]>(
     testCase: HttpTestCase<Steps>,
-    reason?: string
+    reason?: string,
   ): PipelineItem<HttpTestCase<Steps>, Locals>;
 }

--- a/libs/http-testing/src/http-test/http-test-pipeline.ts
+++ b/libs/http-testing/src/http-test/http-test-pipeline.ts
@@ -9,12 +9,12 @@ import type {
 
 export type PipelineItem<
   Current,
-  Locals extends HttpTestContextLocals = HttpTestContextLocals
+  Locals extends HttpTestContextLocals = HttpTestContextLocals,
 > = {
   current: Current;
   ctx: HttpTestContext<Locals>;
 };
 
 export type HttpTestPipeline<Locals extends HttpTestContextLocals> = (
-  transactions: Observable<PipelineItem<ThymianHttpTransaction, Locals>>
+  transactions: Observable<PipelineItem<ThymianHttpTransaction, Locals>>,
 ) => Observable<PipelineItem<HttpTestCase, Locals>>;

--- a/libs/http-testing/src/http-test/http-test.ts
+++ b/libs/http-testing/src/http-test/http-test.ts
@@ -15,11 +15,11 @@ export type HttpTestResult = {
 };
 
 export type HttpTestRunnerFn<Locals extends HttpTestContextLocals> = (
-  ctx: HttpTestContext<Locals>
+  ctx: HttpTestContext<Locals>,
 ) => Promise<HttpTestResult>;
 
 export function httpTest<
-  Locals extends HttpTestContextLocals = HttpTestContextLocals
+  Locals extends HttpTestContextLocals = HttpTestContextLocals,
 >(name: string, fn: HttpTestPipeline<Locals>): HttpTestRunnerFn<Locals> {
   return (ctx) => {
     const start = performance.now();

--- a/libs/http-testing/src/http-test/utils.ts
+++ b/libs/http-testing/src/http-test/utils.ts
@@ -7,31 +7,31 @@ import type {
 } from './http-test-case.js';
 
 export function isSingleHttpTestCaseStep(
-  step?: HttpTestCaseStep
+  step?: HttpTestCaseStep,
 ): step is SingleHttpTestCaseStep {
   return step?.type === 'single';
 }
 
 export function isGroupedHttpTestCaseStep(
-  step?: HttpTestCaseStep
+  step?: HttpTestCaseStep,
 ): step is GroupedHttpTestCaseStep {
   return step?.type === 'grouped';
 }
 
 export function isCustomHttpTestCaseStep(
-  step?: HttpTestCaseStep
+  step?: HttpTestCaseStep,
 ): step is CustomHttpTestCaseStep {
   return step?.type === 'custom';
 }
 
 export function isSkippedTestCase<Steps extends HttpTestCaseStep[]>(
-  testCase: HttpTestCase<Steps>
+  testCase: HttpTestCase<Steps>,
 ): testCase is HttpTestCase<Steps> & { status: 'skipped' } {
   return testCase.status === 'skipped';
 }
 
 export function isFailedTestCase<Steps extends HttpTestCaseStep[]>(
-  testCase: HttpTestCase<Steps>
+  testCase: HttpTestCase<Steps>,
 ): testCase is HttpTestCase<Steps> & { status: 'failed' } {
   return testCase.status === 'failed';
 }

--- a/libs/http-testing/src/operators/expect-for-transaction.operator.ts
+++ b/libs/http-testing/src/operators/expect-for-transaction.operator.ts
@@ -12,11 +12,11 @@ import {
 } from '../http-test/index.js';
 
 export type HttpTestCaseTransactionValidationFn = (
-  transaction: HttpTestCaseStepTransaction
+  transaction: HttpTestCaseStepTransaction,
 ) => void;
 
 export function expectForTransactions<Steps extends HttpTestCaseStep[]>(
-  fn: HttpTestCaseTransactionValidationFn
+  fn: HttpTestCaseTransactionValidationFn,
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map(({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {
@@ -27,7 +27,7 @@ export function expectForTransactions<Steps extends HttpTestCaseStep[]>(
 
     if (!step) {
       ctx.logger.warn(
-        `Calling "expectForTransaction" for test case "${current.name}" that includes no test case steps.`
+        `Calling "expectForTransaction" for test case "${current.name}" that includes no test case steps.`,
       );
 
       return { current, ctx };

--- a/libs/http-testing/src/operators/expect-headers.operator.ts
+++ b/libs/http-testing/src/operators/expect-headers.operator.ts
@@ -14,8 +14,8 @@ import {
 export function expectHeaders<Steps extends HttpTestCaseStep[]>(
   fn: (
     headers: Record<string, string | string[] | undefined>,
-    transaction: HttpTestCaseStepTransaction
-  ) => void
+    transaction: HttpTestCaseStepTransaction,
+  ) => void,
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map(({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {

--- a/libs/http-testing/src/operators/expect-status-code.operator.ts
+++ b/libs/http-testing/src/operators/expect-status-code.operator.ts
@@ -14,7 +14,7 @@ import {
 } from '../http-test/index.js';
 
 export function expectStatusCode<Steps extends HttpTestCaseStep[]>(
-  statusCode: number | HttpStatusCodeRange | (number | HttpStatusCodeRange)[]
+  statusCode: number | HttpStatusCodeRange | (number | HttpStatusCodeRange)[],
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map(({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {

--- a/libs/http-testing/src/operators/expect.operator.ts
+++ b/libs/http-testing/src/operators/expect.operator.ts
@@ -11,7 +11,7 @@ import {
 } from '../http-test/index.js';
 
 export function expect<Steps extends HttpTestCaseStep[]>(
-  fn: (testInstance: PipelineItem<HttpTestCase<Steps>>) => void
+  fn: (testInstance: PipelineItem<HttpTestCase<Steps>>) => void,
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map((item) => {
     if (isSkippedTestCase(item.current) || isFailedTestCase(item.current)) {

--- a/libs/http-testing/src/operators/fail.operator.ts
+++ b/libs/http-testing/src/operators/fail.operator.ts
@@ -3,7 +3,7 @@ import { map, type OperatorFunction } from 'rxjs';
 import type { HttpTestCase, HttpTestCaseStep } from '../http-test/index.js';
 
 export function failTestCase<Steps extends HttpTestCaseStep[]>(
-  fn: (testCase: HttpTestCase<Steps>) => boolean = () => true
+  fn: (testCase: HttpTestCase<Steps>) => boolean = () => true,
 ): OperatorFunction<HttpTestCase<Steps>, HttpTestCase<Steps>> {
   return map((testCase) => ({
     ...testCase,

--- a/libs/http-testing/src/operators/filter-http-transactions.operator.ts
+++ b/libs/http-testing/src/operators/filter-http-transactions.operator.ts
@@ -12,7 +12,7 @@ import { type StringAndNumberProperties } from '../utils.js';
 export type RequestFilterFn = (
   req: ThymianHttpRequest,
   reqId: string,
-  responses: [string, ThymianHttpResponse][]
+  responses: [string, ThymianHttpResponse][],
 ) => boolean;
 
 export type RequestFilter =
@@ -23,7 +23,7 @@ export type ResponseFilterFn = (
   res: ThymianHttpResponse,
   resId: string,
   req: ThymianHttpRequest,
-  reqId: string
+  reqId: string,
 ) => boolean;
 
 export type ResponseFilter =
@@ -32,7 +32,7 @@ export type ResponseFilter =
 
 export function filterHttpTransactions(
   reqFilter: RequestFilter = {},
-  resFilter: ResponseFilter = {}
+  resFilter: ResponseFilter = {},
 ): MonoTypeOperatorFunction<PipelineItem<ThymianHttpTransaction>> {
   return filter(({ current: transaction, ctx }) => {
     const requestFilter =
@@ -41,7 +41,7 @@ export function filterHttpTransactions(
         : (t: ThymianHttpTransaction) => {
             const responses = ctx.format.getNeighboursOfType(
               transaction.thymianReqId,
-              'http-response'
+              'http-response',
             );
 
             return reqFilter(t.thymianReq, t.thymianReqId, responses);
@@ -55,7 +55,7 @@ export function filterHttpTransactions(
               t.thymianRes,
               t.thymianResId,
               t.thymianReq,
-              t.thymianReqId
+              t.thymianReqId,
             );
 
     return requestFilter(transaction) && responseFilter(transaction);

--- a/libs/http-testing/src/operators/generate-requests.operator.ts
+++ b/libs/http-testing/src/operators/generate-requests.operator.ts
@@ -26,7 +26,7 @@ type InferStep<Step extends HttpTestCaseStep> =
           PartialExceptFor<
             HttpTestCaseStepTransaction,
             'requestTemplate' | 'source'
-          >
+          >,
         ]
       >
     : Step;
@@ -34,9 +34,9 @@ type InferStep<Step extends HttpTestCaseStep> =
 export function generateRequests<
   PreviousSteps extends HttpTestCaseStep[],
   CurrentStep extends HttpTestCaseStep,
-  Locals extends HttpTestContextLocals
+  Locals extends HttpTestContextLocals,
 >(
-  options?: GenerateRequestsOptions
+  options?: GenerateRequestsOptions,
 ): OperatorFunction<
   PipelineItem<HttpTestCase<[...PreviousSteps, CurrentStep]>, Locals>,
   PipelineItem<HttpTestCase<[...PreviousSteps, InferStep<CurrentStep>]>, Locals>
@@ -70,7 +70,7 @@ export function generateRequests<
       }
     } else if (isCustomHttpTestCaseStep(step)) {
       ctx.logger.warn(
-        'generateRequests was called on custom http test step which is not supported.'
+        'generateRequests was called on custom http test step which is not supported.',
       );
     }
 

--- a/libs/http-testing/src/operators/map-to-grouped-test-case.operator.ts
+++ b/libs/http-testing/src/operators/map-to-grouped-test-case.operator.ts
@@ -16,7 +16,7 @@ import type { HttpTestContextLocals } from '../http-test/http-test-context.js';
 import type { PipelineItem } from '../http-test/http-test-pipeline.js';
 
 export function mapToGroupedTestCase<
-  Locals extends HttpTestContextLocals
+  Locals extends HttpTestContextLocals,
 >(): OperatorFunction<
   GroupedObservable<string, PipelineItem<ThymianHttpTransaction, Locals>>,
   PipelineItem<HttpTestCase<[GroupedHttpTestCaseStep]>, Locals>
@@ -53,7 +53,7 @@ export function mapToGroupedTestCase<
         };
 
         return envelope;
-      })
+      }),
     );
   });
 }

--- a/libs/http-testing/src/operators/map-to-test-case.operator.ts
+++ b/libs/http-testing/src/operators/map-to-test-case.operator.ts
@@ -12,7 +12,7 @@ import type { HttpTestContextLocals } from '../http-test/http-test-context.js';
 import type { PipelineItem } from '../http-test/http-test-pipeline.js';
 
 export function mapToTestCase<
-  Locals extends HttpTestContextLocals
+  Locals extends HttpTestContextLocals,
 >(): OperatorFunction<
   PipelineItem<ThymianHttpTransaction, Locals>,
   PipelineItem<HttpTestCase<[SingleHttpTestCaseStep]>, Locals>
@@ -22,7 +22,7 @@ export function mapToTestCase<
     current: {
       name: thymianHttpTransactionToString(
         current.thymianReq,
-        current.thymianRes
+        current.thymianRes,
       ),
       status: 'running',
       start: performance.now(),

--- a/libs/http-testing/src/operators/override-headers.operator.ts
+++ b/libs/http-testing/src/operators/override-headers.operator.ts
@@ -10,8 +10,8 @@ import { isFailedTestCase, isSkippedTestCase } from '../http-test/index.js';
 export function overrideHeaders<Steps extends HttpTestCaseStep[]>(
   fn: (
     headers: Record<string, unknown>,
-    testCase: HttpTestCase<Steps>
-  ) => Record<string, unknown>
+    testCase: HttpTestCase<Steps>,
+  ) => Record<string, unknown>,
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map(({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {
@@ -27,7 +27,7 @@ export function overrideHeaders<Steps extends HttpTestCaseStep[]>(
     for (const transaction of currentStep.transactions) {
       transaction.requestTemplate.headers = fn(
         transaction.requestTemplate.headers,
-        current
+        current,
       );
     }
 

--- a/libs/http-testing/src/operators/override-with-previous.operator.ts
+++ b/libs/http-testing/src/operators/override-with-previous.operator.ts
@@ -12,12 +12,12 @@ import {
 export function overrideRequestWithPrevious<
   Steps extends HttpTestCaseStep[],
   Previous extends HttpTestCaseStep,
-  Current extends HttpTestCaseStep
+  Current extends HttpTestCaseStep,
 >(
   fn: (
     requestTemplate: HttpRequestTemplate,
-    previous: Previous
-  ) => HttpRequestTemplate
+    previous: Previous,
+  ) => HttpRequestTemplate,
 ): MonoTypeOperatorFunction<
   PipelineItem<HttpTestCase<[...Steps, Previous, Current]>>
 > {

--- a/libs/http-testing/src/operators/replay-previous-step.operator.ts
+++ b/libs/http-testing/src/operators/replay-previous-step.operator.ts
@@ -9,15 +9,15 @@ import { isFailedTestCase, isSkippedTestCase } from '../http-test/index.js';
 
 export function replayStep<
   Steps extends HttpTestCaseStep[],
-  CurrentStep extends HttpTestCaseStep
+  CurrentStep extends HttpTestCaseStep,
 >(
   fn: (
     step: Observable<
       PipelineItem<HttpTestCase<[...Steps, CurrentStep, CurrentStep]>>
-    >
+    >,
   ) => Observable<
     PipelineItem<HttpTestCase<[...Steps, CurrentStep, CurrentStep]>>
-  >
+  >,
 ): OperatorFunction<
   PipelineItem<HttpTestCase<[...Steps, CurrentStep]>>,
   PipelineItem<HttpTestCase<[...Steps, CurrentStep, CurrentStep]>>
@@ -50,7 +50,7 @@ export function replayStep<
       of({
         ctx,
         current: current as HttpTestCase<[...Steps, CurrentStep, CurrentStep]>,
-      })
+      }),
     );
   });
 }

--- a/libs/http-testing/src/operators/reply-previous-but-expect-response.operator.ts
+++ b/libs/http-testing/src/operators/reply-previous-but-expect-response.operator.ts
@@ -22,12 +22,12 @@ export function replayStepButExpectResponse<Steps extends HttpTestCaseStep[]>(
       PipelineItem<
         HttpTestCase<[...Steps, SingleHttpTestCaseStep, SingleHttpTestCaseStep]>
       >
-    >
+    >,
   ) => Observable<
     PipelineItem<
       HttpTestCase<[...Steps, SingleHttpTestCaseStep, SingleHttpTestCaseStep]>
     >
-  >
+  >,
 ): OperatorFunction<
   PipelineItem<HttpTestCase<[...Steps, SingleHttpTestCaseStep]>>,
   PipelineItem<
@@ -83,8 +83,8 @@ export function replayStepButExpectResponse<Steps extends HttpTestCaseStep[]>(
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           current,
-          `A single transaction must be referenced but ${transactions.length} were referenced.`
-        )
+          `A single transaction must be referenced but ${transactions.length} were referenced.`,
+        ),
       );
     }
 
@@ -97,7 +97,7 @@ export function replayStepButExpectResponse<Steps extends HttpTestCaseStep[]>(
           ({
             requestTemplate: transaction.requestTemplate,
             source: transactions[0],
-          } as HttpTestCaseStepTransaction)
+          }) as HttpTestCaseStepTransaction,
       ),
     };
 
@@ -109,7 +109,7 @@ export function replayStepButExpectResponse<Steps extends HttpTestCaseStep[]>(
         current: current as HttpTestCase<
           [...Steps, SingleHttpTestCaseStep, SingleHttpTestCaseStep]
         >,
-      })
+      }),
     );
   });
 }

--- a/libs/http-testing/src/operators/requires-authorization.operator.ts
+++ b/libs/http-testing/src/operators/requires-authorization.operator.ts
@@ -4,14 +4,14 @@ import { filter, type MonoTypeOperatorFunction } from 'rxjs';
 import type { PipelineItem } from '../http-test/http-test-pipeline.js';
 
 export function requiresAuthorization(
-  requireAuthorization = true
+  requireAuthorization = true,
 ): MonoTypeOperatorFunction<PipelineItem<ThymianHttpTransaction>> {
   return filter(({ current, ctx }) => {
     return (
       requireAuthorization ===
       (typeof ctx.format.graph.findOutNeighbor(
         current.thymianReqId,
-        (id, node) => node.type === 'security-scheme'
+        (id, node) => node.type === 'security-scheme',
       ) ===
         'string')
     );

--- a/libs/http-testing/src/operators/run-requests.operator.ts
+++ b/libs/http-testing/src/operators/run-requests.operator.ts
@@ -26,9 +26,9 @@ export type RunRequestsOptions = {
 
 export function runRequests<
   Steps extends HttpTestCaseStep[],
-  Locals extends HttpTestContextLocals
+  Locals extends HttpTestContextLocals,
 >(
-  opts: Partial<RunRequestsOptions> = {}
+  opts: Partial<RunRequestsOptions> = {},
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>, Locals>> {
   return mergeMap(async ({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {
@@ -112,7 +112,7 @@ export function runRequests<
           if (options.checkStatusCode || options.checkResponse) {
             const result = validateStatusCode(
               transaction.source.thymianRes.statusCode,
-              transaction.response.statusCode
+              transaction.response.statusCode,
             );
 
             if (result.type === 'assertion-failure') {
@@ -139,8 +139,8 @@ export function runRequests<
             results.push(
               ...validateBodyForResponse(
                 transaction.response.body,
-                transaction.source.thymianRes
-              )
+                transaction.source.thymianRes,
+              ),
             );
           }
 
@@ -148,8 +148,8 @@ export function runRequests<
             results.push(
               ...validateHeaders(
                 transaction.response.headers,
-                transaction.source.thymianRes
-              )
+                transaction.source.thymianRes,
+              ),
             );
           }
 
@@ -163,7 +163,7 @@ export function runRequests<
                 }
 
                 return r;
-              })
+              }),
             );
 
             return ctx.fail(current);
@@ -172,7 +172,7 @@ export function runRequests<
       }
     } else {
       ctx.logger.warn(
-        `Test case ${current.name} does not contain any steps to run requests for.`
+        `Test case ${current.name} does not contain any steps to run requests for.`,
       );
     }
 

--- a/libs/http-testing/src/operators/single-step-for-transaction.operator.ts
+++ b/libs/http-testing/src/operators/single-step-for-transaction.operator.ts
@@ -17,7 +17,7 @@ import {
 
 export function singleStepForTransaction<
   Steps extends HttpTestCaseStep[],
-  CurrentStep extends HttpTestCaseStep
+  CurrentStep extends HttpTestCaseStep,
 >(
   findTransaction: (previous: CurrentStep, format: ThymianFormat) => string,
   fn: (
@@ -25,10 +25,10 @@ export function singleStepForTransaction<
       PipelineItem<
         HttpTestCase<[...Steps, CurrentStep, SingleHttpTestCaseStep]>
       >
-    >
+    >,
   ) => Observable<
     PipelineItem<HttpTestCase<[...Steps, CurrentStep, SingleHttpTestCaseStep]>>
-  >
+  >,
 ): OperatorFunction<
   PipelineItem<HttpTestCase<[...Steps, CurrentStep]>>,
   PipelineItem<HttpTestCase<[...Steps, CurrentStep, SingleHttpTestCaseStep]>>
@@ -49,10 +49,10 @@ export function singleStepForTransaction<
       return of(
         ctx.fail(
           current,
-          'Previous step must be defined.'
+          'Previous step must be defined.',
         ) as unknown as PipelineItem<
           HttpTestCase<[...Steps, CurrentStep, SingleHttpTestCaseStep]>
-        >
+        >,
       );
     }
 
@@ -67,10 +67,10 @@ export function singleStepForTransaction<
       return of(
         ctx.fail(
           current,
-          'Invalid HTTP transaction ID.'
+          'Invalid HTTP transaction ID.',
         ) as unknown as PipelineItem<
           HttpTestCase<[...Steps, CurrentStep, SingleHttpTestCaseStep]>
-        >
+        >,
       );
     }
 
@@ -95,7 +95,7 @@ export function singleStepForTransaction<
         current: current as unknown as HttpTestCase<
           [...Steps, CurrentStep, SingleHttpTestCaseStep]
         >,
-      })
+      }),
     );
   });
 }

--- a/libs/http-testing/src/operators/skip.operator.ts
+++ b/libs/http-testing/src/operators/skip.operator.ts
@@ -7,7 +7,7 @@ import type {
 import type { PipelineItem } from '../http-test/http-test-pipeline.js';
 
 export function skipTestCase<Steps extends HttpTestCaseStep[]>(
-  fn: (testCase: HttpTestCase<Steps>) => boolean = () => true
+  fn: (testCase: HttpTestCase<Steps>) => boolean = () => true,
 ): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return map(({ current, ctx }) => ({
     current: {

--- a/libs/http-testing/src/operators/step.operator.ts
+++ b/libs/http-testing/src/operators/step.operator.ts
@@ -14,11 +14,11 @@ import { isFailedTestCase, isSkippedTestCase } from '../http-test/index.js';
 
 export function step<
   Steps extends HttpTestCaseStep[],
-  CurrentStep extends HttpTestCaseStep
+  CurrentStep extends HttpTestCaseStep,
 >(
   fn: MonoTypeOperatorFunction<
     PipelineItem<HttpTestCase<[...Steps, CurrentStep, CustomHttpTestCaseStep]>>
-  >
+  >,
 ): OperatorFunction<
   PipelineItem<HttpTestCase<[...Steps, CurrentStep]>>,
   PipelineItem<HttpTestCase<[...Steps, CurrentStep, CustomHttpTestCaseStep]>>
@@ -47,6 +47,6 @@ export function step<
 
         return { current: newCurr, ctx };
       }),
-      fn
+      fn,
     );
 }

--- a/libs/http-testing/src/operators/utils.ts
+++ b/libs/http-testing/src/operators/utils.ts
@@ -7,25 +7,25 @@ import type {
 
 export function hasOwnProperty<
   T extends Record<PropertyKey, unknown>,
-  K extends PropertyKey
+  K extends PropertyKey,
 >(obj: T, key: K): obj is T & Record<K, unknown> {
   return Object.hasOwn(obj, key);
 }
 
 export function hasThymianReqId(
-  value: unknown
+  value: unknown,
 ): value is Record<PropertyKey, unknown> & { thymianReqId: string } {
   return isRecord(value) && 'thymianReqId' in value;
 }
 
 export function hasThymianResId(
-  value: unknown
+  value: unknown,
 ): value is Record<PropertyKey, unknown> & { thymianResId: string } {
   return isRecord(value) && 'thymianResId' in value;
 }
 
 export function previousStep<Steps extends HttpTestCaseStep[]>(
-  testCase: HttpTestCase<Steps>
+  testCase: HttpTestCase<Steps>,
 ): Steps extends [...HttpTestCaseStep[], infer Previous, HttpTestCaseStep]
   ? Previous
   : undefined {

--- a/libs/http-testing/src/operators/validate-responses.operator.ts
+++ b/libs/http-testing/src/operators/validate-responses.operator.ts
@@ -12,7 +12,7 @@ import { validateResponse } from '../validate/index.js';
 import { hasThymianResId } from './utils.js';
 
 export function validateResponses<
-  Steps extends HttpTestCaseStep[]
+  Steps extends HttpTestCaseStep[],
 >(): MonoTypeOperatorFunction<PipelineItem<HttpTestCase<Steps>>> {
   return mergeMap(async ({ current, ctx }) => {
     if (isSkippedTestCase(current) || isFailedTestCase(current)) {
@@ -31,7 +31,7 @@ export function validateResponses<
       }
 
       const response = ctx.format.getNode<ThymianHttpResponse>(
-        transaction.source.thymianResId
+        transaction.source.thymianResId,
       );
 
       if (!response) {
@@ -40,7 +40,7 @@ export function validateResponses<
 
       const result = validateResponse(
         transaction.source.thymianRes,
-        transaction.response
+        transaction.response,
       );
 
       current.results.push(...result.results);

--- a/libs/http-testing/src/serialize-parameter.ts
+++ b/libs/http-testing/src/serialize-parameter.ts
@@ -4,7 +4,7 @@ import { parseTemplate, type PrimitiveValue } from 'url-template';
 export function serializePathParameter(
   name: string,
   content: unknown,
-  serializationStyle: SerializationStyle
+  serializationStyle: SerializationStyle,
 ): string {
   let prefix = '';
 
@@ -24,7 +24,7 @@ export function serializePathParameter(
 export function serializeHeaderParameter(
   name: string,
   content: unknown,
-  serializationStyle: SerializationStyle
+  serializationStyle: SerializationStyle,
 ): string {
   const postfix = serializationStyle.explode ? '*' : '';
 
@@ -35,7 +35,7 @@ export function serializeHeaderParameter(
 
 export function serializeCookieParameter(
   name: string,
-  content: unknown
+  content: unknown,
 ): string {
   return parseTemplate(`{${name}}`).expand({
     [name]: content as PrimitiveValue,
@@ -45,7 +45,7 @@ export function serializeCookieParameter(
 export function serializeQueryParameter(
   name: string,
   content: unknown,
-  serializationStyle: SerializationStyle
+  serializationStyle: SerializationStyle,
 ): string {
   // See matrix https://swagger.io/docs/specification/v3_0/serialization/#query-parameters
   const queryParameterTemplates: Record<
@@ -74,7 +74,7 @@ export function serializeQueryParameter(
 
   if (typeof template === 'undefined') {
     throw new Error(
-      `Serialization with style "${style}" and explode "${explode}" is currently not supported.`
+      `Serialization with style "${style}" and explode "${explode}" is currently not supported.`,
     );
   }
 

--- a/libs/http-testing/src/serialize-request.ts
+++ b/libs/http-testing/src/serialize-request.ts
@@ -22,7 +22,7 @@ function serializeBasePath(transaction: HttpTestCaseStepTransaction) {
           return serializePathParameter(
             parameterName,
             transaction.requestTemplate.pathParameters[parameterName],
-            transaction.source.thymianReq.pathParameters[parameterName].style
+            transaction.source.thymianReq.pathParameters[parameterName].style,
           );
         } else {
           const type =
@@ -36,11 +36,11 @@ function serializeBasePath(transaction: HttpTestCaseStepTransaction) {
             type === 'symbol'
           ) {
             return String(
-              transaction.requestTemplate.pathParameters[parameterName]
+              transaction.requestTemplate.pathParameters[parameterName],
             );
           } else {
             throw new Error(
-              `Value of path parameter "${parameterName}" must be of type string but got "${type}".`
+              `Value of path parameter "${parameterName}" must be of type string but got "${type}".`,
             );
           }
         }
@@ -48,17 +48,17 @@ function serializeBasePath(transaction: HttpTestCaseStepTransaction) {
         const transactionName = transaction.source
           ? thymianHttpTransactionToString(
               transaction.source.thymianReq,
-              transaction.source.thymianRes
+              transaction.source.thymianRes,
             )
           : `${transaction.requestTemplate.method.toUpperCase()} ${
               transaction.requestTemplate.origin
             }${transaction.requestTemplate.path}`;
 
         throw new Error(
-          `Missing value for path parameter "${parameterName}" of transaction "${transactionName}".`
+          `Missing value for path parameter "${parameterName}" of transaction "${transactionName}".`,
         );
       }
-    }
+    },
   );
 }
 
@@ -69,7 +69,7 @@ function serializeQuery(transaction: HttpTestCaseStepTransaction) {
         return serializeQueryParameter(
           name,
           value,
-          transaction.source?.thymianReq.queryParameters[name].style
+          transaction.source?.thymianReq.queryParameters[name].style,
         );
       } else {
         const type = typeof value;
@@ -84,7 +84,7 @@ function serializeQuery(transaction: HttpTestCaseStepTransaction) {
           return encodeURIComponent(String(value));
         } else {
           throw new Error(
-            `Invalid type for query parameter. Got type: ${type}.`
+            `Invalid type for query parameter. Got type: ${type}.`,
           );
         }
       }
@@ -93,7 +93,7 @@ function serializeQuery(transaction: HttpTestCaseStepTransaction) {
 }
 
 export function serializePath(
-  transaction: HttpTestCaseStepTransaction
+  transaction: HttpTestCaseStepTransaction,
 ): string {
   const path = serializeBasePath(transaction);
 
@@ -103,7 +103,7 @@ export function serializePath(
 }
 
 export function serializeHeaders(
-  transaction: HttpTestCaseStepTransaction
+  transaction: HttpTestCaseStepTransaction,
 ): Record<string, string> {
   const headers = transaction.source?.thymianReq.headers ?? {};
 
@@ -116,14 +116,14 @@ export function serializeHeaders(
           acc[key] = serializeHeaderParameter(key, value, headers[key].style);
         } else {
           throw new Error(
-            `Header value must be of type "string" but got "${typeof value}".`
+            `Header value must be of type "string" but got "${typeof value}".`,
           );
         }
       }
 
       return acc;
     },
-    {} as Record<string, string>
+    {} as Record<string, string>,
   );
 }
 
@@ -155,7 +155,7 @@ export function serializeBody(body: unknown): string | undefined {
 }
 
 export function serializeRequest(
-  transaction: HttpTestCaseStepTransaction
+  transaction: HttpTestCaseStepTransaction,
 ): HttpRequest {
   return {
     body: serializeBody(transaction.requestTemplate.body),

--- a/libs/http-testing/src/test-builder/compilers/http-filter-to-transaction-filter.ts
+++ b/libs/http-testing/src/test-builder/compilers/http-filter-to-transaction-filter.ts
@@ -15,18 +15,18 @@ export type TransactionFilterFn = (
   reqId: string,
   res: ThymianHttpResponse,
   resId: string,
-  responses: [string, ThymianHttpResponse][]
+  responses: [string, ThymianHttpResponse][],
 ) => boolean;
 
 export function httpFilterToTransactionFilter(
   filterExpression: HttpFilterExpression,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): TransactionFilterFn {
   switch (filterExpression.kind) {
     case 'request':
       return requestScopedHttpFilterToTransactionFilter(
         filterExpression,
-        format
+        format,
       );
     case 'response':
       return responseScopeHttpFilterToTransactionFilter(filterExpression);
@@ -37,7 +37,7 @@ export function httpFilterToTransactionFilter(
           reqId: string,
           res: ThymianHttpResponse,
           resId: string,
-          responses: [string, ThymianHttpResponse][]
+          responses: [string, ThymianHttpResponse][],
         ) =>
           filterExpression.filters.every((expr) =>
             httpFilterToTransactionFilter(expr, format)(
@@ -45,8 +45,8 @@ export function httpFilterToTransactionFilter(
               reqId,
               res,
               resId,
-              responses
-            )
+              responses,
+            ),
           );
       } else if (filterExpression.type === 'or') {
         return (
@@ -54,7 +54,7 @@ export function httpFilterToTransactionFilter(
           reqId: string,
           res: ThymianHttpResponse,
           resId: string,
-          responses: [string, ThymianHttpResponse][]
+          responses: [string, ThymianHttpResponse][],
         ) =>
           filterExpression.filters.some((expr) =>
             httpFilterToTransactionFilter(expr, format)(
@@ -62,8 +62,8 @@ export function httpFilterToTransactionFilter(
               reqId,
               res,
               resId,
-              responses
-            )
+              responses,
+            ),
           );
       } else if (filterExpression.type === 'xor') {
         return (
@@ -71,7 +71,7 @@ export function httpFilterToTransactionFilter(
           reqId: string,
           res: ThymianHttpResponse,
           resId: string,
-          responses: [string, ThymianHttpResponse][]
+          responses: [string, ThymianHttpResponse][],
         ) =>
           filterExpression.filters
             .map((expr) =>
@@ -80,8 +80,8 @@ export function httpFilterToTransactionFilter(
                 reqId,
                 res,
                 resId,
-                responses
-              )
+                responses,
+              ),
             )
             .reduce((acc, curr) => acc !== curr);
       } else if (filterExpression.type === 'not') {
@@ -90,14 +90,14 @@ export function httpFilterToTransactionFilter(
           reqId: string,
           res: ThymianHttpResponse,
           resId: string,
-          responses: [string, ThymianHttpResponse][]
+          responses: [string, ThymianHttpResponse][],
         ) =>
           !httpFilterToTransactionFilter(filterExpression.filter, format)(
             req,
             reqId,
             res,
             resId,
-            responses
+            responses,
           );
       } else {
         return () => Boolean(filterExpression.value);
@@ -107,14 +107,14 @@ export function httpFilterToTransactionFilter(
 }
 
 export function responseScopeHttpFilterToTransactionFilter(
-  expression: ResponseFilterExpression
+  expression: ResponseFilterExpression,
 ): TransactionFilterFn {
   switch (expression.type) {
     case 'responseMediaType':
       return (
         req: ThymianHttpRequest,
         reqId: string,
-        res: ThymianHttpResponse
+        res: ThymianHttpResponse,
       ) => res.mediaType === expression.mediaType;
     case 'responseTrailer':
       // TODO
@@ -123,13 +123,13 @@ export function responseScopeHttpFilterToTransactionFilter(
       return (
         req: ThymianHttpRequest,
         reqId: string,
-        res: ThymianHttpResponse
+        res: ThymianHttpResponse,
       ) => res.statusCode === expression.code;
     case 'hasResponseBody':
       return (
         req: ThymianHttpRequest,
         reqId: string,
-        res: ThymianHttpResponse
+        res: ThymianHttpResponse,
       ) => !!res.schema;
     case 'responseHeader': {
       if (typeof expression.header === 'undefined') return () => false;
@@ -137,7 +137,7 @@ export function responseScopeHttpFilterToTransactionFilter(
       return (
         req: ThymianHttpRequest,
         reqId: string,
-        res: ThymianHttpResponse
+        res: ThymianHttpResponse,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       ) => equalsIgnoreCase(expression.header!, ...Object.keys(res.headers));
     }
@@ -145,7 +145,7 @@ export function responseScopeHttpFilterToTransactionFilter(
       return (
         req: ThymianHttpRequest,
         reqId: string,
-        res: ThymianHttpResponse
+        res: ThymianHttpResponse,
       ) =>
         Number.isInteger(res.statusCode) &&
         res.statusCode >= expression.start &&
@@ -155,7 +155,7 @@ export function responseScopeHttpFilterToTransactionFilter(
 
 export function requestScopedHttpFilterToTransactionFilter(
   filterExpression: RequestFilterExpression,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): TransactionFilterFn {
   switch (filterExpression.type) {
     case 'origin':
@@ -194,7 +194,7 @@ export function requestScopedHttpFilterToTransactionFilter(
         equalsIgnoreCase(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           filterExpression.param!,
-          ...Object.keys(req.queryParameters)
+          ...Object.keys(req.queryParameters),
         );
     }
     case 'path':
@@ -205,15 +205,15 @@ export function requestScopedHttpFilterToTransactionFilter(
         reqId: string,
         res: ThymianHttpResponse,
         resId: string,
-        responses: [string, ThymianHttpResponse][]
+        responses: [string, ThymianHttpResponse][],
       ) => {
         const fn = httpFilterToTransactionFilter(
           filterExpression.filter,
-          format
+          format,
         );
 
         return responses.some(([resId, res]) =>
-          fn(req, reqId, res, resId, responses)
+          fn(req, reqId, res, resId, responses),
         );
       };
     case 'isAuthorized':
@@ -221,7 +221,7 @@ export function requestScopedHttpFilterToTransactionFilter(
         format.requestIsSecured(reqId) === filterExpression.isAuthorized;
     default:
       throw new Error(
-        `Invalid expression: ${JSON.stringify(filterExpression, null, 2)}.`
+        `Invalid expression: ${JSON.stringify(filterExpression, null, 2)}.`,
       );
   }
 }

--- a/libs/http-testing/src/test-builder/compilers/response-scoped-to-response-checker.ts
+++ b/libs/http-testing/src/test-builder/compilers/response-scoped-to-response-checker.ts
@@ -3,7 +3,7 @@ import type { HttpFilterExpression } from '@thymian/http-filter';
 
 export function compileResponseScopedToResponseChecker(
   expression: HttpFilterExpression,
-  response: HttpResponse
+  response: HttpResponse,
 ): boolean {
   if (expression.kind === 'request') {
     throw new Error();
@@ -28,16 +28,16 @@ export function compileResponseScopedToResponseChecker(
       );
     case 'and':
       return expression.filters.every((expr) =>
-        compileResponseScopedToResponseChecker(expr, response)
+        compileResponseScopedToResponseChecker(expr, response),
       );
     case 'or':
       return expression.filters.some((expr) =>
-        compileResponseScopedToResponseChecker(expr, response)
+        compileResponseScopedToResponseChecker(expr, response),
       );
     case 'not':
       return !compileResponseScopedToResponseChecker(
         expression.filter,
-        response
+        response,
       );
     case 'xor':
       return expression.filters

--- a/libs/http-testing/src/test-builder/compilers/response-scoped-to-transaction-validator.ts
+++ b/libs/http-testing/src/test-builder/compilers/response-scoped-to-transaction-validator.ts
@@ -6,11 +6,11 @@ import type { HttpFilterExpression } from '@thymian/http-filter';
 import type { HttpTestCaseTransactionValidationFn } from '../../operators/index.js';
 
 export function compileResponseScopedExpressionToTransactionValidationFn(
-  expression: HttpFilterExpression
+  expression: HttpFilterExpression,
 ): HttpTestCaseTransactionValidationFn {
   if (expression.kind === 'request') {
     throw new Error(
-      'Cannot used an request-based HTTP filter in a response-based context.'
+      'Cannot used an request-based HTTP filter in a response-based context.',
     );
   }
 
@@ -19,7 +19,7 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
       return (transaction) =>
         assert.strictEqual(
           transaction.response?.headers['content-type'],
-          expression.mediaType
+          expression.mediaType,
         );
     case 'responseTrailer':
       if (typeof expression.trailer === 'undefined') return () => true;
@@ -28,7 +28,7 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
         if (expression.value) {
           assert.strictEqual(
             transaction.response?.trailers[expression.trailer!],
-            expression.value
+            expression.value,
           );
         } else {
           assert.ok(transaction.response?.trailers[expression.trailer!]);
@@ -49,8 +49,8 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
           equalsIgnoreCase(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expression.header!,
-            ...Object.keys(transaction.response?.headers ?? {})
-          )
+            ...Object.keys(transaction.response?.headers ?? {}),
+          ),
         );
     }
     case 'statusCodeRange':
@@ -64,28 +64,28 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
       return (transaction) =>
         expression.filters.every((expr) =>
           compileResponseScopedExpressionToTransactionValidationFn(expr)(
-            transaction
-          )
+            transaction,
+          ),
         );
     case 'or':
       return (transaction) =>
         expression.filters.some((expr) => {
           compileResponseScopedExpressionToTransactionValidationFn(expr)(
-            transaction
+            transaction,
           );
         });
     case 'xor':
       return (transaction) =>
         expression.filters.every((expr) =>
           compileResponseScopedExpressionToTransactionValidationFn(expr)(
-            transaction
-          )
+            transaction,
+          ),
         );
     case 'not':
       return (transaction) => {
         try {
           compileResponseScopedExpressionToTransactionValidationFn(
-            expression.filter
+            expression.filter,
           )(transaction);
         } catch {
           return;

--- a/libs/http-testing/src/test-builder/extract-value-from-response.ts
+++ b/libs/http-testing/src/test-builder/extract-value-from-response.ts
@@ -3,7 +3,7 @@ import type { ResponseFilterExpression } from '@thymian/http-filter';
 
 export function extractValueFromResponse(
   response: HttpResponse,
-  filter: ResponseFilterExpression
+  filter: ResponseFilterExpression,
 ): unknown {
   switch (filter.type) {
     case 'statusCode':

--- a/libs/http-testing/src/test-builder/override-request-template.ts
+++ b/libs/http-testing/src/test-builder/override-request-template.ts
@@ -4,7 +4,7 @@ import type { RequestFilterExpression } from '@thymian/http-filter';
 export function overrideTemplate(
   template: HttpRequestTemplate,
   toRequest: RequestFilterExpression,
-  value: unknown
+  value: unknown,
 ): HttpRequestTemplate {
   switch (toRequest.type) {
     case 'method':

--- a/libs/http-testing/src/test-builder/reply-step-builder.ts
+++ b/libs/http-testing/src/test-builder/reply-step-builder.ts
@@ -18,7 +18,7 @@ export class ReplyStepBuilder {
 
   set(
     toRequest: RequestFilterExpression,
-    fromResponse: ResponseFilterExpression | Constant
+    fromResponse: ResponseFilterExpression | Constant,
   ): ReplyStepBuilder {
     const operator = overrideRequestWithPrevious(
       (requestTemplate, previous) => {
@@ -38,7 +38,7 @@ export class ReplyStepBuilder {
         }
 
         throw new Error('No response found to override template.');
-      }
+      },
     );
 
     this.pipeline.push(operator);

--- a/libs/http-testing/src/test-builder/single-step-test-builder.ts
+++ b/libs/http-testing/src/test-builder/single-step-test-builder.ts
@@ -42,36 +42,37 @@ export interface RunRequests {
   tap(fn: () => void): RunRequests;
 
   run(
-    options?: RunOptions
+    options?: RunOptions,
   ): ExpectOrStep<[Required<HttpTestCaseStepTransaction>]>;
 }
 
 export interface ExpectOrStep<
-  Transactions extends Required<HttpTestCaseStepTransaction>[]
+  Transactions extends Required<HttpTestCaseStepTransaction>[],
 > {
   expectForTransactions(
     ...filters: HttpFilterExpression[]
   ): ExpectOrStep<Transactions>;
 
   replayStep(
-    step: (step: ReplyStepBuilder) => BuilderPipeline
+    step: (step: ReplyStepBuilder) => BuilderPipeline,
   ): ExpectOrStep<[...Transactions, Required<HttpTestCaseStepTransaction>]>;
 
   skipIf(
     expression: HttpFilterExpression,
-    message?: string
+    message?: string,
   ): ExpectOrStep<Transactions>;
 
   done(): HttpTestPipeline<Record<PropertyKey, unknown>>;
 
   transactions(
-    fn: (transactions: Transactions) => void
+    fn: (transactions: Transactions) => void,
   ): ExpectOrStep<Transactions>;
 }
 
 export class SingleStepTestBuilder<
-  Transactions extends Required<HttpTestCaseStepTransaction>[]
-> implements RunRequests, FilterTransactions, ExpectOrStep<Transactions>
+    Transactions extends Required<HttpTestCaseStepTransaction>[],
+  >
+  implements RunRequests, FilterTransactions, ExpectOrStep<Transactions>
 {
   protected readonly pipeline: BuilderPipeline = [];
 
@@ -82,11 +83,11 @@ export class SingleStepTestBuilder<
       filter<PipelineItem<ThymianHttpTransaction>>(({ current, ctx }) => {
         const filterFn = httpFilterToTransactionFilter(
           filterExpression,
-          ctx.format
+          ctx.format,
         );
         const responses = ctx.format.getNeighboursOfType(
           current.thymianReqId,
-          'http-response'
+          'http-response',
         );
 
         return filterFn(
@@ -94,9 +95,9 @@ export class SingleStepTestBuilder<
           current.thymianReqId,
           current.thymianRes,
           current.thymianResId,
-          responses
+          responses,
         );
-      })
+      }),
     );
 
     return this;
@@ -109,7 +110,7 @@ export class SingleStepTestBuilder<
 
   set(
     filter: RequestFilterExpression,
-    value: unknown
+    value: unknown,
   ): SingleStepTestBuilder<Transactions> {
     const operator: MonoTypeOperatorFunction<PipelineItem<HttpTestCase>> = map(
       ({ current, ctx }) => {
@@ -117,12 +118,12 @@ export class SingleStepTestBuilder<
           current.steps[0].transactions[0].requestTemplate = overrideTemplate(
             current.steps[0].transactions[0].requestTemplate,
             filter,
-            value
+            value,
           );
         }
 
         return { current, ctx };
-      }
+      },
     );
 
     this.#requestOverrides.push(operator);
@@ -132,7 +133,7 @@ export class SingleStepTestBuilder<
 
   skipIf(
     expression: HttpFilterExpression,
-    message?: string
+    message?: string,
   ): ExpectOrStep<Transactions> {
     const operator: MonoTypeOperatorFunction<PipelineItem<HttpTestCase>> = map(
       ({ current, ctx }) => {
@@ -154,7 +155,7 @@ export class SingleStepTestBuilder<
         }
 
         return { current, ctx };
-      }
+      },
     );
 
     this.pipeline.push(operator);
@@ -163,13 +164,13 @@ export class SingleStepTestBuilder<
   }
 
   run(
-    options: RunOptions = {}
+    options: RunOptions = {},
   ): SingleStepTestBuilder<[Required<HttpTestCaseStepTransaction>]> {
     this.pipeline.push(
       mapToTestCase(),
       generateRequests(options),
       ...this.#requestOverrides,
-      runRequests(options)
+      runRequests(options),
     );
 
     return this as unknown as SingleStepTestBuilder<
@@ -181,7 +182,7 @@ export class SingleStepTestBuilder<
     ...filters: HttpFilterExpression[]
   ): ExpectOrStep<Transactions> {
     const validate = compileResponseScopedExpressionToTransactionValidationFn(
-      and(...filters)
+      and(...filters),
     );
 
     const fn: MonoTypeOperatorFunction<PipelineItem<HttpTestCase>> =
@@ -197,12 +198,12 @@ export class SingleStepTestBuilder<
       transactions.pipe(
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
-        ...this.pipeline
+        ...this.pipeline,
       );
   }
 
   replayStep(
-    step: (step: ReplyStepBuilder) => BuilderPipeline
+    step: (step: ReplyStepBuilder) => BuilderPipeline,
   ): SingleStepTestBuilder<
     [...Transactions, Required<HttpTestCaseStepTransaction>]
   > {
@@ -211,9 +212,9 @@ export class SingleStepTestBuilder<
         step1.pipe(
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          ...step(new ReplyStepBuilder())
-        )
-      )
+          ...step(new ReplyStepBuilder()),
+        ),
+      ),
     );
 
     return this as unknown as SingleStepTestBuilder<
@@ -222,7 +223,7 @@ export class SingleStepTestBuilder<
   }
 
   transactions(
-    fn: (transactions: Transactions) => void
+    fn: (transactions: Transactions) => void,
   ): SingleStepTestBuilder<Transactions> {
     const operator: MonoTypeOperatorFunction<PipelineItem<HttpTestCase>> = map(
       ({ current, ctx }) => {
@@ -243,7 +244,7 @@ export class SingleStepTestBuilder<
         }
 
         return { current, ctx };
-      }
+      },
     );
 
     this.pipeline.push(operator);

--- a/libs/http-testing/src/testing-utils/index.ts
+++ b/libs/http-testing/src/testing-utils/index.ts
@@ -3,7 +3,7 @@ import type { Parameter } from '@thymian/core';
 import type { HttpTestContext, HttpTestHooks } from '../http-test/index.js';
 
 export const exampleRequestSampler: HttpTestContext['sampleRequest'] = async (
-  transaction
+  transaction,
 ) => {
   return {
     authorize: true,
@@ -14,14 +14,14 @@ export const exampleRequestSampler: HttpTestContext['sampleRequest'] = async (
     origin: `${transaction.thymianReq.protocol}://${transaction.thymianReq.host}:${transaction.thymianReq.port}`,
     path: transaction.thymianReq.path,
     pathParameters: generateExampleParameters(
-      transaction.thymianReq.pathParameters
+      transaction.thymianReq.pathParameters,
     ),
     query: generateExampleParameters(transaction.thymianReq.queryParameters),
   };
 };
 
 export function generateExampleParameters(
-  parameters: Record<string, Parameter>
+  parameters: Record<string, Parameter>,
 ): Record<string, unknown> {
   return Object.entries(parameters).reduce((acc, [name, param]) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -34,7 +34,7 @@ export function generateExampleParameters(
 
 export const identityHookRunner: HttpTestContext['runHook'] = async (
   name,
-  payload
+  payload,
 ) => {
   return {
     value: payload.value,

--- a/libs/http-testing/src/validate/validate-body.ts
+++ b/libs/http-testing/src/validate/validate-body.ts
@@ -6,7 +6,7 @@ import { ajv } from './ajv.js';
 
 export function validateJsonBody(
   body: string,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   try {
     const json = parse(body);
@@ -57,7 +57,7 @@ export function validateJsonBody(
 
 export function validateBodyForResponse(
   body: string | undefined,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   if (typeof body === 'undefined') {
     return [];

--- a/libs/http-testing/src/validate/validate-headers.ts
+++ b/libs/http-testing/src/validate/validate-headers.ts
@@ -39,7 +39,7 @@ const commonHeadersSet = new Set<string>(commonHttpHeaders);
 // checks if the response is missing required headers
 export function checkForMissingHeaders(
   headers: Record<string, string | string[] | undefined>,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   return Object.entries(response.headers).reduce((acc, [name, header]) => {
     const value = getHeader(headers, name);
@@ -58,13 +58,13 @@ export function checkForMissingHeaders(
 // Are there headers included in the response that are not in the description format?
 export function checkForAdditionalHeaders(
   headers: Record<string, string | string[] | undefined>,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   const failures = Object.keys(headers)
     .filter(
       (headerName) =>
         !Object.hasOwn(response.headers, headerName) &&
-        !commonHeadersSet.has(headerName)
+        !commonHeadersSet.has(headerName),
     )
     .map((headerName) => ({
       type: 'assertion-failure',
@@ -83,7 +83,7 @@ export function checkForAdditionalHeaders(
 
 export function validateExistingHeader(
   headers: Record<string, string | string[] | undefined>,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   return Object.entries(headers)
     .filter(([name]) => Object.hasOwn(response.headers, name))
@@ -118,7 +118,7 @@ export function validateExistingHeader(
 
 export function validateHeaders(
   headers: Record<string, string | string[] | undefined>,
-  response: ThymianHttpResponse
+  response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
   return [
     ...checkForMissingHeaders(headers, response),

--- a/libs/http-testing/src/validate/validate-response.ts
+++ b/libs/http-testing/src/validate/validate-response.ts
@@ -7,7 +7,7 @@ import { validateStatusCode } from './validate-status-code.js';
 
 export function validateResponse(
   response: ThymianHttpResponse,
-  actualResponse: HttpResponse
+  actualResponse: HttpResponse,
 ): { valid: boolean; results: HttpTestCaseResult[] } {
   const results = [
     validateStatusCode(response.statusCode, actualResponse.statusCode),

--- a/libs/http-testing/src/validate/validate-status-code.ts
+++ b/libs/http-testing/src/validate/validate-status-code.ts
@@ -2,7 +2,7 @@ import type { HttpTestCaseResult } from '../http-test/index.js';
 
 export function validateStatusCode(
   statusCode: number,
-  actualStatusCode: number
+  actualStatusCode: number,
 ): HttpTestCaseResult {
   if (statusCode !== actualStatusCode) {
     return {

--- a/libs/http-testing/test/http-test.test.ts
+++ b/libs/http-testing/test/http-test.test.ts
@@ -43,13 +43,13 @@ describe('httpTest - todo app', () => {
       transactions.pipe(
         filterHttpTransactions(
           { method: 'GET', path: '/projects/{id}' },
-          { statusCode: 200 }
+          { statusCode: 200 },
         ),
         mapToTestCase(),
         generateRequests(),
         runRequests(),
-        validateResponses()
-      )
+        validateResponses(),
+      ),
     );
 
     const r = await test(context);

--- a/libs/http-testing/test/serialize-parameter.test.ts
+++ b/libs/http-testing/test/serialize-parameter.test.ts
@@ -8,7 +8,7 @@ describe('serializePathParameter', () => {
     const serialized = serializePathParameter(
       'id',
       [2, 3, 5, 7],
-      new SerializationStyleBuilder('simple', false).build()
+      new SerializationStyleBuilder('simple', false).build(),
     );
 
     expect(serialized).toStrictEqual('2,3,5,7');

--- a/libs/http-testing/vitest.config.ts
+++ b/libs/http-testing/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
-    passWithNoTests: true
-  }
+    passWithNoTests: true,
+  },
 });

--- a/libs/rfc-9110-rules/eslint.config.mjs
+++ b/libs/rfc-9110-rules/eslint.config.mjs
@@ -9,8 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['vitest', '@thymian/test-utils']
-
+          ignoredDependencies: ['vitest', '@thymian/test-utils'],
         },
       ],
     },

--- a/libs/rfc-9110-rules/src/rules/methods/general-purpose-severs-must-support-get-and-head.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/general-purpose-severs-must-support-get-and-head.rule.ts
@@ -3,30 +3,30 @@ import { httpRule } from '@thymian/http-linter';
 import { singleTestCase } from '@thymian/http-testing';
 
 export default httpRule(
-  'rfc9110/general-purpose-severs-must-support-get-and-head'
+  'rfc9110/general-purpose-severs-must-support-get-and-head',
 )
   .severity('error')
   .type('test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-overview')
   .description(
-    'All general-purpose servers MUST support the methods GET and HEAD.'
+    'All general-purpose servers MUST support the methods GET and HEAD.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(or(method('get'), method('head')), statusCode(200)),
-      statusCode(501)
-    )
+      statusCode(501),
+    ),
   )
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()
         .forTransactionsWith(
-          and(or(method('get'), method('head')), statusCode(200))
+          and(or(method('get'), method('head')), statusCode(200)),
         )
         .run({ checkResponse: false })
         .expectForTransactions(not(statusCode(501)))
-        .done()
-    )
+        .done(),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/client-must-ignore-content-length-or-transfer-encoding-headers-in-response-to-connect.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/client-must-ignore-content-length-or-transfer-encoding-headers-in-response-to-connect.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-ignore-content-length-or-transfer-encoding-headers-in-response-to-connect'
+  'rfc9110/client-must-ignore-content-length-or-transfer-encoding-headers-in-response-to-connect',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'A client MUST ignore any Content-Length or Transfer-Encoding header fields received in a successful response to CONNECT.'
+    'A client MUST ignore any Content-Length or Transfer-Encoding header fields received in a successful response to CONNECT.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/client-must-send-port-number-for-connect-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/client-must-send-port-number-for-connect-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-send-port-number-for-connect-request'
+  'rfc9110/client-must-send-port-number-for-connect-request',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'A client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port.'
+    'A client MUST send the port number even if the CONNECT request is based on a URI reference that contains an authority component with an elided port.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/intermediary-must-attempt-to-send-outstanding-data-coming-from-closed-side-for-connect-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/intermediary-must-attempt-to-send-outstanding-data-coming-from-closed-side-for-connect-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/intermediary-must-attempt-to-send-outstanding-data-coming-from-closed-side-for-connect-request'
+  'rfc9110/intermediary-must-attempt-to-send-outstanding-data-coming-from-closed-side-for-connect-request',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'A tunnel is closed when a tunnel intermediary detects that either side has closed its connection: the intermediary MUST attempt to send any outstanding data that came from the closed side to the other side, close both connections, and then discard any remaining data left undelivered.'
+    'A tunnel is closed when a tunnel intermediary detects that either side has closed its connection: the intermediary MUST attempt to send any outstanding data that came from the closed side to the other side, close both connections, and then discard any remaining data left undelivered.',
   )
   .appliesTo('intermediary')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/origin-sever-may-accept-connect-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/origin-sever-may-accept-connect-request.rule.ts
@@ -6,10 +6,10 @@ export default httpRule('rfc9110/origin-sever-may-accept-connect-request')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'An origin server MAY accept a CONNECT request, but most origin servers do not implement CONNECT'
+    'An origin server MAY accept a CONNECT request, but most origin servers do not implement CONNECT',
   )
   .appliesTo('origin server')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(method('CONNECT'), statusCode(501))
+    ctx.validateCommonHttpTransactions(method('CONNECT'), statusCode(501)),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request.rule.ts
@@ -8,19 +8,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request'
+  'rfc9110/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request',
 )
   .severity('error')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'A server MUST NOT send any Transfer-Encoding or Content-Length header fields in a 2xx (Successful) response to CONNECT.'
+    'A server MUST NOT send any Transfer-Encoding or Content-Length header fields in a 2xx (Successful) response to CONNECT.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(method('CONNECT'), statusCodeRange(200, 299)),
-      or(responseHeader('transfer-encoding'), responseHeader('content-length'))
-    )
+      or(responseHeader('transfer-encoding'), responseHeader('content-length')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/server-must-reject-connect-request-with-empty-or-invalid-port-number.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/connect/server-must-reject-connect-request-with-empty-or-invalid-port-number.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-reject-connect-request-with-empty-or-invalid-port-number'
+  'rfc9110/server-must-reject-connect-request-with-empty-or-invalid-port-number',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')
   .description(
-    'A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.'
+    'A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/client-should-not-generate-content-for-delete-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/client-should-not-generate-content-for-delete-request.rule.ts
@@ -2,16 +2,16 @@ import { hasRequestBody, method } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-generate-content-for-delete-request'
+  'rfc9110/client-should-not-generate-content-for-delete-request',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-delete')
   .description(
-    'A client SHOULD NOT generate content in a DELETE request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.'
+    'A client SHOULD NOT generate content in a DELETE request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.',
   )
   .appliesTo('client')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(method('DELETE'), hasRequestBody())
+    ctx.validateCommonHttpTransactions(method('DELETE'), hasRequestBody()),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/origin-server-should-not-rely-on-private-agreements-to-receive-content-in-delete-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/origin-server-should-not-rely-on-private-agreements-to-receive-content-in-delete-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-not-rely-on-private-agreements-to-receive-content-in-delete-request'
+  'rfc9110/origin-server-should-not-rely-on-private-agreements-to-receive-content-in-delete-request',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-delete')
   .description(
-    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.'
+    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/origin-server-should-send-correct-successful-status-code-to-delete-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/delete/origin-server-should-send-correct-successful-status-code-to-delete-request.rule.ts
@@ -9,19 +9,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-send-correct-successful-status-code-to-delete-request'
+  'rfc9110/origin-server-should-send-correct-successful-status-code-to-delete-request',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-delete')
   .description(
-    'If a DELETE method is successfully applied, the origin server SHOULD send 202 (Accepted), 204 (No Content) or 200 (OK).'
+    'If a DELETE method is successfully applied, the origin server SHOULD send 202 (Accepted), 204 (No Content) or 200 (OK).',
   )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(method('DELETE'), statusCodeRange(200, 299)),
-      not(or(statusCode(204), statusCode(202), statusCode(200)))
-    )
+      not(or(statusCode(204), statusCode(202), statusCode(200))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/cache-may-use-responses-to-get-for-satisfy-subsequent-get-and-head-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/cache-may-use-responses-to-get-for-satisfy-subsequent-get-and-head-requests.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/cache-may-use-responses-to-get-for-satisfy-subsequent-get-and-head-requests'
+  'rfc9110/cache-may-use-responses-to-get-for-satisfy-subsequent-get-and-head-requests',
 )
   .severity('hint')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'a cache MAY use it to satisfy subsequent GET and HEAD requests unless otherwise indicated by the Cache-Control header field.'
+    'a cache MAY use it to satisfy subsequent GET and HEAD requests unless otherwise indicated by the Cache-Control header field.',
   )
   .appliesTo('cache')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/client-should-not-generate-content-in-get-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/client-should-not-generate-content-in-get-request.rule.ts
@@ -2,17 +2,17 @@ import { and, hasRequestBody, method } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-generate-content-in-get-request'
+  'rfc9110/client-should-not-generate-content-in-get-request',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. '
+    'A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. ',
   )
   .summary('A client SHOULD NOT generate content in a GET request.')
   .appliesTo('client')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(method('GET'), hasRequestBody()))
+    ctx.validateCommonHttpTransactions(and(method('GET'), hasRequestBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/origin-server-should-not-rely-on-private-agreements-for-get-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/get/origin-server-should-not-rely-on-private-agreements-for-get-requests.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-not-rely-on-private-agreements'
+  'rfc9110/origin-server-should-not-rely-on-private-agreements',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.'
+    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/cache-may-use-responses-to-head-for-satisfy-subsequent-head-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/cache-may-use-responses-to-head-for-satisfy-subsequent-head-requests.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/cache-may-use-responses-to-head-for-satisfy-subsequent-head-requests'
+  'rfc9110/cache-may-use-responses-to-head-for-satisfy-subsequent-head-requests',
 )
   .severity('hint')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'a cache MAY use it to satisfy subsequent GET and HEAD requests unless otherwise indicated by the Cache-Control header field.'
+    'a cache MAY use it to satisfy subsequent GET and HEAD requests unless otherwise indicated by the Cache-Control header field.',
   )
   .appliesTo('cache')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/client-should-not-generate-content-in-head-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/client-should-not-generate-content-in-head-request.rule.ts
@@ -2,17 +2,17 @@ import { and, hasRequestBody, method } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-generate-content-in-get-request'
+  'rfc9110/client-should-not-generate-content-in-get-request',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. '
+    'A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. ',
   )
   .summary('A client SHOULD NOT generate content in a HEAD request.')
   .appliesTo('client')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(method('HEAD'), hasRequestBody()))
+    ctx.validateCommonHttpTransactions(and(method('HEAD'), hasRequestBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/origin-server-should-not-rely-on-private-agreements-for-head-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/origin-server-should-not-rely-on-private-agreements-for-head-requests.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-not-rely-on-private-agreements-for-head-requests'
+  'rfc9110/origin-server-should-not-rely-on-private-agreements-for-head-requests',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-get')
   .description(
-    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.'
+    'An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-may-omit-header-fields-for-head-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-may-omit-header-fields-for-head-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-may-omit-header-fields-for-head-response'
+  'rfc9110/server-may-omit-header-fields-for-head-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-head')
   .description(
-    'A server MAY omit header fields for which a value is determined only while generating the content.'
+    'A server MAY omit header fields for which a value is determined only while generating the content.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-must-not-send-content-in-response-to-head.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-must-not-send-content-in-response-to-head.rule.ts
@@ -2,16 +2,16 @@ import { and, hasRequestBody, method } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-send-content-in-response-to-head'
+  'rfc9110/server-must-not-send-content-in-response-to-head',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-head')
   .description(
-    'The HEAD method is identical to GET except that the server MUST NOT send content in the response.'
+    'The HEAD method is identical to GET except that the server MUST NOT send content in the response.',
   )
   .appliesTo('server')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(method('HEAD'), hasRequestBody()))
+    ctx.validateCommonHttpTransactions(and(method('HEAD'), hasRequestBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-should-send-same-header-fields-in-response-to-head.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/head/server-should-send-same-header-fields-in-response-to-head.rule.ts
@@ -5,13 +5,13 @@ import { httpRule, type RuleViolation } from '@thymian/http-linter';
 import { arrayDifference, createList } from '../../../../utils.js';
 
 export default httpRule(
-  'rfc9110/server-should-send-same-header-fields-in-response-to-head'
+  'rfc9110/server-should-send-same-header-fields-in-response-to-head',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-head')
   .description(
-    'The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET.'
+    'The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET.',
   )
   .appliesTo('server')
   .rule((ctx) =>
@@ -20,11 +20,11 @@ export default httpRule(
       url(),
       (_, transactions) => {
         const getTransaction = transactions.find(([req]) =>
-          equalsIgnoreCase(req.method, 'get')
+          equalsIgnoreCase(req.method, 'get'),
         );
 
         const headTransaction = transactions.find(([req]) =>
-          equalsIgnoreCase(req.method, 'head')
+          equalsIgnoreCase(req.method, 'head'),
         );
 
         if (
@@ -38,7 +38,7 @@ export default httpRule(
 
         const difference = arrayDifference(
           getTransaction[1].headers,
-          headTransaction[1].headers
+          headTransaction[1].headers,
         );
 
         if (difference.length === 0) {
@@ -51,10 +51,10 @@ export default httpRule(
             elementType: 'node',
           },
           message: `Response to HEAD request is missing headers: ${createList(
-            difference
+            difference,
           )}`,
         } satisfies RuleViolation;
-      }
-    )
+      },
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/client-may-send-max-forwards-header-in-option-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/client-may-send-max-forwards-header-in-option-request.rule.ts
@@ -2,19 +2,19 @@ import { method, not, requestHeader } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-send-max-forwards-header-in-option-request'
+  'rfc9110/client-may-send-max-forwards-header-in-option-request',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-options')
   .description(
-    'A client MAY send a Max-Forwards header field in an OPTIONS request to target a specific recipient in the request chain.'
+    'A client MAY send a Max-Forwards header field in an OPTIONS request to target a specific recipient in the request chain.',
   )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       method('OPTIONS'),
-      not(requestHeader('max-forwards'))
-    )
+      not(requestHeader('max-forwards')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/client-must-send-content-type-header-for-content-in-options-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/client-must-send-content-type-header-for-content-in-options-request.rule.ts
@@ -8,19 +8,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-send-content-type-header-for-content-in-options-request'
+  'rfc9110/client-must-send-content-type-header-for-content-in-options-request',
 )
   .severity('error')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-options')
   .description(
-    'A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.'
+    'A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.',
   )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(method('OPTIONS'), hasRequestBody()),
-      not(requestHeader('content-type'))
-    )
+      not(requestHeader('content-type')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/proxy-must-not-generate-new-max-forwards-header.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/proxy-must-not-generate-new-max-forwards-header.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/proxy-must-not-generate-new-max-forwards-header'
+  'rfc9110/proxy-must-not-generate-new-max-forwards-header',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-options')
   .description(
-    'A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.'
+    'A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.',
   )
   .appliesTo('proxy')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/options/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request.rule.ts
@@ -11,19 +11,19 @@ import { httpRule } from '@thymian/http-linter';
 const headerNames = ['allow'];
 
 export default httpRule(
-  'rfc9110/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request'
+  'rfc9110/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-options')
   .description(
-    'A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.'
+    'A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(method('OPTIONS'), successfulStatusCode()),
-      not(or(...headerNames.map((name) => responseHeader(name))))
-    )
+      not(or(...headerNames.map((name) => responseHeader(name)))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/post/origin-server-may-redirect-for-existing-resource-for-201-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/post/origin-server-may-redirect-for-existing-resource-for-201-response.rule.ts
@@ -2,16 +2,18 @@ import { and, method, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-may-redirect-for-existing-resource-for-201-response'
+  'rfc9110/origin-server-may-redirect-for-existing-resource-for-201-response',
 )
   .severity('hint')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-post')
   .description(
-    "If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field."
+    "If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field.",
   )
   .appliesTo('origin server')
   .rule((context) =>
-    context.validateCommonHttpTransactions(and(method('POST'), statusCode(201)))
+    context.validateCommonHttpTransactions(
+      and(method('POST'), statusCode(201)),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/post/origin-server-should-send-location-header-for-201-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/post/origin-server-should-send-location-header-for-201-response.rule.ts
@@ -8,22 +8,22 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-send-location-header-for-201-response'
+  'rfc9110/origin-server-should-send-location-header-for-201-response',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-post')
   .summary(
-    'Origin server should send 201 (Created) response containing a Location header for the primary created resource.'
+    'Origin server should send 201 (Created) response containing a Location header for the primary created resource.',
   )
   .description(
-    'If one or more resources has been created on the origin server as a result of successfully processing a POST request, the origin server SHOULD send a 201 (Created) response containing a Location header field that provides an identifier for the primary resource created and a representation that describes the status of the request while referring to the new resource(s).'
+    'If one or more resources has been created on the origin server as a result of successfully processing a POST request, the origin server SHOULD send a 201 (Created) response containing a Location header field that provides an identifier for the primary resource created and a representation that describes the status of the request while referring to the new resource(s).',
   )
   .appliesTo('origin server')
   .rule((context) =>
     context.validateCommonHttpTransactions(
       and(method('POST'), statusCode(201)),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-not-sent-validator-field-in-response-to-put-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-not-sent-validator-field-in-response-to-put-request.rule.ts
@@ -8,19 +8,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-must-not-sent-validator-field-in-response-to-put-request'
+  'rfc9110/origin-server-must-not-sent-validator-field-in-response-to-put-request',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    "An origin server MUST NOT send a validator field, such as an ETag or Last-Modified field, in a successful response to PUT unless the request's representation data was saved without any transformation applied to the content (i.e., the resource's new representation data is identical to the content received in the PUT request) and the validator field value reflects the new representation."
+    "An origin server MUST NOT send a validator field, such as an ETag or Last-Modified field, in a successful response to PUT unless the request's representation data was saved without any transformation applied to the content (i.e., the resource's new representation data is identical to the content received in the PUT request) and the validator field value reflects the new representation.",
   )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(statusCodeRange(200, 299), method('PUT')),
-      or(responseHeader('etag'), responseHeader('last-modified'))
-    )
+      or(responseHeader('etag'), responseHeader('last-modified')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-respond-with-correct-response-code-for-put-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-respond-with-correct-response-code-for-put-request.rule.ts
@@ -9,22 +9,22 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-must-respond-with-correct-response-code-for-put-request'
+  'rfc9110/origin-server-must-respond-with-correct-response-code-for-put-request',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .summary(
-    'Origin server MUST sending a 200 (OK), 201 (Created) or 204 (No Content) response, depending on whether a resource was created or updated.'
+    'Origin server MUST sending a 200 (OK), 201 (Created) or 204 (No Content) response, depending on whether a resource was created or updated.',
   )
   .description(
-    'If the target resource does not have a current representation and the PUT successfully creates one, then the origin server MUST inform the user agent by sending a 201 (Created) response. If the target resource does have a current representation and that representation is successfully modified in accordance with the state of the enclosed representation, then the origin server MUST send either a 200 (OK) or a 204 (No Content) response to indicate successful completion of the request.'
+    'If the target resource does not have a current representation and the PUT successfully creates one, then the origin server MUST inform the user agent by sending a 201 (Created) response. If the target resource does have a current representation and that representation is successfully modified in accordance with the state of the enclosed representation, then the origin server MUST send either a 200 (OK) or a 204 (No Content) response to indicate successful completion of the request.',
   )
   .appliesTo('origin server')
   .rule((context) =>
     context.validateCommonHttpTransactions(
       and(method('PUT'), statusCodeRange(200, 299)),
-      not(or(statusCode(200), statusCode(201), statusCode(204)))
-    )
+      not(or(statusCode(200), statusCode(201), statusCode(204))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-send-3xx-response-if-state-change-should-be-applied-to-other-resource.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-must-send-3xx-response-if-state-change-should-be-applied-to-other-resource.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-must-send-3xx-response-if-state-change-should-be-applied-to-other-resource'
+  'rfc9110/origin-server-must-send-3xx-response-if-state-change-should-be-applied-to-other-resource',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'If the origin server will not make the requested PUT state change to the target resource and instead wishes to have it applied to a different resource, such as when the resource has been moved to a different URI, then the origin server MUST send an appropriate 3xx (Redirection) response.'
+    'If the origin server will not make the requested PUT state change to the target resource and instead wishes to have it applied to a different resource, such as when the resource has been moved to a different URI, then the origin server MUST send an appropriate 3xx (Redirection) response.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-ingore-unrecognized-header-and-trailer-fields-received-in-put-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-ingore-unrecognized-header-and-trailer-fields-received-in-put-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-ingore-unrecognized-header-and-trailer-fields-received-in-put-request'
+  'rfc9110/origin-server-should-ingore-unrecognized-header-and-trailer-fields-received-in-put-request',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'An origin server SHOULD ignore unrecognized header and trailer fields received in a PUT request (i.e., not save them as part of the resource state).'
+    'An origin server SHOULD ignore unrecognized header and trailer fields received in a PUT request (i.e., not save them as part of the resource state).',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-response-with-409-or-415-status-code-to-put-request-for-inconsistent-representation.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-response-with-409-or-415-status-code-to-put-request-for-inconsistent-representation.rule.ts
@@ -2,19 +2,19 @@ import { method, not, or, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-response-with-409-or-415-status-code-to-put-request-for-inconsistent-representation'
+  'rfc9110/origin-server-should-response-with-409-or-415-status-code-to-put-request-for-inconsistent-representation',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'When a PUT representation is inconsistent with the target resource, the origin server SHOULD either make them consistent, by transforming the representation or changing the resource configuration, or respond with an appropriate error message containing sufficient information to explain why the representation is unsuitable. The 409 (Conflict) or 415 (Unsupported Media Type) status codes are suggested, with the latter being specific to constraints on Content-Type values.'
+    'When a PUT representation is inconsistent with the target resource, the origin server SHOULD either make them consistent, by transforming the representation or changing the resource configuration, or respond with an appropriate error message containing sufficient information to explain why the representation is unsuitable. The 409 (Conflict) or 415 (Unsupported Media Type) status codes are suggested, with the latter being specific to constraints on Content-Type values.',
   )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       method('PUT'),
-      not(or(statusCode(409), statusCode(415)))
-    )
+      not(or(statusCode(409), statusCode(415))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-verify-constraints-for-target-resource-for-put-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-should-verify-constraints-for-target-resource-for-put-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-verify-constraints-for-target-resource-for-put-request'
+  'rfc9110/origin-server-should-verify-constraints-for-target-resource-for-put-request',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'An origin server SHOULD verify that the PUT representation is consistent with its configured constraints for the target resource.'
+    'An origin server SHOULD verify that the PUT representation is consistent with its configured constraints for the target resource.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-that-selects-uri-for-client-should-use-post-instead-of-put.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/origin-server-that-selects-uri-for-client-should-use-post-instead-of-put.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/service-that-selects-uri-for-client-should-use-post-instead-of-put'
+  'rfc9110/service-that-selects-uri-for-client-should-use-post-instead-of-put',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'A service that selects a proper URI on behalf of the client, after receiving a state-changing request, SHOULD be implemented using the POST method rather than PUT.'
+    'A service that selects a proper URI on behalf of the client, after receiving a state-changing request, SHOULD be implemented using the POST method rather than PUT.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/user-agent-may-make-own-decision-to-redirect-request-for-3xx-response-to-put-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/put/user-agent-may-make-own-decision-to-redirect-request-for-3xx-response-to-put-request.rule.ts
@@ -2,17 +2,17 @@ import { and, method, statusCodeRange } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-make-own-decision-to-redirect-request-for-3xx-response-to-put-request'
+  'rfc9110/user-agent-may-make-own-decision-to-redirect-request-for-3xx-response-to-put-request',
 )
   .severity('hint')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-put')
   .description(
-    'The user agent MAY then make its own decision regarding whether or not to redirect the request.'
+    'The user agent MAY then make its own decision regarding whether or not to redirect the request.',
   )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
-      and(method('PUT'), statusCodeRange(300, 399))
-    )
+      and(method('PUT'), statusCodeRange(300, 399)),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/client-must-not-generate-fields-containing-sensitive-data-in-trace-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/client-must-not-generate-fields-containing-sensitive-data-in-trace-request.rule.ts
@@ -5,19 +5,19 @@ import { httpRule } from '@thymian/http-linter';
 const sensitiveHeaders = ['Authorization', 'Proxy-Authorization', 'X-API-Key'];
 
 export default httpRule(
-  'rfc9110/client-must-not-generate-fields-containing-sensitive-data-in-trace-request'
+  'rfc9110/client-must-not-generate-fields-containing-sensitive-data-in-trace-request',
 )
   .severity('error')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-trace')
   .description(
-    'A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.'
+    'A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.',
   )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       method('TRACE'),
-      or(...sensitiveHeaders.map((header) => requestHeader(header)))
-    )
+      or(...sensitiveHeaders.map((header) => requestHeader(header))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/client-must-not-send-content-in-trace-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/client-must-not-send-content-in-trace-request.rule.ts
@@ -8,6 +8,6 @@ export default httpRule('rfc9110/client-must-not-send-content-in-trace-request')
   .description('A client MUST NOT send content in a TRACE request.')
   .appliesTo('client')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(method('TRACE'), hasRequestBody())
+    ctx.validateCommonHttpTransactions(method('TRACE'), hasRequestBody()),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/final-recipient-of-trace-request-should-reflect-received-message.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/final-recipient-of-trace-request-should-reflect-received-message.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/final-recipient-of-trace-request-should-reflect-received-message'
+  'rfc9110/final-recipient-of-trace-request-should-reflect-received-message',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-trace')
   .description(
-    'The final recipient of the request SHOULD reflect the message received, excluding some fields described below, back to the client as the content of a 200 (OK) response.'
+    'The final recipient of the request SHOULD reflect the message received, excluding some fields described below, back to the client as the content of a 200 (OK) response.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-definitions/trace/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace'
+  'rfc9110/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-trace')
   .description(
-    'The final recipient of the request SHOULD exclude any request fields that are likely to contain sensitive data when that recipient generates the response content.'
+    'The final recipient of the request SHOULD exclude any request fields that are likely to contain sensitive data when that recipient generates the response content.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-properties/client-should-not-automatically-retry-a-failed-automatic-retry.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-properties/client-should-not-automatically-retry-a-failed-automatic-retry.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-automatically-retry-a-failed-automatic-retry'
+  'rfc9110/client-should-not-automatically-retry-a-failed-automatic-retry',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods')
   .description(
-    'A client SHOULD NOT automatically retry a failed automatic retry.'
+    'A client SHOULD NOT automatically retry a failed automatic retry.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-properties/client-should-not-automatically-retry-request-with-non-idempotent-method.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-properties/client-should-not-automatically-retry-request-with-non-idempotent-method.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-automatically-retry-request-with-non-idempotent-method'
+  'rfc9110/client-should-not-automatically-retry-request-with-non-idempotent-method',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods')
   .description(
-    'A client SHOULD NOT automatically retry a request with a non-idempotent method unless it has some means to know that the request semantics are actually idempotent, regardless of the method, or some means to detect that the original request was never applied.'
+    'A client SHOULD NOT automatically retry a request with a non-idempotent method unless it has some means to know that the request semantics are actually idempotent, regardless of the method, or some means to detect that the original request was never applied.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-properties/origin-server-must-disable-safe-methods-for-unsafe-resources.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-properties/origin-server-must-disable-safe-methods-for-unsafe-resources.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-must-disable-safe-methods-for-unsafe-resources'
+  'rfc9110/origin-server-must-disable-safe-methods-for-unsafe-resources',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-safe-methods')
   .summary(
-    'If the purpose of such a resource is to perform an unsafe action, then the resource owner MUST disable or disallow that action when it is accessed using a safe request method.'
+    'If the purpose of such a resource is to perform an unsafe action, then the resource owner MUST disable or disallow that action when it is accessed using a safe request method.',
   )
   .description(
-    'When a resource is constructed such that parameters within the target URI have the effect of selecting an action, it is the resource owner\'s responsibility to ensure that the action is consistent with the request method semantics. For example, it is common for Web-based content editing software to use actions within query parameters, such as "page?do=delete". If the purpose of such a resource is to perform an unsafe action, then the resource owner MUST disable or disallow that action when it is accessed using a safe request method.'
+    'When a resource is constructed such that parameters within the target URI have the effect of selecting an action, it is the resource owner\'s responsibility to ensure that the action is consistent with the request method semantics. For example, it is common for Web-based content editing software to use actions within query parameters, such as "page?do=delete". If the purpose of such a resource is to perform an unsafe action, then the resource owner MUST disable or disallow that action when it is accessed using a safe request method.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/method-properties/proxy-must-not-automatically-retry-non-idempontent-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-properties/proxy-must-not-automatically-retry-non-idempontent-requests.rule.ts
@@ -1,7 +1,7 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/proxy-must-not-automatically-retry-non-idempontent-requests'
+  'rfc9110/proxy-must-not-automatically-retry-non-idempontent-requests',
 )
   .severity('error')
   .type('informational')

--- a/libs/rfc-9110-rules/src/rules/methods/method-properties/user-agent-distinguish-between-safe-and-unsafe-methods.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/method-properties/user-agent-distinguish-between-safe-and-unsafe-methods.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-distinguish-between-safe-and-unsafe-methods'
+  'rfc9110/user-agent-distinguish-between-safe-and-unsafe-methods',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-safe-methods')
   .description(
-    'A user agent SHOULD distinguish between safe and unsafe methods when presenting potential actions to a user, such that the user can be made aware of an unsafe action before it is requested.'
+    'A user agent SHOULD distinguish between safe and unsafe methods when presenting potential actions to a user, such that the user can be made aware of an unsafe action before it is requested.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/origin-server-should-send-405-response-for-unallowed-method.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/origin-server-should-send-405-response-for-unallowed-method.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-send-405-response-for-unallowed-method'
+  'rfc9110/origin-server-should-send-405-response-for-unallowed-method',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-overview')
   .description(
-    'An origin server that receives a request method that is recognized and implemented, but not allowed for the target resource, SHOULD respond with the 405 (Method Not Allowed) status code.'
+    'An origin server that receives a request method that is recognized and implemented, but not allowed for the target resource, SHOULD respond with the 405 (Method Not Allowed) status code.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/origin-server-should-send-501-response-for-unrecognized-method.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/origin-server-should-send-501-response-for-unrecognized-method.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-should-send-501-response-for-unrecognized-method'
+  'rfc9110/origin-server-should-send-501-response-for-unrecognized-method',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-overview')
   .description(
-    'An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.'
+    'An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.',
   )
   .appliesTo('origin server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/methods/other-methods-than-get-and-head-are-optional.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/methods/other-methods-than-get-and-head-are-optional.rule.ts
@@ -10,7 +10,7 @@ export default httpRule('rfc9110/other-methods-than-get-and-head-are-optional')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       not(or(method('GET'), method('HEAD'))),
-      statusCode(501)
-    )
+      statusCode(501),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/server-must-send-www-authenticate-header-for-401-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/server-must-send-www-authenticate-header-for-401-response.rule.ts
@@ -30,21 +30,21 @@ const optionSchema: JSONSchemaType<Options> = {
 };
 
 export default httpRule(
-  'rfc9110/server-must-send-www-authenticate-header-for-401-response'
+  'rfc9110/server-must-send-www-authenticate-header-for-401-response',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized')
   .options<Options>(optionSchema)
   .description(
-    'The server generating a 401 response MUST send a WWW-Authenticate header field containing at least one challenge applicable to the target resource.'
+    'The server generating a 401 response MUST send a WWW-Authenticate header field containing at least one challenge applicable to the target resource.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(401),
-      not(responseHeader('www-authenticate'))
-    )
+      not(responseHeader('www-authenticate')),
+    ),
   )
   .overrideTest((testContext, options) =>
     testContext.httpTest(
@@ -54,13 +54,13 @@ export default httpRule(
             not(method('HEAD')),
             or(
               and(authorization(), constant(options.checkAllSecured)),
-              responseWith(statusCode(401))
-            )
-          )
+              responseWith(statusCode(401)),
+            ),
+          ),
         )
         .run()
         .expectForTransactions(responseHeader('www-authenticate'))
-        .done()
-    )
+        .done(),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/user-agent-may-repeat-request-with-new-authorization-header.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/user-agent-may-repeat-request-with-new-authorization-header.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-repeat-request-with-new-authorization-header'
+  'rfc9110/user-agent-may-repeat-request-with-new-authorization-header',
 )
   .severity('hint')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized')
   .summary(
-    'The user agent MAY repeat the request with a new or replaced Authorization header field.'
+    'The user agent MAY repeat the request with a new or replaced Authorization header field.',
   )
   .description(
-    'If the request included authentication credentials, then the 401 response indicates that authorization has been refused for those credentials. The user agent MAY repeat the request with a new or replaced Authorization header field. '
+    'If the request included authentication credentials, then the 401 response indicates that authorization has been refused for those credentials. The user agent MAY repeat the request with a new or replaced Authorization header field. ',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/user-agent-should-present-error-representation-to-user.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/401/user-agent-should-present-error-representation-to-user.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-should-present-error-representation-to-user'
+  'rfc9110/user-agent-should-present-error-representation-to-user',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized')
   .description(
-    'If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.'
+    'If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/402/402-status-code-is-reserved.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/402/402-status-code-is-reserved.rule.ts
@@ -6,7 +6,7 @@ export default httpRule('rfc9110/402-status-code-is-reserved')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-402-payment-required')
   .description(
-    'The 402 (Payment Required) status code is reserved for future use.'
+    'The 402 (Payment Required) status code is reserved for future use.',
   )
   .appliesTo('server')
   .rule((ctx) => ctx.validateCommonHttpTransactions(statusCode(402)))

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/client-may-repeat-request-with-new-credentials-for-403-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/client-may-repeat-request-with-new-credentials-for-403-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-repeat-request-with-new-credentials-for-403-response'
+  'rfc9110/client-may-repeat-request-with-new-credentials-for-403-response',
 )
   .severity('hint')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden')
   .description(
-    'The client MAY repeat the request with new or different credentials.'
+    'The client MAY repeat the request with new or different credentials.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/client-should-not-automatically-repeat-request-for-403-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/client-should-not-automatically-repeat-request-for-403-response.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-not-automatically-repeat-request-for-403-response'
+  'rfc9110/client-should-not-automatically-repeat-request-for-403-response',
 )
   .severity('warn')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden')
   .summary(
-    'The client SHOULD NOT automatically repeat the request with the same credentials.'
+    'The client SHOULD NOT automatically repeat the request with the same credentials.',
   )
   .description(
-    'If authentication credentials were provided in the request, the server considers them insufficient to grant access. The client SHOULD NOT automatically repeat the request with the same credentials.'
+    'If authentication credentials were provided in the request, the server considers them insufficient to grant access. The client SHOULD NOT automatically repeat the request with the same credentials.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/origin-server-may-respond-with-404-instead-of-403.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/403/origin-server-may-respond-with-404-instead-of-403.rule.ts
@@ -2,13 +2,13 @@ import { statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-server-may-respond-with-404-instead-of-403'
+  'rfc9110/origin-server-may-respond-with-404-instead-of-403',
 )
   .severity('hint')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden')
   .description(
-    'An origin server that wishes to "hide" the current existence of a forbidden target resource MAY instead respond with a status code of 404 (Not Found).'
+    'An origin server that wishes to "hide" the current existence of a forbidden target resource MAY instead respond with a status code of 404 (Not Found).',
   )
   .appliesTo('origin server')
   .rule((ctx) => ctx.validateCommonHttpTransactions(statusCode(403)))

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/405/origin-sever-must-generate-allow-header-for-405-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/405/origin-sever-must-generate-allow-header-for-405-response.rule.ts
@@ -2,21 +2,21 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/origin-sever-must-generate-allow-header-for-405-response'
+  'rfc9110/origin-sever-must-generate-allow-header-for-405-response',
 )
   .severity('error')
   .type('static', 'analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-405-method-not-allowed'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-405-method-not-allowed',
   )
   .description(
-    "The origin server MUST generate an Allow header field in a 405 response containing a list of the target resource's currently supported methods."
+    "The origin server MUST generate an Allow header field in a 405 response containing a list of the target resource's currently supported methods.",
   )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(405),
-      not(responseHeader('allow'))
-    )
+      not(responseHeader('allow')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/406/server-should-generate-content-for-406-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/406/server-should-generate-content-for-406-response.rule.ts
@@ -2,16 +2,16 @@ import { hasResponseBody, not, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-content-for-406-response'
+  'rfc9110/server-should-generate-content-for-406-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable')
   .description(
-    'The server SHOULD generate content containing a list of available representation characteristics and corresponding resource identifiers from which the user or user agent can choose the one most appropriate.'
+    'The server SHOULD generate content containing a list of available representation characteristics and corresponding resource identifiers from which the user or user agent can choose the one most appropriate.',
   )
   .appliesTo('server')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(statusCode(406), not(hasResponseBody()))
+    ctx.validateCommonHttpTransactions(statusCode(406), not(hasResponseBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/406/user-agent-may-select-most-appropriate-choice-for-406-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/406/user-agent-may-select-most-appropriate-choice-for-406-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-select-most-appropriate-choice-for-406-response'
+  'rfc9110/user-agent-may-select-most-appropriate-choice-for-406-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable')
   .description(
-    'A user agent MAY automatically select the most appropriate choice from that list.'
+    'A user agent MAY automatically select the most appropriate choice from that list.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/407/client-may-repeat-request-with-new-proxy-authenticate-header-for-407-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/407/client-may-repeat-request-with-new-proxy-authenticate-header-for-407-response.rule.ts
@@ -1,15 +1,15 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-repeat-request-with-new-proxy-authenticate-header-for-407-response'
+  'rfc9110/client-may-repeat-request-with-new-proxy-authenticate-header-for-407-response',
 )
   .severity('hint')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re',
   )
   .description(
-    'The client MAY repeat the request with a new or replaced Proxy-Authorization header field.'
+    'The client MAY repeat the request with a new or replaced Proxy-Authorization header field.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/407/proxy-must-send-proxy-authenticate-header-for-407-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/407/proxy-must-send-proxy-authenticate-header-for-407-response.rule.ts
@@ -2,21 +2,21 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/proxy-must-send-proxy-authenticate-header-for-407-response'
+  'rfc9110/proxy-must-send-proxy-authenticate-header-for-407-response',
 )
   .severity('error')
   .type('static', 'analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re',
   )
   .description(
-    'The proxy MUST send a Proxy-Authenticate header field containing a challenge applicable to that proxy for the request.'
+    'The proxy MUST send a Proxy-Authenticate header field containing a challenge applicable to that proxy for the request.',
   )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(407),
-      not(responseHeader('proxy-authenticate'))
-    )
+      not(responseHeader('proxy-authenticate')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/408/client-may-repeat-request-for-408-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/408/client-may-repeat-request-for-408-response.rule.ts
@@ -5,7 +5,7 @@ export default httpRule('rfc9110/client-may-repeat-request-for-408-response')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout')
   .description(
-    'If the client has an outstanding request in transit, it MAY repeat that request.'
+    'If the client has an outstanding request in transit, it MAY repeat that request.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/409/server-should-generate-content-for-409-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/409/server-should-generate-content-for-409-response.rule.ts
@@ -2,16 +2,16 @@ import { hasResponseBody, not, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-content-for-409-response'
+  'rfc9110/server-should-generate-content-for-409-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict')
   .description(
-    'The server SHOULD generate content that includes enough information for a user to recognize the source of the conflict.'
+    'The server SHOULD generate content that includes enough information for a user to recognize the source of the conflict.',
   )
   .appliesTo('server')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(statusCode(409), not(hasResponseBody()))
+    ctx.validateCommonHttpTransactions(statusCode(409), not(hasResponseBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/411/client-may-repeat-request-with-valid-content-length-header-for-411-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/411/client-may-repeat-request-with-valid-content-length-header-for-411-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-repeat-request-with-valid-content-length-header-for-411-response'
+  'rfc9110/client-may-repeat-request-with-valid-content-length-header-for-411-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-411-length-required')
   .description(
-    'The client MAY repeat the request if it adds a valid Content-Length header field containing the length of the request content.'
+    'The client MAY repeat the request if it adds a valid Content-Length header field containing the length of the request content.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/client-may-retry-after-given-time-for-413-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/client-may-retry-after-given-time-for-413-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-retry-after-given-time-for-413-response'
+  'rfc9110/client-may-retry-after-given-time-for-413-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large')
   .description(
-    'If the condition is temporary, the server should generate a Retry-After header field to indicate that it is temporary and after what time the client MAY try again.'
+    'If the condition is temporary, the server should generate a Retry-After header field to indicate that it is temporary and after what time the client MAY try again.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-may-close-connection-for-413-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-may-close-connection-for-413-response.rule.ts
@@ -5,7 +5,7 @@ export default httpRule('rfc9110/server-may-close-connection-for-413-response')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large')
   .description(
-    'The server MAY terminate the request, if the protocol version in use allows it; otherwise, the server MAY close the connection.'
+    'The server MAY terminate the request, if the protocol version in use allows it; otherwise, the server MAY close the connection.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-may-terminate-request-for-413-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-may-terminate-request-for-413-response.rule.ts
@@ -5,7 +5,7 @@ export default httpRule('rfc9110/server-may-terminate-request-for-413-response')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large')
   .description(
-    'The server MAY terminate the request, if the protocol version in use allows it.'
+    'The server MAY terminate the request, if the protocol version in use allows it.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-should-generate-retry-after-header-for-413-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/413/server-should-generate-retry-after-header-for-413-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-retry-after-header-for-413-response'
+  'rfc9110/server-should-generate-retry-after-header-for-413-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large')
   .description(
-    'If the condition is temporary, the server SHOULD generate a Retry-After header field to indicate that it is temporary and after what time the client may try again.'
+    'If the condition is temporary, the server SHOULD generate a Retry-After header field to indicate that it is temporary and after what time the client may try again.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(413),
-      not(responseHeader('retry-after'))
-    )
+      not(responseHeader('retry-after')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/416/server-should-generate-content-range-header-for-416-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/416/server-should-generate-content-range-header-for-416-response.rule.ts
@@ -2,19 +2,21 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-content-range-header-for-416-response'
+  'rfc9110/server-should-generate-content-range-header-for-416-response',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable',
   )
   .description(
-    'A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation.'
+    'A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation.',
   )
   .appliesTo('server')
-  .rule(ctx => ctx.validateCommonHttpTransactions(
-    statusCode(416),
-    not(responseHeader('content-range'))
-  ))
+  .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(
+      statusCode(416),
+      not(responseHeader('content-range')),
+    ),
+  )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/421/client-may-retry-request-over-different-connection.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/421/client-may-retry-request-over-different-connection.rule.ts
@@ -1,15 +1,15 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-retry-request-over-different-connection'
+  'rfc9110/client-may-retry-request-over-different-connection',
 )
   .severity('hint')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request',
   )
   .description(
-    "A client that receives a 421 (Misdirected Request) response MAY retry the request, whether or not the request method is idempotent, over a different connection, such as a fresh connection specific to the target resource's origin, or via an alternative service."
+    "A client that receives a 421 (Misdirected Request) response MAY retry the request, whether or not the request method is idempotent, over a different connection, such as a fresh connection specific to the target resource's origin, or via an alternative service.",
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/421/proxy-must-not-send-421-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/421/proxy-must-not-send-421-response.rule.ts
@@ -5,7 +5,7 @@ export default httpRule('rfc9110/proxy-must-not-send-421-response')
   .severity('error')
   .type('analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request',
   )
   .description('A proxy MUST NOT generate a 421 response.')
   .appliesTo('proxy')

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/426/server-must-send-upgrade-header-for-426-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/426/server-must-send-upgrade-header-for-426-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-send-upgrade-header-for-426-response'
+  'rfc9110/server-must-send-upgrade-header-for-426-response',
 )
   .severity('error')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required')
   .description(
-    'The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s).'
+    'The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s).',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(426),
-      not(responseHeader('upgrade'))
-    )
+      not(responseHeader('upgrade')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/server-should-send-error-representation-for-4xx-responses.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/server-should-send-error-representation-for-4xx-responses.rule.ts
@@ -8,22 +8,22 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-send-error-representation-for-4xx-responses'
+  'rfc9110/server-should-send-error-representation-for-4xx-responses',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-client-error-4xx')
   .summary(
-    'The server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.'
+    'The server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.',
   )
   .description(
-    'The 4xx (Client Error) class of status code indicates that the client seems to have erred. Except when responding to a HEAD request, the server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.'
+    'The 4xx (Client Error) class of status code indicates that the client seems to have erred. Except when responding to a HEAD request, the server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(not(method('HEAD')), statusCodeRange(400, 499)),
-      not(hasResponseBody())
-    )
+      not(hasResponseBody()),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/user-agents-should-display-error-representation-to-user.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-error-4xx/user-agents-should-display-error-representation-to-user.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agents-should-display-error-representation-to-user'
+  'rfc9110/user-agents-should-display-error-representation-to-user',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-client-error-4xx')
   .description(
-    'User agents SHOULD display any included error representation to the user.'
+    'User agents SHOULD display any included error representation to the user.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-must-understand-class-of-any-status-code.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-must-understand-class-of-any-status-code.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-understand-class-of-any-status-code'
+  'rfc9110/client-must-understand-class-of-any-status-code',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes')
   .description(
-    'HTTP status codes are extensible. A client is not required to understand the meaning of all registered status codes, though such understanding is obviously desirable. However, a client MUST understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class.'
+    'HTTP status codes are extensible. A client is not required to understand the meaning of all registered status codes, though such understanding is obviously desirable. However, a client MUST understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class.',
   )
   .summary('Clients MUST understand the class of any status code.')
   .appliesTo('client')

--- a/libs/rfc-9110-rules/src/rules/status-codes/client-should-process-invalid-status-code-as-5xx.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/client-should-process-invalid-status-code-as-5xx.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-should-process-invalid-status-code-as-5xx'
+  'rfc9110/client-should-process-invalid-status-code-as-5xx',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes')
   .description(
-    'Values outside the range 100..599 are invalid. Implementations often use three-digit integer values outside of that range (i.e., 600..999) for internal communication of non-HTTP status (e.g., library errors). A client that receives a response with an invalid status code SHOULD process the response as if it had a 5xx (Server Error) status code'
+    'Values outside the range 100..599 are invalid. Implementations often use three-digit integer values outside of that range (i.e., 600..999) for internal communication of non-HTTP status (e.g., library errors). A client that receives a response with an invalid status code SHOULD process the response as if it had a 5xx (Server Error) status code',
   )
   .summary(
-    'Clients should process responses with an invalid status code as a 5xx (Server Error) status code.'
+    'Clients should process responses with an invalid status code as a 5xx (Server Error) status code.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/client-must-be-able-to-parse-multiple-1xx-responses.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/client-must-be-able-to-parse-multiple-1xx-responses.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-be-able-to-parse-multiple-1xx-responses'
+  'rfc9110/client-must-be-able-to-parse-multiple-1xx-responses',
 )
   .severity('error')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-informational-1xx')
   .description(
-    'A client MUST be able to parse one or more 1xx responses received prior to a final response, even if the client does not expect one.'
+    'A client MUST be able to parse one or more 1xx responses received prior to a final response, even if the client does not expect one.',
   )
   .summary(
-    'A client MUST be able to parse one or more 1xx responses received prior to a final response, even if the client does not expect one.'
+    'A client MUST be able to parse one or more 1xx responses received prior to a final response, even if the client does not expect one.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/proxy-must-forward-1xx-responses.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/proxy-must-forward-1xx-responses.rule.ts
@@ -5,10 +5,10 @@ export default httpRule('rfc9110/proxy-must-forward-1xx-responses')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-informational-1xx')
   .description(
-    'A proxy MUST forward 1xx responses unless the proxy itself requested the generation of the 1xx response. For example, if a proxy adds an "Expect: 100-continue" header field when it forwards a request, then it need not forward the corresponding 100 (Continue) response(s).'
+    'A proxy MUST forward 1xx responses unless the proxy itself requested the generation of the 1xx response. For example, if a proxy adds an "Expect: 100-continue" header field when it forwards a request, then it need not forward the corresponding 100 (Continue) response(s).',
   )
   .summary(
-    'A proxy MUST forward 1xx responses unless the proxy itself requested the generation of the 1xx response.'
+    'A proxy MUST forward 1xx responses unless the proxy itself requested the generation of the 1xx response.',
   )
   .appliesTo('proxy')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/server-must-generate-upgrade-header-field.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/server-must-generate-upgrade-header-field.rule.ts
@@ -4,13 +4,13 @@ export default httpRule('rfc9110/server-must-generate-upgrade-header-field')
   .severity('error')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols',
   )
   .description(
-    "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection. The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
+    "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection. The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.",
   )
   .summary(
-    'The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.'
+    'The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/server-must-not-send-1xx-response-to-1.0-client.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/informational-1xx/server-must-not-send-1xx-response-to-1.0-client.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-send-1xx-response-to-1.0-client'
+  'rfc9110/server-must-not-send-1xx-response-to-1.0-client',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-informational-1xx')
   .description(
-    'The 1xx (Informational) class of status code indicates an interim response for communicating connection status or request progress prior to completing the requested action and sending a final response. Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.'
+    'The 1xx (Informational) class of status code indicates an interim response for communicating connection status or request progress prior to completing the requested action and sending a final response. Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.',
   )
   .summary(
-    'Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.'
+    'Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/server-should-generate-content-for-300-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/server-should-generate-content-for-300-response.rule.ts
@@ -8,19 +8,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-content-for-300-response'
+  'rfc9110/server-should-generate-content-for-300-response',
 )
   .severity('warn')
   .type('analytics', 'static')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices')
   .description(
-    'For request methods other than HEAD, the server SHOULD generate content in the 300 response containing a list of representation metadata and URI reference(s) from which the user or user agent can choose the one most preferred.'
+    'For request methods other than HEAD, the server SHOULD generate content in the 300 response containing a list of representation metadata and URI reference(s) from which the user or user agent can choose the one most preferred.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(not(method('HEAD')), statusCode(300)),
-      not(hasResponseBody())
-    )
+      not(hasResponseBody()),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/server-should-generate-location-header-for-preferred-choice-for-300-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/server-should-generate-location-header-for-preferred-choice-for-300-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-location-header-for-preferred-choice-for-300-response'
+  'rfc9110/server-should-generate-location-header-for-preferred-choice-for-300-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices')
   .description(
-    "If the server has a preferred choice, the server SHOULD generate a Location header field containing a preferred choice's URI reference."
+    "If the server has a preferred choice, the server SHOULD generate a Location header field containing a preferred choice's URI reference.",
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(300),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/user-agent-may-select-redirection-from-content.rule-for-300-response.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/user-agent-may-select-redirection-from-content.rule-for-300-response.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-select-redirection-from-content'
+  'rfc9110/user-agent-may-select-redirection-from-content',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices')
   .description(
-    'The user agent MAY make a selection from that list automatically if it understands the provided media type.'
+    'The user agent MAY make a selection from that list automatically if it understands the provided media type.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/user-agent-may-use-location-field-for-automatic-redirect-for-300-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/300/user-agent-may-use-location-field-for-automatic-redirect-for-300-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-use-location-field-for-automatic-redirect'
+  'rfc9110/user-agent-may-use-location-field-for-automatic-redirect',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices')
   .description(
-    'The user agent MAY use the Location field value for automatic redirection.'
+    'The user agent MAY use the Location field value for automatic redirection.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/server-should-generate-location-header-field-for-301-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/server-should-generate-location-header-field-for-301-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-location-header-field-for-301-response'
+  'rfc9110/server-should-generate-location-header-field-for-301-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently')
   .description(
-    'The server SHOULD generate a Location header field in the response containing a preferred URI reference for the new permanent URI.'
+    'The server SHOULD generate a Location header field in the response containing a preferred URI reference for the new permanent URI.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(301),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/user-agent-may-change-request-method-from-post-to-get-for-301-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/user-agent-may-change-request-method-from-post-to-get-for-301-response.rule.ts
@@ -2,19 +2,19 @@ import { and, method, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-change-request-method-from-post-to-get-for-301-response'
+  'rfc9110/user-agent-may-change-request-method-from-post-to-get-for-301-response',
 )
   .severity('hint')
   .type('static')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently')
   .summary(
-    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request.'
+    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request.',
   )
   .description(
-    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request. If this behavior is undesired, the 308 (Permanent Redirect) status code can be used instead.'
+    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request. If this behavior is undesired, the 308 (Permanent Redirect) status code can be used instead.',
   )
   .appliesTo('user-agent')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(method('POST'), statusCode(301)))
+    ctx.validateCommonHttpTransactions(and(method('POST'), statusCode(301))),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/user-agent-may-use-location-header-for-automatic-redirection-for-301-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/301/user-agent-may-use-location-header-for-automatic-redirection-for-301-response.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-301-response'
+  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-301-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently')
   .summary(
-    'The user agent MAY use the Location field value for automatic redirection.'
+    'The user agent MAY use the Location field value for automatic redirection.',
   )
   .description(
-    "The user agent MAY use the Location field value for automatic redirection. The server's response content usually contains a short hypertext note with a hyperlink to the new URI(s)."
+    "The user agent MAY use the Location field value for automatic redirection. The server's response content usually contains a short hypertext note with a hyperlink to the new URI(s).",
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/server-should-generate-location-header-for-302-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/server-should-generate-location-header-for-302-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-location-header-for-302-response'
+  'rfc9110/server-should-generate-location-header-for-302-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found')
   .description(
-    'The server SHOULD generate a Location header field in the response containing a URI reference for the different URI.'
+    'The server SHOULD generate a Location header field in the response containing a URI reference for the different URI.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(302),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/user-agent-may-change-request-method-from-post-to-get-for-302-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/user-agent-may-change-request-method-from-post-to-get-for-302-response.rule.ts
@@ -2,19 +2,19 @@ import { and, method, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-change-request-method-from-post-to-get-for-302-response'
+  'rfc9110/user-agent-may-change-request-method-from-post-to-get-for-302-response',
 )
   .severity('hint')
   .type('static')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found')
   .summary(
-    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request.'
+    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request.',
   )
   .description(
-    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request. If this behavior is undesired, the 307 (Temporary Redirect) status code can be used instead.'
+    'For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request. If this behavior is undesired, the 307 (Temporary Redirect) status code can be used instead.',
   )
   .appliesTo('user-agent')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(method('POST'), statusCode(302)))
+    ctx.validateCommonHttpTransactions(and(method('POST'), statusCode(302))),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/user-agent-may-use-location-header-for-automatic-redirection-for-302-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/302/user-agent-may-use-location-header-for-automatic-redirection-for-302-response.rule.ts
@@ -1,16 +1,16 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-302-response'
+  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-302-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found')
   .summary(
-    'The user agent MAY use the Location field value for automatic redirection.'
+    'The user agent MAY use the Location field value for automatic redirection.',
   )
   .description(
-    "The user agent MAY use the Location field value for automatic redirection. The server's response content usually contains a short hypertext note with a hyperlink to the different URI(s)."
+    "The user agent MAY use the Location field value for automatic redirection. The server's response content usually contains a short hypertext note with a hyperlink to the different URI(s).",
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/proxy-should-forward-304-response-to-outbound-client.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/proxy-should-forward-304-response-to-outbound-client.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/proxy-should-forward-304-response-to-outbound-client'
+  'rfc9110/proxy-should-forward-304-response-to-outbound-client',
 )
   .severity('warn')
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified')
   .description(
-    'If the conditional request originated with an outbound client, such as a user agent with its own cache sending a conditional GET to a shared proxy, then the proxy SHOULD forward the 304 response to that client.'
+    'If the conditional request originated with an outbound client, such as a user agent with its own cache sending a conditional GET to a shared proxy, then the proxy SHOULD forward the 304 response to that client.',
   )
   .appliesTo('proxy')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/sender-should-not-generate-additional-representation-metadata-for-304-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/sender-should-not-generate-additional-representation-metadata-for-304-response.rule.ts
@@ -22,18 +22,18 @@ import { requiredHeadersFor304 } from './server-must-generate-header-fields-for-
 
 export function checkHeaders(
   notModifiedHeaders: string[],
-  transactionId: string
+  transactionId: string,
 ): RuleViolation | undefined {
   const additionalHeaders = representationFields.filter(
     (header) =>
       !equalsIgnoreCase(header, ...requiredHeadersFor304) &&
-      equalsIgnoreCase(header, ...notModifiedHeaders)
+      equalsIgnoreCase(header, ...notModifiedHeaders),
   );
 
   if (additionalHeaders.length > 0) {
     return {
       message: `304 Not Modified response SHOULD NOT include additional headers ${createList(
-        additionalHeaders
+        additionalHeaders,
       )}.`,
       location: {
         elementType: 'edge',
@@ -46,16 +46,16 @@ export function checkHeaders(
 }
 
 export default httpRule(
-  'rfc9110/sender-should-not-generate-additional-representation-metadata-for-304-response'
+  'rfc9110/sender-should-not-generate-additional-representation-metadata-for-304-response',
 )
   .severity('warn')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified')
   .summary(
-    'A sender SHOULD NOT generate additional representation metadata for a 304 response.'
+    'A sender SHOULD NOT generate additional representation metadata for a 304 response.',
   )
   .description(
-    'Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).'
+    'Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).',
   )
   .appliesTo('server')
   .rule((ctx) =>
@@ -64,44 +64,44 @@ export default httpRule(
       (
         req: CommonHttpRequest,
         res: CommonHttpResponse,
-        transactionId: string
-      ) => checkHeaders(res.headers, transactionId)
-    )
+        transactionId: string,
+      ) => checkHeaders(res.headers, transactionId),
+    ),
   )
   .overrideTest((testContext) =>
     testContext.httpTest(
       singleTestCase()
         .forTransactionsWith(
-          and(or(method('GET'), method('HEAD')), statusCode(200))
+          and(or(method('GET'), method('HEAD')), statusCode(200)),
         )
         .run()
         .skipIf(
           not(or(responseHeader('etag'), responseHeader('last-modified'))),
-          '200 OK response does not include ETag or Last-Modified header and therefore no 304 Not Modified response can be triggered.'
+          '200 OK response does not include ETag or Last-Modified header and therefore no 304 Not Modified response can be triggered.',
         )
         .replayStep((step) =>
           step
             .set(requestHeader('if-none-match'), responseHeader('etag'))
             .set(
               requestHeader('if-modified-since'),
-              responseHeader('last-modified')
+              responseHeader('last-modified'),
             )
             .run({ expectStatusCode: 304 })
-            .done()
+            .done(),
         )
         .transactions((transactions) => {
           const [, notModifiedTransaction] = transactions;
 
           const violation = checkHeaders(
             Object.keys(notModifiedTransaction.response.headers ?? {}),
-            notModifiedTransaction.source.transactionId
+            notModifiedTransaction.source.transactionId,
           );
 
           if (violation) {
             testContext.reportViolation(violation);
           }
         })
-        .done()
-    )
+        .done(),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/server-must-generate-header-fields-for-304-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/304/server-must-generate-header-fields-for-304-response.rule.ts
@@ -28,18 +28,18 @@ export const requiredHeadersFor304 = [
 export function checkHeaders(
   okResponseHeaders: string[],
   notModifiedHeaders: string[],
-  transactionId: string
+  transactionId: string,
 ): RuleViolation | undefined {
   const missingHeaders = requiredHeadersFor304.filter(
     (header) =>
       equalsIgnoreCase(header, ...okResponseHeaders) &&
-      !equalsIgnoreCase(header, ...notModifiedHeaders)
+      !equalsIgnoreCase(header, ...notModifiedHeaders),
   );
 
   if (missingHeaders.length > 0) {
     return {
       message: `304 Not Modified response MUST include headers ${createList(
-        missingHeaders
+        missingHeaders,
       )} because these were included in the corresponding 200 OK response.`,
       location: {
         elementType: 'edge',
@@ -52,25 +52,25 @@ export function checkHeaders(
 }
 
 export default httpRule(
-  'rfc9110/server-must-generate-header-fields-for-304-response'
+  'rfc9110/server-must-generate-header-fields-for-304-response',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified')
   .description(
-    'The server generating a 304 response MUST generate any of the following header fields that would have been sent in a 200 (OK) response to the same request: Content-Location, Date, ETag, Vary, Cache-Control, Expires.'
+    'The server generating a 304 response MUST generate any of the following header fields that would have been sent in a 200 (OK) response to the same request: Content-Location, Date, ETag, Vary, Cache-Control, Expires.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateGroupedCommonHttpTransactions(
       and(
         or(method('GET'), method('HEAD')),
-        or(statusCode(304), statusCode(200))
+        or(statusCode(304), statusCode(200)),
       ),
       and(method(), origin(), path()),
       (_, transactions) => {
         const okResponse = transactions.find(
-          ([, res]) => res.statusCode === 200
+          ([, res]) => res.statusCode === 200,
         )?.[1];
         const [notModifiedRequest, notModifiedResponse] =
           transactions.find(([, res]) => res.statusCode === 304) ?? [];
@@ -79,42 +79,42 @@ export default httpRule(
           const transactionId = ctx.format.graph.findEdge(
             notModifiedRequest.id,
             notModifiedResponse.id,
-            (_, edge) => edge.type === 'http-transaction'
+            (_, edge) => edge.type === 'http-transaction',
           );
 
           if (transactionId) {
             return checkHeaders(
               okResponse.headers,
               notModifiedResponse.headers,
-              transactionId
+              transactionId,
             );
           }
         }
 
         return undefined;
-      }
-    )
+      },
+    ),
   )
   .overrideTest((testContext) =>
     testContext.httpTest(
       singleTestCase()
         .forTransactionsWith(
-          and(or(method('GET'), method('HEAD')), statusCode(200))
+          and(or(method('GET'), method('HEAD')), statusCode(200)),
         )
         .run()
         .skipIf(
           not(or(responseHeader('etag'), responseHeader('last-modified'))),
-          '200 OK response does not include ETag or Last-Modified header and therefore no 304 Not Modified response can be triggered.'
+          '200 OK response does not include ETag or Last-Modified header and therefore no 304 Not Modified response can be triggered.',
         )
         .replayStep((step) =>
           step
             .set(requestHeader('if-none-match'), responseHeader('etag'))
             .set(
               requestHeader('if-modified-since'),
-              responseHeader('last-modified')
+              responseHeader('last-modified'),
             )
             .run({ expectStatusCode: 304 })
-            .done()
+            .done(),
         )
         .transactions((transactions) => {
           const [okTransaction, notModifiedTransaction] = transactions;
@@ -122,14 +122,14 @@ export default httpRule(
           const violation = checkHeaders(
             Object.keys(okTransaction.response.headers ?? {}),
             Object.keys(notModifiedTransaction.response.headers ?? {}),
-            notModifiedTransaction.source.transactionId
+            notModifiedTransaction.source.transactionId,
           );
 
           if (violation) {
             testContext.reportViolation(violation);
           }
         })
-        .done()
-    )
+        .done(),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/305/status-code-305-is-deprecated.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/305/status-code-305-is-deprecated.rule.ts
@@ -6,9 +6,9 @@ export default httpRule('rfc9110/status-code-305-is-deprecated')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-305-use-proxy')
   .description(
-    'The 305 (Use Proxy) status code was defined in a previous version of this specification and is now deprecated.'
+    'The 305 (Use Proxy) status code was defined in a previous version of this specification and is now deprecated.',
   )
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(statusCode(305), statusCode(305))
+    ctx.validateCommonHttpTransactions(statusCode(305), statusCode(305)),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/306/status-code-306-is-reserved.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/306/status-code-306-is-reserved.rule.ts
@@ -6,9 +6,9 @@ export default httpRule('rfc9110/status-code-306-is-reserved')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-306-unused')
   .description(
-    'The 306 status code was defined in a previous version of this specification, is no longer used, and the code is reserved.'
+    'The 306 status code was defined in a previous version of this specification, is no longer used, and the code is reserved.',
   )
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(statusCode(306), statusCode(306))
+    ctx.validateCommonHttpTransactions(statusCode(306), statusCode(306)),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/server-should-generate-location-header-for-307-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/server-should-generate-location-header-for-307-response.rule.ts
@@ -2,21 +2,21 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-location-header-for-307-response'
+  'rfc9110/server-should-generate-location-header-for-307-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect',
   )
   .description(
-    'The server SHOULD generate a Location header field in the response containing a URI reference for the different URI.'
+    'The server SHOULD generate a Location header field in the response containing a URI reference for the different URI.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(307),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/user-agent-may-use-location-header-for-automatic-redirection.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/user-agent-may-use-location-header-for-automatic-redirection.rule.ts
@@ -1,15 +1,15 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection'
+  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection',
 )
   .severity('hint')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect',
   )
   .description(
-    'The user agent MAY use the Location field value for automatic redirection.'
+    'The user agent MAY use the Location field value for automatic redirection.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/user-agent-must-not-change-request-method-for-automatic-redirection-for-307-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/307/user-agent-must-not-change-request-method-for-automatic-redirection-for-307-response.rule.ts
@@ -1,15 +1,15 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-must-not-change-request-method-for-automatic-redirection-for-307-response'
+  'rfc9110/user-agent-must-not-change-request-method-for-automatic-redirection-for-307-response',
 )
   .severity('error')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect',
   )
   .description(
-    'The 307 (Temporary Redirect) status code indicates that the target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.'
+    'The 307 (Temporary Redirect) status code indicates that the target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/308/server-should-generate-location-header-for-308-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/308/server-should-generate-location-header-for-308-response.rule.ts
@@ -2,21 +2,21 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-location-header-for-308-response'
+  'rfc9110/server-should-generate-location-header-for-308-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect',
   )
   .description(
-    'The server SHOULD generate a Location header field in the response containing a preferred URI reference for the new permanent URI.'
+    'The server SHOULD generate a Location header field in the response containing a preferred URI reference for the new permanent URI.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(308),
-      not(responseHeader('location'))
-    )
+      not(responseHeader('location')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/308/user-agent-may-use-location-header-for-automatic-redirection-for-308-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/308/user-agent-may-use-location-header-for-automatic-redirection-for-308-response.rule.ts
@@ -1,15 +1,15 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-308-response'
+  'rfc9110/user-agent-may-use-location-header-for-automatic-redirection-for-308-response',
 )
   .severity('hint')
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect',
   )
   .description(
-    'The user agent MAY use the Location field value for automatic redirection.'
+    'The user agent MAY use the Location field value for automatic redirection.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/clients-should-detect-and-intervene-cyclical-redirections.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/clients-should-detect-and-intervene-cyclical-redirections.rule.ts
@@ -1,12 +1,12 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/clients-should-detect-and-intervene-cyclical-redirections'
+  'rfc9110/clients-should-detect-and-intervene-cyclical-redirections',
 )
   .severity('warn')
   .type('informational')
   .description(
-    'A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops).'
+    'A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops).',
   )
   .appliesTo('client')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx')

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/user-agent-may-redirect-to-location-header-uri-for-3xx-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/user-agent-may-redirect-to-location-header-uri-for-3xx-response.rule.ts
@@ -1,14 +1,14 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-may-redirect-to-location-header-uri-for-3xx-response'
+  'rfc9110/user-agent-may-redirect-to-location-header-uri-for-3xx-response',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx')
   .appliesTo('user-agent')
   .description(
-    'If a Location header field is provided, the user agent MAY automatically redirect its request to the URI referenced by the Location field value, even if the specific status code is not understood. Automatic redirection needs to be done with care for methods not known to be safe, as defined in Section 9.2.1, since the user might not wish to redirect an unsafe request.'
+    'If a Location header field is provided, the user agent MAY automatically redirect its request to the URI referenced by the Location field value, even if the specific status code is not understood. Automatic redirection needs to be done with care for methods not known to be safe, as defined in Section 9.2.1, since the user might not wish to redirect an unsafe request.',
   )
   .summary('Clients MAY use the location headers URI for redirection.')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/user-agent-shoud-resend-original-request-with-modifications-for-redirected-requests.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/redirection-3xx/user-agent-shoud-resend-original-request-with-modifications-for-redirected-requests.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-shoud-resend-original-request-with-modifications-for-redirected-requests'
+  'rfc9110/user-agent-shoud-resend-original-request-with-modifications-for-redirected-requests',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx')
   .description(
-    'When automatically following a redirected request, the user agent SHOULD resend the original request message with modifications (see RFC 9110).'
+    'When automatically following a redirected request, the user agent SHOULD resend the original request message with modifications (see RFC 9110).',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/503/server-may-send-retry-after-header-for-503-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/503/server-may-send-retry-after-header-for-503-response.rule.ts
@@ -2,19 +2,19 @@ import { not, responseHeader, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-may-send-retry-after-header-for-503-response'
+  'rfc9110/server-may-send-retry-after-header-for-503-response',
 )
   .severity('hint')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx')
   .description(
-    'The server MAY send a Retry-After header field to suggest an appropriate amount of time for the client to wait before retrying the request.'
+    'The server MAY send a Retry-After header field to suggest an appropriate amount of time for the client to wait before retrying the request.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCode(503),
-      not(responseHeader('retry-after'))
-    )
+      not(responseHeader('retry-after')),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/505/server-should-generate-representation-for-505-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/505/server-should-generate-representation-for-505-response.rule.ts
@@ -2,18 +2,18 @@ import { hasResponseBody, not, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-representation-for-505-response'
+  'rfc9110/server-should-generate-representation-for-505-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-505-http-version-not-suppor'
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-505-http-version-not-suppor',
   )
   .description(
-    'The server SHOULD generate a representation for the 505 response that describes why that version is not supported and what other protocols are supported by that server.'
+    'The server SHOULD generate a representation for the 505 response that describes why that version is not supported and what other protocols are supported by that server.',
   )
   .appliesTo('server')
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(statusCode(505), not(hasResponseBody()))
+    ctx.validateCommonHttpTransactions(statusCode(505), not(hasResponseBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/server-should-send-error-representation-for-5xx-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/server-should-send-error-representation-for-5xx-response.rule.ts
@@ -8,19 +8,19 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-send-error-representation-for-5xx-response'
+  'rfc9110/server-should-send-error-representation-for-5xx-response',
 )
   .severity('warn')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx')
   .description(
-    'Except when responding to a HEAD request, the server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.'
+    'Except when responding to a HEAD request, the server SHOULD send a representation containing an explanation of the error situation, and whether it is a temporary or permanent condition.',
   )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(statusCodeRange(500, 599), not(method('HEAD'))),
-      not(hasResponseBody())
-    )
+      not(hasResponseBody()),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/user-agent-should-display-representation-to-the-user-for-5xx-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/server-error-5xx/user-agent-should-display-representation-to-the-user-for-5xx-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/user-agent-should-display-representation-to-the-user-for-5xx-response'
+  'rfc9110/user-agent-should-display-representation-to-the-user-for-5xx-response',
 )
   .severity('warn')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx')
   .description(
-    'A user agent SHOULD display any included representation to the user.'
+    'A user agent SHOULD display any included representation to the user.',
   )
   .appliesTo('user-agent')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/200/origin-server-should-send-validator-fields-for-200-response.rule.test.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/200/origin-server-should-send-validator-fields-for-200-response.rule.test.ts
@@ -35,10 +35,10 @@ describe('server-must-generate-header-fields-for-206-response', () => {
           'server-must-generate-header-fields-for-206-response',
           context,
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {}
+          () => {},
         ),
         { mode: 'test' },
-        new NoopLogger()
+        new NoopLogger(),
       );
     });
   });

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/200/origin-server-should-send-validator-fields-for-200-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/200/origin-server-should-send-validator-fields-for-200-response.rule.ts
@@ -15,15 +15,15 @@ export default httpRule('rfc9110/server-should-send-validator-fields')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-200-ok')
   .description(
     `In 200 responses to GET or HEAD, an origin server SHOULD send any available validator fields for 
-    the selected representation, with both a strong entity tag and a Last-Modified date being preferred.`
+    the selected representation, with both a strong entity tag and a Last-Modified date being preferred.`,
   )
   .summary(
-    'Origin servers SHOULD send Etag or Last-Modified header in a 200 (OK) responses to GET or HEAD requests.'
+    'Origin servers SHOULD send Etag or Last-Modified header in a 200 (OK) responses to GET or HEAD requests.',
   )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(or(method('get'), method('head')), statusCode(200)),
-      not(or(responseHeader('etag'), responseHeader('last-modified')))
-    )
+      not(or(responseHeader('etag'), responseHeader('last-modified'))),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/205/server-must-not-generate-content-for-205-response.rule.test.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/205/server-must-not-generate-content-for-205-response.rule.test.ts
@@ -35,10 +35,10 @@ describe('server-must-not-generate-content-for-205-response', () => {
           'server-must-not-generate-content-for-205-response',
           context,
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {}
+          () => {},
         ),
         { mode: 'test' },
-        new NoopLogger()
+        new NoopLogger(),
       );
     });
   });

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/205/server-must-not-generate-content-for-205-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/205/server-must-not-generate-content-for-205-response.rule.ts
@@ -2,16 +2,16 @@ import { and, hasResponseBody, statusCode } from '@thymian/http-filter';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-generate-content-for-205-response'
+  'rfc9110/server-must-not-generate-content-for-205-response',
 )
   .severity('error')
   .type('test', 'static', 'analytics')
   .appliesTo('origin server')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-205-reset-content')
   .description(
-    `Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.`
+    `Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.`,
   )
   .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(and(statusCode(205), hasResponseBody()))
+    ctx.validateCommonHttpTransactions(and(statusCode(205), hasResponseBody())),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/client-must-inspect-206-response-content-type-and-range.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/client-must-inspect-206-response-content-type-and-range.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-generate-content-for-205-response'
+  'rfc9110/server-must-not-generate-content-for-205-response',
 )
   .severity('error')
   .type('informational')
   .appliesTo('client')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content')
   .description(
-    `A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.`
+    `A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.`,
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-may-combine-multiple-ranges-with-same-strong-validator-to-larger-range.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-may-combine-multiple-ranges-with-same-strong-validator-to-larger-range.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-may-combine-multiple-ranges-with-same-strong-validator-to-larger-range'
+  'rfc9110/client-may-combine-multiple-ranges-with-same-strong-validator-to-larger-range',
 )
   .severity('hint')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-combining-parts')
   .description(
-    'A client that has received multiple partial responses to GET requests on a target resource MAY combine those responses into a larger continuous range if they share the same strong validator.'
+    'A client that has received multiple partial responses to GET requests on a target resource MAY combine those responses into a larger continuous range if they share the same strong validator.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-must-process-combined-response-correct.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-must-process-combined-response-correct.ts
@@ -5,7 +5,7 @@ export default httpRule('rfc9110/client-must-process-combined-response-correct')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-combining-parts')
   .description(
-    'If the union consists of the entire range of the representation, then the client MUST process the combined response as if it were a complete 200 (OK) response, including a Content-Length header field that reflects the complete length. Otherwise, the client MUST process the set of continuous ranges as one of the following: an incomplete 200 (OK) response if the combined response is a prefix of the representation, a single 206 (Partial Content) response containing "multipart/byteranges" content, or multiple 206 (Partial Content) responses, each with one continuous range that is indicated by a Content-Range header field.'
+    'If the union consists of the entire range of the representation, then the client MUST process the combined response as if it were a complete 200 (OK) response, including a Content-Length header field that reflects the complete length. Otherwise, the client MUST process the set of continuous ranges as one of the following: an incomplete 200 (OK) response if the combined response is a prefix of the representation, a single 206 (Partial Content) response containing "multipart/byteranges" content, or multiple 206 (Partial Content) responses, each with one continuous range that is indicated by a Content-Range header field.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-must-use-other-header-fields-provided-in-new-for-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/combining-parts/client-must-use-other-header-fields-provided-in-new-for-206-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-use-other-header-fields-provided-in-new-for-206-response'
+  'rfc9110/client-must-use-other-header-fields-provided-in-new-for-206-response',
 )
   .severity('error')
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-combining-parts')
   .description(
-    'the client MUST use other header fields provided in the new response, aside from Content-Range, to replace all instances of the corresponding header fields in the stored response.'
+    'the client MUST use other header fields provided in the new response, aside from Content-Range, to replace all instances of the corresponding header fields in the stored response.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/client-must-inspect-content-range-header-in-multiple-parts-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/client-must-inspect-content-range-header-in-multiple-parts-206-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-inspect-content-range-header-in-multiple-parts-206-response'
+  'rfc9110/client-must-inspect-content-range-header-in-multiple-parts-206-response',
 )
   .severity('error')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'A client that receives a multipart response MUST inspect the Content-Range header field present in each body part in order to determine which range is contained in that body part; a client cannot rely on receiving the same ranges that it requested, nor the same order that it requested.'
+    'A client that receives a multipart response MUST inspect the Content-Range header field present in each body part in order to determine which range is contained in that body part; a client cannot rely on receiving the same ranges that it requested, nor the same order that it requested.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/client-must-not-generate-multiple-ranges-request-if-not-supported.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/client-must-not-generate-multiple-ranges-request-if-not-supported.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/client-must-not-generate-multiple-ranges-request-if-not-supported'
+  'rfc9110/client-must-not-generate-multiple-ranges-request-if-not-supported',
 )
   .severity('error')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'A client that cannot process a "multipart/byteranges" response MUST NOT generate a request that asks for multiple ranges.'
+    'A client that cannot process a "multipart/byteranges" response MUST NOT generate a request that asks for multiple ranges.',
   )
   .appliesTo('client')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-may-coalesce-overlapping-or-small-gapped-ranges.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-may-coalesce-overlapping-or-small-gapped-ranges.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-may-coalesce-overlapping-or-small-gapped-ranges'
+  'rfc9110/server-may-coalesce-overlapping-or-small-gapped-ranges',
 )
   .severity('hint')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'When multiple ranges are requested, a server MAY coalesce any of the ranges that overlap, or that are separated by a gap that is smaller than the overhead of sending multiple parts, regardless of the order in which the corresponding range-spec appeared in the received Range header field.'
+    'When multiple ranges are requested, a server MAY coalesce any of the ranges that overlap, or that are separated by a gap that is smaller than the overhead of sending multiple parts, regardless of the order in which the corresponding range-spec appeared in the received Range header field.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-may-generate-multiple-parts-response-with-single-body.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-may-generate-multiple-parts-response-with-single-body.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-may-generate-multiple-parts-response-with-single-body'
+  'rfc9110/server-may-generate-multiple-parts-response-with-single-body',
 )
   .severity('hint')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'A server MAY generate a "multipart/byteranges" response with only a single body part if multiple ranges were requested and only one range was found to be satisfiable or only one range remained after coalescing.'
+    'A server MAY generate a "multipart/byteranges" response with only a single body part if multiple ranges were requested and only one range was found to be satisfiable or only one range remained after coalescing.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-generate-content-range-header-in-corresponding-body-part-for-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-generate-content-range-header-in-corresponding-body-part-for-206-response.rule.ts
@@ -1,12 +1,12 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-generate-content-range-header-in-corresponding-body-part-for-206-response'
+  'rfc9110/server-must-generate-content-range-header-in-corresponding-body-part-for-206-response',
 )
   .severity('error')
   .type('informational')
   .description(
-    'Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.'
+    'Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.',
   )
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .appliesTo('server')

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-generate-multipart-byteranges-content-for-multi-part-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-generate-multipart-byteranges-content-for-multi-part-206-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-generate-multipart-byteranges-content-for-multi-part-206-response'
+  'rfc9110/server-must-generate-multipart-byteranges-content-for-multi-part-206-response',
 )
   .severity('error')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.'
+    'If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-not-generate-content-range-header-for-multi-part-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-not-generate-content-range-header-for-multi-part-206-response.rule.ts
@@ -8,13 +8,13 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-generate-content-range-header-for-multi-part-206-response'
+  'rfc9110/server-must-not-generate-content-range-header-for-multi-part-206-response',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).'
+    'To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).',
   )
   .appliesTo('server')
   .rule((ctx) =>
@@ -22,9 +22,9 @@ export default httpRule(
       and(
         method('GET'),
         statusCode(206),
-        responseMediaType('multipart/byteranges')
+        responseMediaType('multipart/byteranges'),
       ),
-      responseHeader('content-range')
-    )
+      responseHeader('content-range'),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-not-generate-multipart-response-to-a-single-part-request.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-must-not-generate-multipart-response-to-a-single-part-request.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-not-generate-multipart-response-to-a-single-part-request'
+  'rfc9110/server-must-not-generate-multipart-response-to-a-single-part-request',
 )
   .severity('error')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.'
+    'A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-should-generate-content-type-header-in-body-for-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-should-generate-content-type-header-in-body-for-206-response.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-should-generate-content-type-header-in-body-for-206-response'
+  'rfc9110/server-should-generate-content-type-header-in-body-for-206-response',
 )
   .severity('warn')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'If the selected representation would have had a Content-Type header field in a 200 (OK) response, the server SHOULD generate that same Content-Type header field in the header area of each body part.'
+    'If the selected representation would have had a Content-Type header field in a 200 (OK) response, the server SHOULD generate that same Content-Type header field in the header area of each body part.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-should-send-parts-in-order-of-range-header.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/multiple-parts/server-should-send-parts-in-order-of-range-header.rule.ts
@@ -1,13 +1,13 @@
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/ server-should-send-parts-in-order-of-range-header'
+  'rfc9110/ server-should-send-parts-in-order-of-range-header',
 )
   .severity('warn')
   .type('informational')
   .url('https://datatracker.ietf.org/doc/html/rfc9110#name-multiple-parts')
   .description(
-    'A server that generates a multipart response SHOULD send the parts in the same order that the corresponding range-spec appeared in the received Range header field, excluding those ranges that were deemed unsatisfiable or that were coalesced into other ranges.'
+    'A server that generates a multipart response SHOULD send the parts in the same order that the corresponding range-spec appeared in the received Range header field, excluding those ranges that were deemed unsatisfiable or that were coalesced into other ranges.',
   )
   .appliesTo('server')
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/sender-should-not-generate-additional-representation-header-fields-for-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/sender-should-not-generate-additional-representation-header-fields-for-206-response.rule.ts
@@ -33,33 +33,33 @@ export function checkHeaders(
   partialResponseHeaders: string[],
   partialRequestId: string,
   partialResponseId: string,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): RuleViolation | undefined {
   const requiredFields = requiredHeaders.filter((header) =>
-    equalsIgnoreCase(header, ...okResponseHeaders)
+    equalsIgnoreCase(header, ...okResponseHeaders),
   );
 
   const additionalRepresentationHeaders = partialResponseHeaders.filter(
     (header) =>
       !equalsIgnoreCase(header, ...requiredFields) &&
-      equalsIgnoreCase(header, ...representationHeaderFields)
+      equalsIgnoreCase(header, ...representationHeaderFields),
   );
 
   // The sender generated additional representation header
   if (additionalRepresentationHeaders.length > 0) {
     const representationHeaderFromOkResponse =
       representationHeaderFields.filter((header) =>
-        equalsIgnoreCase(header, ...okResponseHeaders)
+        equalsIgnoreCase(header, ...okResponseHeaders),
       );
 
     const representationHeaderFromPartialResponse =
       representationHeaderFields.filter((header) =>
-        equalsIgnoreCase(header, ...partialResponseHeaders)
+        equalsIgnoreCase(header, ...partialResponseHeaders),
       );
 
     const difference = arrayDifference(
       representationHeaderFromOkResponse,
-      representationHeaderFromPartialResponse
+      representationHeaderFromPartialResponse,
     );
     // but if the 206 response contains ALL representation header fields that are also contained in the 200 OK response, it is specification conform
     if (difference.length === 0) {
@@ -69,7 +69,7 @@ export function checkHeaders(
     const transactionEdge = format.graph.findEdge(
       partialRequestId,
       partialResponseId,
-      (_, attributes) => attributes.type === 'http-transaction'
+      (_, attributes) => attributes.type === 'http-transaction',
     );
 
     if (!transactionEdge) {
@@ -78,9 +78,9 @@ export function checkHeaders(
 
     return {
       message: `206 Partial Content response SHOULD NOT contain additional headers ${createList(
-        additionalRepresentationHeaders
+        additionalRepresentationHeaders,
       )} OR the 206 response MUST contain all representation headers, the 200 OK response also contains. Therefore the partial response is missing header(s): ${createList(
-        difference
+        difference,
       )}.`,
       location: {
         elementType: 'edge' as const,
@@ -93,17 +93,17 @@ export function checkHeaders(
 }
 
 export default httpRule(
-  'rfc9110/sender-should-not-generate-additional-representation-header-fields-for-206-response'
+  'rfc9110/sender-should-not-generate-additional-representation-header-fields-for-206-response',
 )
   // This rule covers 2 keywords from the specification. We therefore select the more strict keyword as the severity.
   .severity('error')
   .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content')
   .description(
-    'A sender that generates a 206 response to a request with an If-Range header field SHOULD NOT generate other representation header fields beyond those required because the client already has a prior response containing those header fields. Otherwise, a sender MUST generate all of the representation header fields that would have been sent in a 200 (OK) response to the same request.'
+    'A sender that generates a 206 response to a request with an If-Range header field SHOULD NOT generate other representation header fields beyond those required because the client already has a prior response containing those header fields. Otherwise, a sender MUST generate all of the representation header fields that would have been sent in a 200 (OK) response to the same request.',
   )
   .summary(
-    'A sender SHOULD NOT sent additional representation header fields or MUST generate all representation headers for a 206 Partial Content response.'
+    'A sender SHOULD NOT sent additional representation header fields or MUST generate all representation headers for a 206 Partial Content response.',
   )
   .rule((ctx) =>
     ctx.validateGroupedCommonHttpTransactions(
@@ -117,7 +117,7 @@ export default httpRule(
       and(method(), origin(), path()),
       (_, transactions) => {
         const okResponse = transactions.find(
-          ([, res]) => res.statusCode === 200
+          ([, res]) => res.statusCode === 200,
         )?.[1];
         const [partialRequest, partialResponse] =
           transactions.find(([, res]) => res.statusCode === 206) ?? [];
@@ -128,13 +128,13 @@ export default httpRule(
             partialResponse.headers,
             partialRequest.id,
             partialResponse.id,
-            ctx.format
+            ctx.format,
           );
         }
 
         return;
-      }
-    )
+      },
+    ),
   )
   // TODO: let's think about later, if we should include this test
   .overrideTest((testContext) =>
@@ -144,21 +144,21 @@ export default httpRule(
           and(
             requestHeader('if-range'),
             responseWith(statusCode(200)),
-            responseWith(statusCode(206))
-          )
+            responseWith(statusCode(206)),
+          ),
         )
         .run()
         .replayStep((step) =>
           step
             .set(requestHeader('if-range'), responseHeader('etag'))
             .run()
-            .done()
+            .done(),
         )
         .replayStep((step) =>
           step
             .set(requestHeader('if-range'), constant('"qupaya"'))
             .run({ expectStatusCode: 200 })
-            .done()
+            .done(),
         )
         .transactions((transactions) => {
           const [, partialTransactions, okTransaction] = transactions;
@@ -168,14 +168,14 @@ export default httpRule(
             Object.keys(partialTransactions.response.headers),
             partialTransactions.source.thymianReqId,
             partialTransactions.source.thymianResId,
-            testContext.format
+            testContext.format,
           );
 
           if (violation) {
             testContext.reportViolation(violation);
           }
         })
-        .done()
-    )
+        .done(),
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/server-must-generate-header-fields-for-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/server-must-generate-header-fields-for-206-response.rule.ts
@@ -20,7 +20,7 @@ export const requiredHeaders = [
 ];
 
 export default httpRule(
-  'rfc9110/server-must-generate-header-fields-for-206-response'
+  'rfc9110/server-must-generate-header-fields-for-206-response',
 )
   .severity('error')
   .type('static', 'test', 'analytics')
@@ -28,19 +28,19 @@ export default httpRule(
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content')
   .description(
     `A server that generates a 206 response MUST generate the following header fields, if the field would have been sent in a 200 (OK) response to the same request: ${requiredHeaders.join(
-      ', '
-    )}`
+      ', ',
+    )}`,
   )
   .rule((ctx) =>
     ctx.validateGroupedCommonHttpTransactions(
       or(
         and(statusCode(200), responseWith(statusCode(206))),
-        and(statusCode(206), responseWith(statusCode(200)))
+        and(statusCode(206), responseWith(statusCode(200))),
       ), // TODO: problem because we also check 200 response if there is no support for partial requests
       and(method(), origin(), path()),
       (_, transactions) => {
         const okResponse = transactions.find(
-          ([, res]) => res.statusCode === 200
+          ([, res]) => res.statusCode === 200,
         )?.[1];
         const [partialRequest, partialResponse] =
           transactions.find(([, res]) => res.statusCode === 206) ?? [];
@@ -49,14 +49,14 @@ export default httpRule(
           const missingHeaders = requiredHeaders.filter(
             (headerName) =>
               equalsIgnoreCase(headerName, ...okResponse.headers) !==
-              equalsIgnoreCase(headerName, ...partialResponse.headers)
+              equalsIgnoreCase(headerName, ...partialResponse.headers),
           );
 
           if (missingHeaders.length > 0) {
             const transactionEdge = ctx.format.graph.findEdge(
               partialRequest.id,
               partialResponse.id,
-              (id, attributes) => attributes.type === 'http-transaction'
+              (id, attributes) => attributes.type === 'http-transaction',
             );
 
             if (!transactionEdge) {
@@ -80,7 +80,7 @@ export default httpRule(
         }
 
         return;
-      }
-    )
+      },
+    ),
   )
   .done();

--- a/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/single-part/server-must-generate-content-range-header-for-single-part-206-response.rule.ts
+++ b/libs/rfc-9110-rules/src/rules/status-codes/successful-2xx/206/single-part/server-must-generate-content-range-header-for-single-part-206-response.rule.ts
@@ -9,13 +9,13 @@ import {
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule(
-  'rfc9110/server-must-generate-content-range-header-for-single-part-206-response'
+  'rfc9110/server-must-generate-content-range-header-for-single-part-206-response',
 )
   .severity('error')
   .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-single-part')
   .description(
-    'If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.'
+    'If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.',
   )
   .appliesTo('server')
   .rule((ctx) =>
@@ -23,8 +23,8 @@ export default httpRule(
       and(method('GET'), statusCode(206)),
       and(
         not(responseHeader('content-range')),
-        not(responseMediaType('multipart/byteranges'))
-      )
-    )
+        not(responseMediaType('multipart/byteranges')),
+      ),
+    ),
   )
   .done();

--- a/plugins/cli-reporter/eslint.config.mjs
+++ b/plugins/cli-reporter/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['@thymian/test-utils', 'vitest']
+          ignoredDependencies: ['@thymian/test-utils', 'vitest'],
         },
       ],
     },

--- a/plugins/cli-reporter/src/report.ts
+++ b/plugins/cli-reporter/src/report.ts
@@ -72,13 +72,13 @@ export function report(thymianReports: ThymianReport[]): void {
     console.log(
       Array.from({ length: topic.length })
         .map(() => '-')
-        .join('')
+        .join(''),
     );
     console.log(chalk.bold(topic));
     console.log(
       Array.from({ length: topic.length })
         .map(() => '-')
-        .join('')
+        .join(''),
     );
     console.log();
     console.group();
@@ -131,7 +131,7 @@ export function report(thymianReports: ThymianReport[]): void {
       Topic: 'Total Number',
       '# of Problems': numberOfProblems,
     },
-    { color: 'red' }
+    { color: 'red' },
   );
   // Table or single line output?
   table.printTable();

--- a/plugins/format-validator/eslint.config.mjs
+++ b/plugins/format-validator/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['vitest']
+          ignoredDependencies: ['vitest'],
         },
       ],
     },

--- a/plugins/format-validator/src/create-context.ts
+++ b/plugins/format-validator/src/create-context.ts
@@ -13,19 +13,19 @@ export function createContext(
   format: ThymianFormat,
   logger: Logger,
   emitter: ThymianEmitter,
-  origin?: string
+  origin?: string,
 ) {
   return createHttpTestContext({
     format,
     logger,
     locals: {},
     sampleRequest: function (
-      transaction: ThymianHttpTransaction
+      transaction: ThymianHttpTransaction,
     ): Promise<HttpRequestTemplate> {
       return emitter.emitAction(
         'sampler.sample-request',
         { transaction },
-        { strategy: 'first' }
+        { strategy: 'first' },
       );
     },
     runRequest: async function (req: HttpRequest): Promise<HttpResponse> {
@@ -40,7 +40,7 @@ export function createContext(
         },
         {
           strategy: 'first',
-        }
+        },
       );
     },
     runHook: createHookRunner(emitter),

--- a/plugins/format-validator/src/index.ts
+++ b/plugins/format-validator/src/index.ts
@@ -37,7 +37,7 @@ export const formatValidatorPlugin: ThymianPlugin = {
       const context = createContext(thymianFormat, logger, emitter);
 
       const valid = await validate(context, logger, (report) =>
-        emitter.emit('core.report', report)
+        emitter.emit('core.report', report),
       );
 
       ctx.reply(valid);
@@ -48,7 +48,7 @@ export const formatValidatorPlugin: ThymianPlugin = {
       const context = createContext(thymianFormat, logger, emitter);
 
       const valid = await validate(context, logger, (report) =>
-        emitter.emit('core.report', report)
+        emitter.emit('core.report', report),
       );
 
       ctx.reply({

--- a/plugins/format-validator/src/validate.ts
+++ b/plugins/format-validator/src/validate.ts
@@ -14,14 +14,14 @@ import {
 export async function validate(
   context: HttpTestContext,
   logger: Logger,
-  report: (report: ThymianReport) => void
+  report: (report: ThymianReport) => void,
 ): Promise<boolean> {
   const test = httpTest(
     'Transactions with 2xx status code',
     singleTestCase()
       .forTransactionsWith(successfulStatusCode())
       .run({ checkResponse: true })
-      .done()
+      .done(),
   );
 
   const results = await test(context);
@@ -31,7 +31,7 @@ export async function validate(
   for (const testCase of results.cases) {
     if (testCase.status === 'skipped') {
       logger.debug(
-        `HTTP test case "${testCase.name}" from test "@thymian/format-validator" is skipped.`
+        `HTTP test case "${testCase.name}" from test "@thymian/format-validator" is skipped.`,
       );
 
       report({
@@ -40,7 +40,7 @@ export async function validate(
           testCase.reason ??
           testCase.results
             .filter(
-              (tc) => tc.type !== 'info' && tc.type !== 'assertion-success'
+              (tc) => tc.type !== 'info' && tc.type !== 'assertion-success',
             )
             .map((tc) => tc.message)
             .join('\n'),
@@ -71,7 +71,7 @@ export async function validate(
 
     const title = thymianHttpTransactionToString(
       source.thymianReq,
-      source.thymianRes
+      source.thymianRes,
     );
 
     const subTopic = '2xx responses';

--- a/plugins/http-linter/src/api-context/analytics-api-context/analytics-api-context.ts
+++ b/plugins/http-linter/src/api-context/analytics-api-context/analytics-api-context.ts
@@ -32,7 +32,7 @@ export class AnalyticsApiContext extends LiveApiContext {
     readonly repository: HttpTransactionRepository,
     logger: Logger,
     format: ThymianFormat,
-    reportFn?: ReportFn
+    reportFn?: ReportFn,
   ) {
     super(format, logger, reportFn);
   }
@@ -41,7 +41,7 @@ export class AnalyticsApiContext extends LiveApiContext {
     filter: HttpFilterExpression,
     validate:
       | ValidationFn<[CommonHttpRequest, CommonHttpResponse, string]>
-      | HttpFilterExpression = filter
+      | HttpFilterExpression = filter,
   ): Promise<RuleFnResult> | RuleFnResult {
     let finalFilter!: HttpFilterExpression;
     let validateFn!: ValidationFn<
@@ -61,7 +61,7 @@ export class AnalyticsApiContext extends LiveApiContext {
     this.logger.debug('Executing SQL query:', sql);
 
     const statement = this.repository.db.prepare<unknown[], { id: string }>(
-      sql
+      sql,
     );
 
     const results: RuleFnResult = [];
@@ -79,7 +79,7 @@ export class AnalyticsApiContext extends LiveApiContext {
       const violation = validateFn(
         httpRequestToCommonHttpRequest(reqId, req),
         httpResponseToCommonHttpResponse(resId, res),
-        transactionId
+        transactionId,
       );
 
       results.push({
@@ -101,7 +101,7 @@ export class AnalyticsApiContext extends LiveApiContext {
     validationFn: ValidationFn<
       [string, [CommonHttpRequest, CommonHttpResponse][]],
       RuleViolation | undefined
-    >
+    >,
   ): Promise<RuleFnResult> | RuleFnResult {
     const { sql, params } = httpFilterToGroupedCommonFilter(filter, groupBy);
     const groupByFn = compileExpressionToGroupByFn(groupBy, this.format);
@@ -124,8 +124,8 @@ export class AnalyticsApiContext extends LiveApiContext {
             [id, ...this.repository.readTransactionById(id)] as [
               string,
               HttpRequest,
-              HttpResponse
-            ]
+              HttpResponse,
+            ],
         )
         .map(([, req, res]) => {
           const matched = this.format.matchTransaction(req, res);

--- a/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-common-filter.ts
+++ b/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-common-filter.ts
@@ -4,7 +4,7 @@ import type { SqlFragment } from '../utils.js';
 import { compileHttpFilterToWhereClause } from './http-filter-to-where-clause.js';
 
 export function httpFilterToCommonFilter(
-  filter: HttpFilterExpression
+  filter: HttpFilterExpression,
 ): SqlFragment {
   const { sql, params } = compileHttpFilterToWhereClause(filter, {
     requests: 'req',

--- a/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-groupby-clause.ts
+++ b/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-groupby-clause.ts
@@ -5,7 +5,7 @@ import type { TableNames } from './types.js';
 
 export function httpFilterToGroupByClause(
   expression: HttpFilterExpression,
-  tables: TableNames
+  tables: TableNames,
 ): SqlFragment {
   const params: unknown[] = [];
 
@@ -37,7 +37,7 @@ export function httpFilterToGroupByClause(
       };
     case 'and': {
       const parts = expression.filters.map((expr) =>
-        httpFilterToGroupByClause(expr, tables)
+        httpFilterToGroupByClause(expr, tables),
       );
 
       return {

--- a/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-grouped-common-filter.ts
+++ b/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-grouped-common-filter.ts
@@ -6,7 +6,7 @@ import { compileHttpFilterToWhereClause } from './http-filter-to-where-clause.js
 
 export function httpFilterToGroupedCommonFilter(
   filter: HttpFilterExpression,
-  groupBy: HttpFilterExpression
+  groupBy: HttpFilterExpression,
 ): SqlFragment {
   const filterFragment = compileHttpFilterToWhereClause(filter, {
     requests: 'req',

--- a/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-where-clause.ts
+++ b/plugins/http-linter/src/api-context/analytics-api-context/compilers/http-filter-to-where-clause.ts
@@ -10,7 +10,7 @@ import type { TableNames } from './types.js';
 
 export function compileHttpFilterToWhereClause(
   filter: HttpFilterExpression,
-  names: Partial<TableNames> = {}
+  names: Partial<TableNames> = {},
 ): SqlFragment {
   const tableNames: TableNames = {
     requests: 'req',
@@ -129,7 +129,7 @@ export function compileHttpFilterToWhereClause(
 
     case 'and': {
       const parts = filter.filters.map((expr) =>
-        compileHttpFilterToWhereClause(expr, tableNames)
+        compileHttpFilterToWhereClause(expr, tableNames),
       );
       return {
         sql: parts.map((p) => parenthesize(p.sql)).join(' AND '),
@@ -139,7 +139,7 @@ export function compileHttpFilterToWhereClause(
 
     case 'or': {
       const parts = filter.filters.map((expr) =>
-        compileHttpFilterToWhereClause(expr, tableNames)
+        compileHttpFilterToWhereClause(expr, tableNames),
       );
       return {
         sql: parts.map((p) => parenthesize(p.sql)).join(' OR '),
@@ -197,14 +197,14 @@ export function compileHttpFilterToWhereClause(
 
       return compileHttpFilterToWhereClause(
         and(origin(url.origin), path(url.pathname)),
-        tableNames
+        tableNames,
       );
     }
     case 'hasResponse':
     case 'isAuthorized':
     case 'port':
       throw new Error(
-        `HTTP filter expression "${filter.type}" is not supported for SQL translation.`
+        `HTTP filter expression "${filter.type}" is not supported for SQL translation.`,
       );
   }
 }

--- a/plugins/http-linter/src/api-context/api-context.ts
+++ b/plugins/http-linter/src/api-context/api-context.ts
@@ -14,7 +14,7 @@ export type FilterFn<Args extends unknown[]> = (...args: Args) => boolean;
 
 export type ValidationFn<
   Args extends unknown[],
-  R = PartialBy<RuleViolation, 'location'> | boolean | undefined
+  R = PartialBy<RuleViolation, 'location'> | boolean | undefined,
 > = (...args: Args) => R;
 
 export type CommonHttpRequest = {
@@ -43,14 +43,14 @@ export abstract class ApiContext {
     readonly format: ThymianFormat,
     protected readonly logger: Logger,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    protected readonly report: ReportFn = () => {}
+    protected readonly report: ReportFn = () => {},
   ) {}
 
   abstract validateCommonHttpTransactions(
     filter: HttpFilterExpression,
     validationFn?:
       | ValidationFn<[CommonHttpRequest, CommonHttpResponse, string]>
-      | HttpFilterExpression
+      | HttpFilterExpression,
   ): Promise<RuleFnResult> | RuleFnResult;
 
   abstract validateGroupedCommonHttpTransactions(
@@ -59,11 +59,11 @@ export abstract class ApiContext {
     validationFn: ValidationFn<
       [string, [CommonHttpRequest, CommonHttpResponse][]],
       RuleViolation | undefined
-    >
+    >,
   ): Promise<RuleFnResult> | RuleFnResult;
 
   protected getCommonHttpResponsesOfRequest(
-    reqId: string
+    reqId: string,
   ): CommonHttpResponse[] {
     const responses = this.format.getNeighboursOfType(reqId, 'http-response');
 

--- a/plugins/http-linter/src/api-context/http-test-api-context.ts
+++ b/plugins/http-linter/src/api-context/http-test-api-context.ts
@@ -61,7 +61,7 @@ function extractMediaType(req: HttpRequest): string {
 
 export function httpRequestToCommonHttpRequest(
   source: string,
-  request: HttpRequest
+  request: HttpRequest,
 ): CommonHttpRequest {
   return {
     id: source,
@@ -70,7 +70,7 @@ export function httpRequestToCommonHttpRequest(
     method: request.method,
     headers: Object.keys(request.headers ?? {}),
     queryParameters: Array.from(
-      new URLSearchParams(request.path.split('?')[1] ?? '').keys()
+      new URLSearchParams(request.path.split('?')[1] ?? '').keys(),
     ),
     cookies: [],
     mediaType: extractMediaType(request),
@@ -80,7 +80,7 @@ export function httpRequestToCommonHttpRequest(
 
 export function httpResponseToCommonHttpResponse(
   source: string,
-  response: HttpResponse
+  response: HttpResponse,
 ): CommonHttpResponse {
   return {
     body: !!response.body,
@@ -93,7 +93,7 @@ export function httpResponseToCommonHttpResponse(
 }
 
 function hasSource(
-  transaction: HttpTestCaseStepTransaction
+  transaction: HttpTestCaseStepTransaction,
 ): transaction is HttpTestCaseStepTransaction & {
   source: ThymianHttpTransaction;
 } {
@@ -101,14 +101,14 @@ function hasSource(
 }
 
 export class HttpTestApiContext<
-  Locals extends HttpTestContextLocals = HttpTestContextLocals
+  Locals extends HttpTestContextLocals = HttpTestContextLocals,
 > extends LiveApiContext {
   private readonly violations: RuleViolation[] = [];
 
   constructor(
     private readonly name: string,
     private readonly ctx: HttpTestContext<Locals>,
-    report: ReportFn
+    report: ReportFn,
   ) {
     super(ctx.format, ctx.logger, report);
   }
@@ -123,12 +123,12 @@ export class HttpTestApiContext<
     validationFn: ValidationFn<
       [string, [CommonHttpRequest, CommonHttpResponse][]],
       RuleViolation | undefined
-    >
+    >,
   ): Promise<RuleFnResult> {
     const filterFn = compileExpressionToFilterFn(filterExpr, this.format);
     const groupByFn = compileExpressionToGroupByFn(
       groupByExpression,
-      this.format
+      this.format,
     );
 
     const test = httpTest(this.name, (test) =>
@@ -137,32 +137,32 @@ export class HttpTestApiContext<
           filterFn(
             thymianToCommonHttpRequest(
               current.thymianReqId,
-              current.thymianReq
+              current.thymianReq,
             ),
             thymianToCommonHttpResponse(
               current.thymianResId,
-              current.thymianRes
+              current.thymianRes,
             ),
             this.getCommonHttpResponsesOfRequest(current.thymianReqId),
-            current.transactionId
-          )
+            current.transactionId,
+          ),
         ),
         groupBy(({ current }) =>
           groupByFn(
             thymianToCommonHttpRequest(
               current.thymianReqId,
-              current.thymianReq
+              current.thymianReq,
             ),
             thymianToCommonHttpResponse(
               current.thymianResId,
-              current.thymianRes
-            )
-          )
+              current.thymianRes,
+            ),
+          ),
         ),
         mapToGroupedTestCase(),
         generateRequests(),
-        runRequests()
-      )
+        runRequests(),
+      ),
     );
 
     const testResult = await test(this.ctx);
@@ -181,18 +181,18 @@ export class HttpTestApiContext<
             httpRequestToCommonHttpRequest(
               transaction.source.thymianReqId,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              transaction.request!
+              transaction.request!,
             ),
             httpResponseToCommonHttpResponse(
               transaction.source.thymianResId,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              transaction.response!
+              transaction.response!,
             ),
           ]);
 
         const validationResult = validationFn(
           source.key,
-          transactionToValidate
+          transactionToValidate,
         );
 
         if (validationResult) {
@@ -208,7 +208,7 @@ export class HttpTestApiContext<
     filterExpr: HttpFilterExpression,
     validate:
       | ValidationFn<[CommonHttpRequest, CommonHttpResponse, string]>
-      | HttpFilterExpression = filterExpr
+      | HttpFilterExpression = filterExpr,
   ): Promise<RuleFnResult> {
     const filterFn = compileExpressionToFilterFn(filterExpr, this.format);
     const validationFn =
@@ -222,20 +222,20 @@ export class HttpTestApiContext<
           filterFn(
             thymianToCommonHttpRequest(
               current.thymianReqId,
-              current.thymianReq
+              current.thymianReq,
             ),
             thymianToCommonHttpResponse(
               current.thymianResId,
-              current.thymianRes
+              current.thymianRes,
             ),
             this.getCommonHttpResponsesOfRequest(current.thymianReqId),
-            current.transactionId
-          )
+            current.transactionId,
+          ),
         ),
         mapToTestCase(),
         generateRequests(),
-        runRequests()
-      )
+        runRequests(),
+      ),
     );
 
     const testResult = await test(this.ctx);
@@ -258,7 +258,7 @@ export class HttpTestApiContext<
             const validationResult = validationFn(
               httpRequestToCommonHttpRequest(source.thymianReqId, request),
               httpResponseToCommonHttpResponse(source.thymianResId, response),
-              source.transactionId
+              source.transactionId,
             );
 
             if (typeof validationResult === 'boolean' && validationResult) {
@@ -284,7 +284,7 @@ export class HttpTestApiContext<
           }
 
           return violations;
-        })
+        }),
       )
       .concat(this.violations);
   }
@@ -293,7 +293,7 @@ export class HttpTestApiContext<
     testResult.cases.forEach((testCase) => {
       if (testCase.status === 'skipped') {
         this.ctx.logger.debug(
-          `HTTP test case "${testCase.name}" from test "${this.name}" is skipped.`
+          `HTTP test case "${testCase.name}" from test "${this.name}" is skipped.`,
         );
 
         this.report({
@@ -302,7 +302,7 @@ export class HttpTestApiContext<
             testCase.reason ??
             testCase.results
               .filter(
-                (tc) => tc.type !== 'info' && tc.type !== 'assertion-success'
+                (tc) => tc.type !== 'info' && tc.type !== 'assertion-success',
               )
               .map((tc) => tc.message)
               .join('\n'),
@@ -312,11 +312,11 @@ export class HttpTestApiContext<
         });
       } else if (testCase.status === 'failed') {
         this.ctx.logger.debug(
-          `HTTP test case "${testCase.name}" from test "${this.name}" failed.`
+          `HTTP test case "${testCase.name}" from test "${this.name}" failed.`,
         );
 
         const assertionFailure = testCase.results.find(
-          (r) => r.type === 'assertion-failure' && !!r.transaction
+          (r) => r.type === 'assertion-failure' && !!r.transaction,
         ) as AssertionFailure;
 
         if (assertionFailure && assertionFailure.transaction) {
@@ -333,7 +333,7 @@ export class HttpTestApiContext<
               testCase.reason ??
               testCase.results
                 .filter(
-                  (tc) => tc.type !== 'info' && tc.type !== 'assertion-success'
+                  (tc) => tc.type !== 'info' && tc.type !== 'assertion-success',
                 )
                 .map((tc) => tc.message)
                 .join('\n'),

--- a/plugins/http-linter/src/api-context/static-api-context.ts
+++ b/plugins/http-linter/src/api-context/static-api-context.ts
@@ -30,7 +30,7 @@ export class StaticApiContext extends ApiContext {
     filter: HttpFilterExpression,
     validate:
       | ValidationFn<[CommonHttpRequest, CommonHttpResponse, string]>
-      | HttpFilterExpression = filter
+      | HttpFilterExpression = filter,
   ): RuleFnResult {
     const filterFn = compileExpressionToFilterFn(filter, this.format);
     const validationFn =
@@ -58,7 +58,7 @@ export class StaticApiContext extends ApiContext {
         ];
       })
       .filter(([req, res, responses, transactionId]) =>
-        filterFn(req, res, responses, transactionId)
+        filterFn(req, res, responses, transactionId),
       )
       .reduce((violations, [req, res, , transactionId]) => {
         const validationResult = validationFn(req, res, transactionId);
@@ -94,7 +94,7 @@ export class StaticApiContext extends ApiContext {
     validationFn: ValidationFn<
       [string, [CommonHttpRequest, CommonHttpResponse][]],
       RuleViolation
-    >
+    >,
   ): RuleFnResult {
     const filterFn = compileExpressionToFilterFn(filter, this.format);
     const groupByFn = compileExpressionToGroupByFn(groupBy, this.format);
@@ -119,20 +119,23 @@ export class StaticApiContext extends ApiContext {
         ];
       })
       .filter(([req, res, responses, transactionId]) =>
-        filterFn(req, res, responses, transactionId)
+        filterFn(req, res, responses, transactionId),
       )
-      .reduce((groups, [req, res, , transactionId]) => {
-        const key = groupByFn(req, res);
+      .reduce(
+        (groups, [req, res, , transactionId]) => {
+          const key = groupByFn(req, res);
 
-        (groups[key] ??= []).push([req, res, transactionId]);
+          (groups[key] ??= []).push([req, res, transactionId]);
 
-        return groups;
-      }, {} as Record<string, [CommonHttpRequest, CommonHttpResponse, string][]>);
+          return groups;
+        },
+        {} as Record<string, [CommonHttpRequest, CommonHttpResponse, string][]>,
+      );
 
     return Object.entries(groups).reduce((violations, [key, group]) => {
       const validationResult = validationFn(
         key,
-        group.map(([req, res]) => [req, res])
+        group.map(([req, res]) => [req, res]),
       );
 
       if (validationResult) {
@@ -147,13 +150,13 @@ export class StaticApiContext extends ApiContext {
     filterFn: (
       req: ThymianHttpRequest,
       res: ThymianHttpResponse,
-      responses: ThymianHttpResponse[]
+      responses: ThymianHttpResponse[],
     ) => boolean,
     validationFn: (
       req: ThymianHttpRequest,
       res: ThymianHttpResponse,
-      responses: ThymianHttpResponse[]
-    ) => PartialBy<RuleViolation, 'location'> | boolean = filterFn
+      responses: ThymianHttpResponse[],
+    ) => PartialBy<RuleViolation, 'location'> | boolean = filterFn,
   ): RuleFnResult {
     return this.format.graph.reduceNodes((violations, id, node) => {
       if (!isNodeType(node, 'http-request')) {
@@ -170,7 +173,7 @@ export class StaticApiContext extends ApiContext {
           const transactionId = this.format.graph.findEdge(
             id,
             resId,
-            (_, edge) => edge.type === 'http-transaction'
+            (_, edge) => edge.type === 'http-transaction',
           );
 
           if (!transactionId) {

--- a/plugins/http-linter/src/api-context/utils.ts
+++ b/plugins/http-linter/src/api-context/utils.ts
@@ -15,7 +15,7 @@ import type {
 
 export function thymianToCommonHttpRequest(
   id: string,
-  node: ThymianHttpRequest
+  node: ThymianHttpRequest,
 ): CommonHttpRequest {
   return {
     id,
@@ -32,7 +32,7 @@ export function thymianToCommonHttpRequest(
 
 export function thymianToCommonHttpResponse(
   id: string,
-  node: ThymianHttpResponse
+  node: ThymianHttpResponse,
 ): CommonHttpResponse {
   return {
     id,
@@ -46,7 +46,7 @@ export function thymianToCommonHttpResponse(
 
 export function compileExpressionToFilterFn(
   expression: HttpFilterExpression,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): FilterFn<
   [CommonHttpRequest, CommonHttpResponse, CommonHttpResponse[], string]
 > {
@@ -97,7 +97,7 @@ export function compileExpressionToFilterFn(
           const transactionId = format.graph.findEdge(
             req.id,
             r.id,
-            (_, edge) => edge.type === 'http-transaction'
+            (_, edge) => edge.type === 'http-transaction',
           );
 
           if (!transactionId) {
@@ -108,7 +108,7 @@ export function compileExpressionToFilterFn(
             req,
             r,
             [],
-            transactionId
+            transactionId,
           );
         });
       };
@@ -118,7 +118,7 @@ export function compileExpressionToFilterFn(
       return (req, res, responses, id) =>
         expression.filters
           .map((expr) =>
-            compileExpressionToFilterFn(expr, format)(req, res, responses, id)
+            compileExpressionToFilterFn(expr, format)(req, res, responses, id),
           )
           .reduce((acc, curr) => acc !== curr);
     case 'method':
@@ -135,12 +135,12 @@ export function compileExpressionToFilterFn(
     case 'and':
       return (req, res, responses, id) =>
         expression.filters.every((e) =>
-          compileExpressionToFilterFn(e, format)(req, res, responses, id)
+          compileExpressionToFilterFn(e, format)(req, res, responses, id),
         );
     case 'or':
       return (req, res, responses, id) =>
         expression.filters.some((e) =>
-          compileExpressionToFilterFn(e, format)(req, res, responses, id)
+          compileExpressionToFilterFn(e, format)(req, res, responses, id),
         );
     case 'not':
       return (req, res, responses, id) =>
@@ -148,14 +148,14 @@ export function compileExpressionToFilterFn(
           req,
           res,
           responses,
-          id
+          id,
         );
   }
 }
 
 export function compileExpressionToValidateFn(
   expression: HttpFilterExpression,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): FilterFn<[CommonHttpRequest, CommonHttpResponse, string]> {
   switch (expression.type) {
     case 'origin':
@@ -206,7 +206,7 @@ export function compileExpressionToValidateFn(
       return (req, res, id) =>
         expression.filters
           .map((expr) =>
-            compileExpressionToValidateFn(expr, format)(req, res, id)
+            compileExpressionToValidateFn(expr, format)(req, res, id),
           )
           .reduce((acc, curr) => acc !== curr);
     case 'method':
@@ -223,12 +223,12 @@ export function compileExpressionToValidateFn(
     case 'and':
       return (req, res, id) =>
         expression.filters.every((e) =>
-          compileExpressionToValidateFn(e, format)(req, res, id)
+          compileExpressionToValidateFn(e, format)(req, res, id),
         );
     case 'or':
       return (req, res, id) =>
         expression.filters.some((e) =>
-          compileExpressionToValidateFn(e, format)(req, res, id)
+          compileExpressionToValidateFn(e, format)(req, res, id),
         );
     case 'not':
       return (req, res, id) =>
@@ -238,7 +238,7 @@ export function compileExpressionToValidateFn(
 
 export function compileExpressionToGroupByFn(
   expression: HttpFilterExpression,
-  format: ThymianFormat
+  format: ThymianFormat,
 ): (req: CommonHttpRequest, res: CommonHttpResponse) => string {
   switch (expression.type) {
     case 'origin':
@@ -260,7 +260,7 @@ export function compileExpressionToGroupByFn(
     case 'queryParam':
       return (req) =>
         req.queryParameters.find(
-          (p) => p.toLowerCase() === expression.param?.toLowerCase()
+          (p) => p.toLowerCase() === expression.param?.toLowerCase(),
         ) ?? '';
     case 'isAuthorized':
       return (req) => String(format.requestIsSecured(req.id));
@@ -269,7 +269,7 @@ export function compileExpressionToGroupByFn(
     case 'requestHeader':
       return (req) =>
         req.headers.find(
-          (p) => p.toLowerCase() === expression.header?.toLowerCase()
+          (p) => p.toLowerCase() === expression.header?.toLowerCase(),
         ) ?? '';
     case 'path':
       return (req) => req.path;
@@ -278,7 +278,7 @@ export function compileExpressionToGroupByFn(
     case 'responseHeader':
       return (req, res) =>
         res.headers.find(
-          (p) => p.toLowerCase() === expression.header?.toLowerCase()
+          (p) => p.toLowerCase() === expression.header?.toLowerCase(),
         ) ?? '';
     case 'and':
       return (req, res) =>
@@ -292,7 +292,7 @@ export function compileExpressionToGroupByFn(
         {
           name: 'UnsupportedGroupByExpression',
           suggestions: ['Use another expression type.'],
-        }
+        },
       );
   }
 }

--- a/plugins/http-linter/src/cli/commands/http-linter/generate.ts
+++ b/plugins/http-linter/src/cli/commands/http-linter/generate.ts
@@ -29,7 +29,7 @@ ${cjs ? 'module.exports =' : 'export default'} httpRule('${meta.name}')
 
   for (const [key, value] of Object.entries(meta) as [
     keyof RuleMeta,
-    RuleMeta[keyof RuleMeta]
+    RuleMeta[keyof RuleMeta],
   ][]) {
     switch (key) {
       case 'name':

--- a/plugins/http-linter/src/cli/commands/http-linter/search.ts
+++ b/plugins/http-linter/src/cli/commands/http-linter/search.ts
@@ -46,8 +46,8 @@ export default class SearchCommand extends BaseCliRunCommand<
       this.log(
         `${ux.colorize('bold', item.meta.name)} ${ux.colorize(
           'dim',
-          `(confidence: ${score})`
-        )}`
+          `(confidence: ${score})`,
+        )}`,
       );
       console.group();
       this.log(item.meta.summary);

--- a/plugins/http-linter/src/cli/init-hook.ts
+++ b/plugins/http-linter/src/cli/init-hook.ts
@@ -9,7 +9,7 @@ import { httpLinterPlugin, type HttpLinterPluginOptions } from '../index.js';
 const defaultRuleSets = ['@thymian/rfc-9110-rules'];
 
 const hook: ThymianPluginInitHook<HttpLinterPluginOptions> = async function (
-  options
+  options,
 ) {
   if (!options.interactive) {
     return {
@@ -51,7 +51,7 @@ const hook: ThymianPluginInitHook<HttpLinterPluginOptions> = async function (
 
     const includeDefaultSets = await confirm({
       message: `Do you want to include default rule sets: ${defaultRuleSets.join(
-        ', '
+        ', ',
       )}?`,
       default: true,
     });

--- a/plugins/http-linter/src/db/http-transaction-repository.ts
+++ b/plugins/http-linter/src/db/http-transaction-repository.ts
@@ -17,7 +17,10 @@ import {
 export class HttpTransactionRepository {
   readonly db: Database;
 
-  constructor(location: string, private readonly logger: Logger) {
+  constructor(
+    location: string,
+    private readonly logger: Logger,
+  ) {
     this.db = new SqliteDb(location);
     this.db.pragma('journal_mode = WAL');
   }
@@ -55,7 +58,7 @@ export class HttpTransactionRepository {
       this.insertQueryParameters(
         url.searchParams,
         insertRequestQueryParameter,
-        reqId
+        reqId,
       );
 
       return inserted.lastInsertRowid.toString();
@@ -63,7 +66,7 @@ export class HttpTransactionRepository {
   }
 
   readTransactionById(
-    transactionId: number | string
+    transactionId: number | string,
   ): [HttpRequest, HttpResponse] {
     const transactionStatement = this.db.prepare<unknown[], any>(`
         SELECT 
@@ -141,7 +144,7 @@ export class HttpTransactionRepository {
   private insertQueryParameters(
     queryParameters: URLSearchParams,
     statement: string,
-    id: number | bigint
+    id: number | bigint,
   ): void {
     if (!queryParameters) {
       return;
@@ -161,7 +164,7 @@ export class HttpTransactionRepository {
   private insertHeaders(
     headers: Record<string, string | string[] | undefined> | undefined,
     statement: string,
-    id: number | bigint
+    id: number | bigint,
   ): void {
     if (!headers) {
       return;
@@ -190,7 +193,7 @@ export class HttpTransactionRepository {
 
   private insertTrailers(
     trailers: Record<string, string> | undefined,
-    responseId: number | bigint
+    responseId: number | bigint,
   ): void {
     if (!trailers) return;
 

--- a/plugins/http-linter/src/index.ts
+++ b/plugins/http-linter/src/index.ts
@@ -133,14 +133,14 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
   async plugin(
     emitter: ThymianEmitter,
     logger: Logger,
-    options
+    options,
   ): Promise<void> {
     const ruleFilter = createRuleFilter(options.ruleFilter);
 
     const loadedRules = await loadRules(
       options.rules,
       ruleFilter,
-      options.ruleOptions
+      options.ruleOptions,
     );
 
     logger.debug(`${loadedRules.length} rules were initially loaded.`);
@@ -153,13 +153,13 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
       const additionalLoadedRules = await loadRules(
         rules,
         ruleFilter,
-        options.ruleOptions
+        options.ruleOptions,
       );
 
       loadedRules.push(...additionalLoadedRules);
 
       logger.debug(
-        `Loaded ${additionalLoadedRules.length} additional rules for @thymian/http-linter.`
+        `Loaded ${additionalLoadedRules.length} additional rules for @thymian/http-linter.`,
       );
 
       ctx.reply();
@@ -181,7 +181,7 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
             loadedRules,
             (report) => emitter.emit('core.report', report),
             thymianFormat,
-            options.ruleOptions ?? {}
+            options.ruleOptions ?? {},
           ).run()) && valid;
       }
 
@@ -195,7 +195,7 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
             loadedRules,
             (report) => emitter.emit('core.report', report),
             thymianFormat,
-            options.ruleOptions ?? {}
+            options.ruleOptions ?? {},
           ).run()) && valid;
       }
 
@@ -223,11 +223,11 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
           loadedRules,
           (report) => emitter.emit('core.report', report),
           thymianFormat,
-          options.ruleOptions ?? {}
+          options.ruleOptions ?? {},
         ).run();
 
         ctx.reply(valid);
-      }
+      },
     );
   },
 };

--- a/plugins/http-linter/src/linter/abstract-linter.ts
+++ b/plugins/http-linter/src/linter/abstract-linter.ts
@@ -39,10 +39,10 @@ export abstract class AbstractLinter {
     protected readonly ruleOptions: Record<
       string,
       Record<string, unknown> | undefined
-    >
+    >,
   ) {
     this.rules = rules.filter(
-      (r) => !(r.meta.type.length === 1 && r.meta.type[0] === 'informational')
+      (r) => !(r.meta.type.length === 1 && r.meta.type[0] === 'informational'),
     );
   }
 
@@ -53,7 +53,7 @@ export abstract class AbstractLinter {
           try {
             return await this.runRule(
               rule,
-              this.ruleOptions[rule.meta.name] ?? {}
+              this.ruleOptions[rule.meta.name] ?? {},
             );
           } catch (e) {
             if (e instanceof ThymianBaseError) {
@@ -64,24 +64,24 @@ export abstract class AbstractLinter {
                 {
                   name: `${this.constructor.name}Error`,
                   cause: e,
-                }
+                },
               );
             }
           }
-        })
+        }),
       )
     ).every(Boolean);
   }
 
   protected abstract runRule<Options extends Record<string, unknown>>(
     rule: Rule,
-    options: Options
+    options: Options,
   ): Promise<boolean>;
 
   protected reportRuleViolations(
     result: RuleViolation | RuleViolation[],
     ruleMeta: RuleMeta<Record<PropertyKey, unknown>>,
-    subTopic: string
+    subTopic: string,
   ) {
     const violations = Array.isArray(result) ? result : [result];
 
@@ -98,7 +98,7 @@ export abstract class AbstractLinter {
 
         if (!node) {
           throw new ThymianBaseError(
-            `Invalid rule violation location for rule ${ruleMeta.name}.`
+            `Invalid rule violation location for rule ${ruleMeta.name}.`,
           );
         }
 
@@ -109,17 +109,17 @@ export abstract class AbstractLinter {
         }
       } else {
         const [source, target] = this.format.graph.extremities(
-          location.elementId
+          location.elementId,
         );
         const transaction = this.format.getEdge<HttpTransaction>(
-          location.elementId
+          location.elementId,
         );
         const req = this.format.getNode<ThymianHttpRequest>(source);
         const res = this.format.getNode<ThymianHttpResponse>(target);
 
         if (!req || !res || !transaction) {
           throw new ThymianBaseError(
-            `Invalid rule violation location for rule ${ruleMeta.name}.`
+            `Invalid rule violation location for rule ${ruleMeta.name}.`,
           );
         }
 
@@ -158,7 +158,7 @@ export abstract class AbstractLinter {
 
 export function hasProperty<T extends object, K extends PropertyKey>(
   obj: T,
-  property: K
+  property: K,
 ): obj is T & Record<K, Record<PropertyKey, unknown>> {
   return property in obj;
 }

--- a/plugins/http-linter/src/linter/analytics-linter.ts
+++ b/plugins/http-linter/src/linter/analytics-linter.ts
@@ -12,14 +12,14 @@ export class AnalyticsLinter extends AbstractLinter {
     rules: Rule[],
     report: (report: ThymianReport) => void,
     format: ThymianFormat,
-    ruleOptions: Record<string, Record<string, unknown> | undefined>
+    ruleOptions: Record<string, Record<string, unknown> | undefined>,
   ) {
     super(logger, rules, report, format, ruleOptions);
   }
 
   protected override async runRule<Options extends Record<string, unknown>>(
     rule: Rule,
-    options: Options
+    options: Options,
   ): Promise<boolean> {
     if (!rule.analyticsRule) {
       return true;
@@ -31,7 +31,7 @@ export class AnalyticsLinter extends AbstractLinter {
         ...options,
         mode: 'analytics',
       },
-      this.logger.child(rule.meta.name)
+      this.logger.child(rule.meta.name),
     );
 
     if (!result || (Array.isArray(result) && result.length === 0)) {

--- a/plugins/http-linter/src/linter/create-context.ts
+++ b/plugins/http-linter/src/linter/create-context.ts
@@ -18,19 +18,19 @@ export function createContext<Locals extends HttpTestContextLocals>(
   logger: Logger,
   emitter: ThymianEmitter,
   origin?: string,
-  locals: Locals = {} as Locals
+  locals: Locals = {} as Locals,
 ) {
   return createHttpTestContext({
     format,
     logger,
     locals,
     sampleRequest: function (
-      transaction: ThymianHttpTransaction
+      transaction: ThymianHttpTransaction,
     ): Promise<HttpRequestTemplate> {
       return emitter.emitAction(
         'sampler.sample-request',
         { transaction },
-        { strategy: 'first' }
+        { strategy: 'first' },
       );
     },
     runRequest: async function (req: HttpRequest): Promise<HttpResponse> {
@@ -45,7 +45,7 @@ export function createContext<Locals extends HttpTestContextLocals>(
         },
         {
           strategy: 'first',
-        }
+        },
       );
     },
     runHook: createHookRunner(emitter),

--- a/plugins/http-linter/src/linter/http-test-linter.ts
+++ b/plugins/http-linter/src/linter/http-test-linter.ts
@@ -12,14 +12,14 @@ export class HttpTestLinter extends AbstractLinter {
     rules: Rule[],
     report: (report: ThymianReport) => void,
     format: ThymianFormat,
-    ruleOptions: Record<string, Record<string, unknown> | undefined>
+    ruleOptions: Record<string, Record<string, unknown> | undefined>,
   ) {
     super(logger, rules, report, format, ruleOptions);
   }
 
   protected override async runRule(
     rule: Rule,
-    options: Record<string, unknown>
+    options: Record<string, unknown>,
   ): Promise<boolean> {
     if (!rule.testRule) {
       return true;
@@ -31,7 +31,7 @@ export class HttpTestLinter extends AbstractLinter {
         ...options,
         mode: 'test',
       },
-      this.logger.child(rule.meta.name)
+      this.logger.child(rule.meta.name),
     );
 
     if (!result || (Array.isArray(result) && result.length === 0)) {

--- a/plugins/http-linter/src/linter/static-linter.ts
+++ b/plugins/http-linter/src/linter/static-linter.ts
@@ -6,7 +6,7 @@ import { AbstractLinter } from './abstract-linter.js';
 export class StaticLinter extends AbstractLinter {
   protected override async runRule<Options extends Record<string, unknown>>(
     rule: Rule,
-    options: Options
+    options: Options,
   ): Promise<boolean> {
     if (!rule.staticRule) {
       return true;
@@ -18,7 +18,7 @@ export class StaticLinter extends AbstractLinter {
         ...options,
         mode: 'test',
       },
-      this.logger.child(rule.meta.name)
+      this.logger.child(rule.meta.name),
     );
 
     if (!result || (Array.isArray(result) && result.length === 0)) {

--- a/plugins/http-linter/src/load-rules.ts
+++ b/plugins/http-linter/src/load-rules.ts
@@ -15,12 +15,12 @@ const require = createRequire(import.meta.url);
 
 export function areFunctionPropertiesIfDefined<Properties extends string[]>(
   obj: Record<PropertyKey, unknown>,
-  properties: Properties
+  properties: Properties,
 ): obj is Record<PropertyKey, unknown> &
   Record<Properties[number], (...args: unknown[]) => unknown> {
   return properties.some(
     (property) =>
-      Object.hasOwn(obj, property) && typeof obj[property] !== 'function'
+      Object.hasOwn(obj, property) && typeof obj[property] !== 'function',
   );
 }
 
@@ -54,7 +54,7 @@ export async function loadRuleSet(
   ruleSet: RuleSet,
   basePath: string,
   filterFn: RuleFilter,
-  options: Record<string, unknown>
+  options: Record<string, unknown>,
 ): Promise<Rule[]> {
   if (ruleSet.rules) {
     return ruleSet.rules.filter(filterFn);
@@ -71,7 +71,7 @@ export async function loadRuleSet(
       const files = await glob(pattern, { cwd: dirname });
       for (const file of files) {
         rules.push(
-          ...(await loadRules(path.join(dirname, file), filterFn, options))
+          ...(await loadRules(path.join(dirname, file), filterFn, options)),
         );
       }
     }
@@ -83,7 +83,7 @@ export async function loadRuleSet(
 export async function loadRules(
   path: string | string[],
   ruleFilter: RuleFilter = () => true,
-  options: Record<string, unknown> = {}
+  options: Record<string, unknown> = {},
 ): Promise<Rule[]> {
   if (Array.isArray(path)) {
     return (
@@ -110,7 +110,7 @@ export async function loadRules(
           'Use "export default" or "module.exports =" to export your rule (set).',
         ],
         name: 'RuleLoadError',
-      }
+      },
     );
   }
 
@@ -134,7 +134,7 @@ export async function loadRules(
               'Check the options for the rule in your Thymian config file.',
             ],
             name: 'InvalidRuleOptionError',
-          }
+          },
         );
       }
     }

--- a/plugins/http-linter/src/rule-builder.ts
+++ b/plugins/http-linter/src/rule-builder.ts
@@ -16,16 +16,16 @@ type ApiContextType<RuleTypes extends [RuleType, ...RuleType[]]> =
   RuleTypes[number] extends 'static'
     ? StaticApiContext
     : RuleTypes[number] extends 'analytics'
-    ? AnalyticsApiContext
-    : RuleTypes[number] extends 'test'
-    ? HttpTestApiContext
-    : RuleTypes[number] extends 'analytics' | 'test'
-    ? LiveApiContext
-    : ApiContext;
+      ? AnalyticsApiContext
+      : RuleTypes[number] extends 'test'
+        ? HttpTestApiContext
+        : RuleTypes[number] extends 'analytics' | 'test'
+          ? LiveApiContext
+          : ApiContext;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isInformationalRule<R extends Rule<any>>(
-  rule: R
+  rule: R,
 ): rule is R & { meta: { type: ['informational'] } } {
   return rule.meta.type.includes('informational');
 }
@@ -46,47 +46,47 @@ interface Done<Options extends Record<PropertyKey, unknown>> {
 
 interface DefineRules<
   RuleTypes extends [RuleType, ...RuleType[]],
-  Options extends Record<PropertyKey, unknown>
+  Options extends Record<PropertyKey, unknown>,
 > extends Done<Options> {
   rule(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<ApiContextType<RuleTypes>, Options>
+      : RuleFn<ApiContextType<RuleTypes>, Options>,
   ): DefineRules<RuleTypes, Options>;
 
   overrideAnalyticsRule(
     ffn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<AnalyticsApiContext, Options>
+      : RuleFn<AnalyticsApiContext, Options>,
   ): DefineRules<RuleTypes, Options>;
 
   overrideStaticRule(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<StaticApiContext, Options>
+      : RuleFn<StaticApiContext, Options>,
   ): DefineRules<RuleTypes, Options>;
 
   overrideTest(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<HttpTestApiContext, Options>
+      : RuleFn<HttpTestApiContext, Options>,
   ): DefineRules<RuleTypes, Options>;
 }
 
 interface DefineOptionalRuleMetaProperties<
   RuleTypes extends [RuleType, ...RuleType[]],
-  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > extends DefineRules<RuleTypes, Options> {
   appliesTo(
     ...participants: [HttpParticipantRole, ...HttpParticipantRole[]]
   ): this;
 
   description(
-    description: string
+    description: string,
   ): DefineOptionalRuleMetaProperties<RuleTypes, Options>;
 
   summary(
-    summary: string
+    summary: string,
   ): DefineOptionalRuleMetaProperties<RuleTypes, Options>;
 
   url(url: string): this;
@@ -94,18 +94,19 @@ interface DefineOptionalRuleMetaProperties<
   tags(...tags: string[]): DefineOptionalRuleMetaProperties<RuleTypes, Options>;
 
   explanation(
-    explanation: string
+    explanation: string,
   ): DefineOptionalRuleMetaProperties<RuleTypes, Options>;
 
   options<Options extends Record<PropertyKey, unknown>>(
-    schema: JSONSchemaType<Options>
+    schema: JSONSchemaType<Options>,
   ): DefineOptionalRuleMetaProperties<RuleTypes, Options>;
 }
 
 class RuleBuilder<
-  Options extends Record<PropertyKey, unknown>,
-  RuleTypes extends [RuleType, ...RuleType[]]
-> implements
+    Options extends Record<PropertyKey, unknown>,
+    RuleTypes extends [RuleType, ...RuleType[]],
+  >
+  implements
     DefineOptionalRuleMetaProperties<RuleTypes, Options>,
     DefineRuleType,
     DefineRuleSeverity
@@ -165,7 +166,7 @@ class RuleBuilder<
   }
 
   options<Opts extends Record<PropertyKey, unknown>>(
-    schema: JSONSchemaType<Opts>
+    schema: JSONSchemaType<Opts>,
   ): DefineOptionalRuleMetaProperties<RuleTypes, Opts> {
     this.#rule.meta.options = schema as JSONSchemaType<Options>;
 
@@ -184,7 +185,7 @@ class RuleBuilder<
   rule(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<ApiContextType<RuleTypes>, Options>
+      : RuleFn<ApiContextType<RuleTypes>, Options>,
   ): DefineRules<RuleTypes, Options> {
     if (isInformationalRule(this.#rule)) {
       throw new Error('Cannot define rule function for this type of rule.');
@@ -206,7 +207,7 @@ class RuleBuilder<
   overrideAnalyticsRule(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<AnalyticsApiContext, Options>
+      : RuleFn<AnalyticsApiContext, Options>,
   ): DefineRules<RuleTypes, Options> {
     if (isInformationalRule(this.#rule)) {
       throw new Error('Cannot define rule function for this type of rule.');
@@ -220,7 +221,7 @@ class RuleBuilder<
   overrideStaticRule(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<StaticApiContext, Options>
+      : RuleFn<StaticApiContext, Options>,
   ): DefineRules<RuleTypes, Options> {
     if (isInformationalRule(this.#rule)) {
       throw new Error('Cannot define rule function for this type of rule.');
@@ -234,7 +235,7 @@ class RuleBuilder<
   overrideTest(
     fn: RuleTypes extends ['informational']
       ? never
-      : RuleFn<HttpTestApiContext, Options>
+      : RuleFn<HttpTestApiContext, Options>,
   ): DefineRules<RuleTypes, Options> {
     if (isInformationalRule(this.#rule)) {
       throw new Error('Cannot define rule function for this type of rule.');

--- a/plugins/http-linter/src/rule-filter.ts
+++ b/plugins/http-linter/src/rule-filter.ts
@@ -4,7 +4,7 @@ import type { Rule } from './rule/rule.js';
 export type RuleFilter = (rule: Rule) => boolean;
 
 export function createRuleFilter(
-  filters: HttpLinterPluginOptions['ruleFilter']
+  filters: HttpLinterPluginOptions['ruleFilter'],
 ): RuleFilter {
   const ruleFilters: RuleFilter[] = [];
 
@@ -13,15 +13,16 @@ export function createRuleFilter(
   if (severity) {
     ruleFilters.push(
       (rule) =>
-        severityLevelValues[rule.meta.severity] <= severityLevelValues[severity]
+        severityLevelValues[rule.meta.severity] <=
+        severityLevelValues[severity],
     );
   }
 
   if (appliesTo) {
     ruleFilters.push((rule) =>
       appliesTo.some((role) =>
-        rule.meta.appliesTo ? rule.meta.appliesTo.includes(role) : true
-      )
+        rule.meta.appliesTo ? rule.meta.appliesTo.includes(role) : true,
+      ),
     );
   }
 

--- a/plugins/http-linter/src/rule/rule-fn.ts
+++ b/plugins/http-linter/src/rule/rule-fn.ts
@@ -7,9 +7,9 @@ export type RuleFnResult = undefined | RuleViolation | RuleViolation[];
 
 export type RuleFn<
   Context extends ApiContext,
-  Options extends Record<PropertyKey, unknown>
+  Options extends Record<PropertyKey, unknown>,
 > = (
   context: Context,
   options: Options & { mode: 'static' | 'analytics' | 'test' },
-  logger: Logger
+  logger: Logger,
 ) => RuleFnResult | Promise<RuleFnResult>;

--- a/plugins/http-linter/src/rule/rule.ts
+++ b/plugins/http-linter/src/rule/rule.ts
@@ -5,7 +5,7 @@ import type { RuleFn } from './rule-fn.js';
 import type { RuleMeta } from './rule-meta.js';
 
 export type Rule<
-  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > = {
   staticRule?: RuleFn<StaticApiContext, Options>;
   analyticsRule?: RuleFn<AnalyticsApiContext, Options>;

--- a/plugins/http-linter/test/api-context/analytics-api-context.test.ts
+++ b/plugins/http-linter/test/api-context/analytics-api-context.test.ts
@@ -26,7 +26,7 @@ describe('AnalyticsApiContext', () => {
   let transactions!: [
     [string, string, string],
     [string, string, string],
-    [string, string, string]
+    [string, string, string],
   ];
 
   beforeEach(async () => {
@@ -68,7 +68,7 @@ describe('AnalyticsApiContext', () => {
           mediaType: 'application/json',
           statusCode: 200,
           type: 'http-response',
-        }
+        },
       ),
       format.addHttpTransaction(
         {
@@ -97,7 +97,7 @@ describe('AnalyticsApiContext', () => {
           mediaType: 'application/json',
           statusCode: 200,
           type: 'http-response',
-        }
+        },
       ),
       format.addHttpTransaction(
         {
@@ -126,7 +126,7 @@ describe('AnalyticsApiContext', () => {
           mediaType: 'application/json',
           statusCode: 200,
           type: 'http-response',
-        }
+        },
       ),
     ];
   });
@@ -136,7 +136,7 @@ describe('AnalyticsApiContext', () => {
 
     const results = analytics.validateCommonHttpTransactions(
       and(or(method('get'), method('head')), statusCode(200)),
-      not(or(responseHeader('etag'), responseHeader('last-modified')))
+      not(or(responseHeader('etag'), responseHeader('last-modified'))),
     );
 
     expect(results).toHaveLength(1);
@@ -166,7 +166,7 @@ describe('AnalyticsApiContext', () => {
             },
           };
         }
-      }
+      },
     );
 
     expect(results).toHaveLength(1);

--- a/plugins/http-linter/test/db/http-transaction-repository.test.ts
+++ b/plugins/http-linter/test/db/http-transaction-repository.test.ts
@@ -87,19 +87,19 @@ describe('HttpTransactionRepository', () => {
     const id = repo.insertHttpTransaction(req, res);
     const row = repo.db
       .prepare(
-        `SELECT request_id, response_id FROM http_transaction WHERE id = ?`
+        `SELECT request_id, response_id FROM http_transaction WHERE id = ?`,
       )
       .get(id) as { request_id: number; response_id: number };
 
     const reqHeaderCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_request_header WHERE request_id = ? AND name = 'x-flag'`
+        `SELECT COUNT(1) as cnt FROM http_request_header WHERE request_id = ? AND name = 'x-flag'`,
       )
       .get(row.request_id) as { cnt: number };
 
     const resHeaderCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_response_header WHERE response_id = ? AND name = 'vary'`
+        `SELECT COUNT(1) as cnt FROM http_response_header WHERE response_id = ? AND name = 'vary'`,
       )
       .get(row.response_id) as { cnt: number };
 
@@ -133,7 +133,7 @@ describe('HttpTransactionRepository', () => {
 
     const trailerCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_response_trailer WHERE response_id = ?`
+        `SELECT COUNT(1) as cnt FROM http_response_trailer WHERE response_id = ?`,
       )
       .get(row.response_id) as { cnt: number };
 
@@ -165,7 +165,7 @@ describe('HttpTransactionRepository', () => {
 
     const qpRows = repo.db
       .prepare(
-        `SELECT name, value FROM http_request_query_parameter WHERE request_id = ? ORDER BY id`
+        `SELECT name, value FROM http_request_query_parameter WHERE request_id = ? ORDER BY id`,
       )
       .all(row.request_id) as Array<{ name: string; value: string }>;
 
@@ -198,25 +198,25 @@ describe('HttpTransactionRepository', () => {
 
     const row = repo.db
       .prepare(
-        `SELECT request_id, response_id FROM http_transaction WHERE id = ?`
+        `SELECT request_id, response_id FROM http_transaction WHERE id = ?`,
       )
       .get(id) as { request_id: number; response_id: number };
 
     const reqHeaderCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_request_header WHERE request_id = ?`
+        `SELECT COUNT(1) as cnt FROM http_request_header WHERE request_id = ?`,
       )
       .get(row.request_id) as { cnt: number };
 
     const resHeaderCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_response_header WHERE response_id = ?`
+        `SELECT COUNT(1) as cnt FROM http_response_header WHERE response_id = ?`,
       )
       .get(row.response_id) as { cnt: number };
 
     const qpCount = repo.db
       .prepare(
-        `SELECT COUNT(1) as cnt FROM http_request_query_parameter WHERE request_id = ?`
+        `SELECT COUNT(1) as cnt FROM http_request_query_parameter WHERE request_id = ?`,
       )
       .get(row.request_id) as { cnt: number };
 

--- a/plugins/http-linter/test/load-rules.test.ts
+++ b/plugins/http-linter/test/load-rules.test.ts
@@ -8,7 +8,7 @@ vitest.mock('./import-meta-resolve.ts', () => ({
     .fn()
     .mockImplementation(
       (specifier) =>
-        `file://${createRequire(import.meta.url).resolve(specifier)}`
+        `file://${createRequire(import.meta.url).resolve(specifier)}`,
     ),
 }));
 

--- a/plugins/http-linter/tsconfig.lib.json
+++ b/plugins/http-linter/tsconfig.lib.json
@@ -11,7 +11,7 @@
     "importHelpers": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["node"],
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "src/**/*.sql"],
   "references": [

--- a/plugins/openapi/src/cli/init-hook.ts
+++ b/plugins/openapi/src/cli/init-hook.ts
@@ -42,7 +42,7 @@ export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
 }
 
 const hook: ThymianPluginInitHook<OpenApiPluginOptions> = async function (
-  opts
+  opts,
 ) {
   if (opts.interactive) {
     return runPrompts(async () => {

--- a/plugins/openapi/src/index.ts
+++ b/plugins/openapi/src/index.ts
@@ -38,7 +38,7 @@ declare module '@thymian/core' {
   interface ThymianFormat {
     getNodeByExtension(
       extensionName: 'openapi',
-      values: { operationId: string }
+      values: { operationId: string },
     ): ThymianNode | undefined;
   }
 

--- a/plugins/openapi/src/load-openapi.ts
+++ b/plugins/openapi/src/load-openapi.ts
@@ -22,7 +22,7 @@ export type ParseOpenApiOptions = {
 // There are a lot of problems with the @scalar/openapi-parser package. We should investigate further
 export async function loadOpenapi(
   logger: Logger,
-  options: ParseOpenApiOptions
+  options: ParseOpenApiOptions,
 ): Promise<[ThymianFormat, OpenAPI.Document]> {
   const plugins = [];
 
@@ -49,7 +49,7 @@ export async function loadOpenapi(
         suggestions: [
           `Does the file ${join(process.cwd(), options.filePath)} exist?`,
         ],
-      }
+      },
     );
   }
   try {
@@ -60,7 +60,7 @@ export async function loadOpenapi(
       `Invalid OpenAPI document from path "${options.filePath}".`,
       {
         cause,
-      }
+      },
     );
   }
 
@@ -71,7 +71,7 @@ export async function loadOpenapi(
       `Cannot upgrade OpenAPI document from path "${options.filePath}".`,
       {
         cause,
-      }
+      },
     );
   }
 
@@ -83,7 +83,7 @@ export async function loadOpenapi(
       {
         cause,
         suggestions: [`Are all external references valid AND available?`],
-      }
+      },
     );
   }
 
@@ -98,7 +98,7 @@ export async function loadOpenapi(
           suggestions: [
             "This might be because some parts of the Swagger/OpenAPI document couldn't be migrated automatically. It's best to migrate to the next version manually.",
           ],
-        }
+        },
       );
     }
   }
@@ -107,7 +107,7 @@ export async function loadOpenapi(
 
   return [
     new OpenapiProcessor(logger, options.serverInfo, locMapper).process(
-      current
+      current,
     ),
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     document!,

--- a/plugins/openapi/src/loc-mapper/json-loc-mapper.ts
+++ b/plugins/openapi/src/loc-mapper/json-loc-mapper.ts
@@ -13,7 +13,7 @@ export class JsonLocMapper extends LocMapper {
   }
 
   public positionForOperationId(
-    operationId: string
+    operationId: string,
   ): SourcePosition | undefined {
     if (!this.root) return undefined;
 
@@ -36,7 +36,7 @@ export class JsonLocMapper extends LocMapper {
 
   private findOperationIdProperty(
     node: JsonNode,
-    wanted: string
+    wanted: string,
   ): JsonNode | undefined {
     const stack: JsonNode[] = [node];
     while (stack.length) {

--- a/plugins/openapi/src/loc-mapper/loc-mapper.ts
+++ b/plugins/openapi/src/loc-mapper/loc-mapper.ts
@@ -7,11 +7,11 @@ export type SourcePosition = {
 export abstract class LocMapper {
   protected constructor(
     protected readonly text: string,
-    protected readonly path: string
+    protected readonly path: string,
   ) {}
 
   abstract positionForOperationId(
-    operationId: string
+    operationId: string,
   ): SourcePosition | undefined;
 
   locationForOperationId(operationId: string): string | undefined {

--- a/plugins/openapi/src/loc-mapper/yaml-loc-mapper.ts
+++ b/plugins/openapi/src/loc-mapper/yaml-loc-mapper.ts
@@ -34,7 +34,7 @@ export class YamlLocMapper extends LocMapper {
   }
 
   public positionForOperationId(
-    operationId: string
+    operationId: string,
   ): SourcePosition | undefined {
     const pathsMap = this.getTopLevelMap('paths');
     if (!pathsMap) return undefined;
@@ -58,7 +58,7 @@ export class YamlLocMapper extends LocMapper {
         const opIdPair = this.findStringProperty(
           opObj,
           'operationId',
-          operationId
+          operationId,
         );
         if (opIdPair) {
           const methodKeyNode = methodPair.key as Scalar | undefined;
@@ -95,7 +95,7 @@ export class YamlLocMapper extends LocMapper {
   private findStringProperty(
     map: YAMLMap,
     propName: string,
-    expectedValue?: string
+    expectedValue?: string,
   ): Pair | null {
     for (const p of map.items as Pair[]) {
       const keyVal = (p.key as Scalar | undefined)?.value;

--- a/plugins/openapi/src/processors/extract-server-info.ts
+++ b/plugins/openapi/src/processors/extract-server-info.ts
@@ -16,7 +16,7 @@ export const defaultServerInfo: ServerInfo = {
 
 export function extractServerInfo(
   serverObjects: OpenApiV31.ServerObject[] = [],
-  defaultInfo: ServerInfo = defaultServerInfo
+  defaultInfo: ServerInfo = defaultServerInfo,
 ): ServerInfo {
   const serverInfo: ServerInfo = {
     ...defaultInfo,
@@ -40,7 +40,7 @@ export function extractServerInfo(
         }
 
         return match;
-      }
+      },
     );
 
     try {
@@ -50,11 +50,11 @@ export function extractServerInfo(
       serverInfo.port = url.port
         ? parseInt(url.port)
         : url.protocol === 'https:'
-        ? 443
-        : 80;
+          ? 443
+          : 80;
       serverInfo.protocol = url.protocol.replace(
         ':',
-        ''
+        '',
       ) as ServerInfo['protocol'];
       serverInfo.basePath = url.pathname;
     } catch (_) {

--- a/plugins/openapi/src/processors/headers-object.processor.ts
+++ b/plugins/openapi/src/processors/headers-object.processor.ts
@@ -6,7 +6,7 @@ import { processParameterObject } from './parameter-object.processor.js';
 export function processHeadersObject(
   headersObject: Record<string, OpenApiV31.HeaderObject> | undefined,
   // https://swagger.io/specification/v3/#response-object
-  ignoreContentTypeHeader = true
+  ignoreContentTypeHeader = true,
 ): Record<string, Parameter> {
   return Object.entries(headersObject ?? {}).reduce(
     (acc, [name, headerObject]) => {
@@ -25,6 +25,6 @@ export function processHeadersObject(
         [name]: parameter,
       };
     },
-    {} as Record<string, Parameter>
+    {} as Record<string, Parameter>,
   );
 }

--- a/plugins/openapi/src/processors/json-schema.processor.ts
+++ b/plugins/openapi/src/processors/json-schema.processor.ts
@@ -43,7 +43,7 @@ export function processSchema(schema: Draft202012SchemaObject): ThymianSchema {
 
       if (!Array.isArray(node.examples)) {
         throw new Error(
-          `Property "examples" must be an array but got type ${typeof node.examples}.`
+          `Property "examples" must be an array but got type ${typeof node.examples}.`,
         );
       }
 
@@ -59,7 +59,7 @@ export function processSchema(schema: Draft202012SchemaObject): ThymianSchema {
 
 export function addExampleToSchema(
   schema: ThymianSchema,
-  example: unknown
+  example: unknown,
 ): ThymianSchema {
   if (isRecord(schema) && typeof example !== 'undefined') {
     (schema.examples ??= []).push(example);

--- a/plugins/openapi/src/processors/link-object.processor.ts
+++ b/plugins/openapi/src/processors/link-object.processor.ts
@@ -8,7 +8,7 @@ import {
 
 export function findPartsInRequest(
   req: ThymianHttpRequest,
-  name: string
+  name: string,
 ): string[] {
   const parts = [];
 
@@ -33,7 +33,7 @@ export function findPartsInRequest(
 
 export function processLinkObjectParameters(
   parameters: Record<string, unknown | RunExpression> | undefined,
-  req: ThymianHttpRequest
+  req: ThymianHttpRequest,
 ): Pick<
   HttpLink,
   'pathParameters' | 'queryParameters' | 'headers' | 'cookies'

--- a/plugins/openapi/src/processors/media-type-object.processor.ts
+++ b/plugins/openapi/src/processors/media-type-object.processor.ts
@@ -15,21 +15,21 @@ import {
 } from './json-schema.processor.js';
 
 export function extractSerializationStyle(
-  encodingObj: OpenApiV31.EncodingObject
+  encodingObj: OpenApiV31.EncodingObject,
 ): SerializationStyle {
   const style = encodingObj.style ?? 'form';
   const explode = encodingObj.explode ?? style === 'form';
 
   return new SerializationStyleBuilder(
     style as SerializationStyle['style'],
-    explode
+    explode,
   ).build();
 }
 
 export function processMediaTypeObject(
   mediaTypeObject: OpenApiV31.MediaTypeObject,
   addEncodings = false,
-  isMultipart = false
+  isMultipart = false,
 ): {
   schema?: ThymianSchema;
   headers: Record<string, Parameter>;
@@ -49,7 +49,7 @@ export function processMediaTypeObject(
   if (isMultipart && mediaTypeObject.encoding) {
     Object.values(mediaTypeObject.encoding).forEach((encodingObject) => {
       headers = processHeadersObject(
-        encodingObject.headers as Record<string, OpenApiV31.HeaderObject>
+        encodingObject.headers as Record<string, OpenApiV31.HeaderObject>,
       );
     });
   }
@@ -74,12 +74,12 @@ export function processMediaTypeObject(
         [propertyName]: {
           contentType: encodingObj.contentType,
           headers: processHeadersObject(
-            encodingObj.headers as Record<string, OpenApiV31.HeaderObject>
+            encodingObj.headers as Record<string, OpenApiV31.HeaderObject>,
           ),
           serializationStyle: extractSerializationStyle(encodingObj),
         },
       }),
-      {} as Encoding
+      {} as Encoding,
     );
   }
 

--- a/plugins/openapi/src/processors/openapi.processor.ts
+++ b/plugins/openapi/src/processors/openapi.processor.ts
@@ -51,7 +51,7 @@ export class OpenapiProcessor {
   constructor(
     private readonly logger: Logger,
     private readonly options: OpenapiV30ParserOptions,
-    private readonly locMapper: LocMapper
+    private readonly locMapper: LocMapper,
   ) {}
 
   private processLinkObject(linkObjectToProcess: LinkObjectToProcess): void {
@@ -63,7 +63,7 @@ export class OpenapiProcessor {
       (id, attributes) =>
         isNodeType(attributes, 'http-request') &&
         attributes.extensions?.openapi?.operationId ===
-          linkObjectToProcess.linkObj.operationId
+          linkObjectToProcess.linkObj.operationId,
     );
 
     linkObjectToProcess.responseIds.forEach((resId) => {
@@ -71,7 +71,7 @@ export class OpenapiProcessor {
         this.format.addHttpLink(resId, reqId, {
           ...processLinkObjectParameters(
             linkObjectToProcess.linkObj.parameters,
-            this.format.getNode(reqId) as ThymianHttpRequest
+            this.format.getNode(reqId) as ThymianHttpRequest,
           ),
         });
       });
@@ -83,26 +83,26 @@ export class OpenapiProcessor {
     params: Parameters,
     method: string,
     path: string,
-    serverInfo: ServerInfo
+    serverInfo: ServerInfo,
   ): void {
     if (operationObject.deprecated) {
       this.logger.debug(
         `Operation with id "${
           operationObject.operationId ?? '(no operationId provided)'
-        }" is deprecated but still used by Thymian.`
+        }" is deprecated but still used by Thymian.`,
       );
     }
 
     const parameters = mergeParameters(
       params,
       processParameterObjects(
-        operationObject.parameters as OpenApiV31.ParameterObject[]
-      )
+        operationObject.parameters as OpenApiV31.ParameterObject[],
+      ),
     );
 
     const operationServerInfo = extractServerInfo(
       operationObject.servers,
-      serverInfo
+      serverInfo,
     );
 
     const requests = processRequestBodyObjet(
@@ -116,19 +116,19 @@ export class OpenapiProcessor {
         operationId: operationObject.operationId,
         method,
         path: join(operationServerInfo.basePath, path),
-      }
+      },
     );
     const responsesAndLinks = processResponsesObject(
       operationObject.responses,
-      parameters
+      parameters,
     );
 
     const securitySchemes = this.globalSecuritySchemes.length
       ? this.globalSecuritySchemes
       : operationObject.security?.length
-      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        operationObject.security.map((sec) => Object.keys(sec)[0]!)
-      : [];
+        ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          operationObject.security.map((sec) => Object.keys(sec)[0]!)
+        : [];
 
     for (const req of requests) {
       const reqId = this.format.addRequest(req);
@@ -141,7 +141,7 @@ export class OpenapiProcessor {
               openapi: {
                 location: operationObject.operationId
                   ? this.locMapper.locationForOperationId(
-                      operationObject.operationId
+                      operationObject.operationId,
                     )
                   : undefined,
               },
@@ -175,7 +175,7 @@ export class OpenapiProcessor {
       (document.components?.securitySchemes as Record<
         string,
         OpenApiV31.SecuritySchemeObject
-      >) ?? {}
+      >) ?? {},
     );
 
     securitySchemes.forEach((scheme) => {
@@ -199,7 +199,7 @@ export class OpenapiProcessor {
       }
 
       const parameters = processParameterObjects(
-        pathItem.parameters as OpenApiV31.ParameterObject[] | undefined
+        pathItem.parameters as OpenApiV31.ParameterObject[] | undefined,
       );
 
       for (const [method, op] of Object.entries(pathItem)) {
@@ -210,7 +210,7 @@ export class OpenapiProcessor {
         const operation = op as OpenApiV31.OperationObject;
 
         const operationParameters = processParameterObjects(
-          operation.parameters as OpenApiV31.ParameterObject[]
+          operation.parameters as OpenApiV31.ParameterObject[],
         );
 
         this.processOperationObject(
@@ -218,13 +218,13 @@ export class OpenapiProcessor {
           mergeParameters(parameters, operationParameters),
           method,
           path,
-          serverInfo
+          serverInfo,
         );
       }
     }
 
     this.linkObjects.forEach((linkToProcess) =>
-      this.processLinkObject(linkToProcess)
+      this.processLinkObject(linkToProcess),
     );
 
     return this.format;

--- a/plugins/openapi/src/processors/parameter-object.processor.ts
+++ b/plugins/openapi/src/processors/parameter-object.processor.ts
@@ -18,7 +18,7 @@ import { processMediaTypeObject } from './media-type-object.processor.js';
 import type { Parameters } from './utils.js';
 
 export function processParameterObjects(
-  parameterObjects: OpenApiV31.ParameterObject[] | undefined
+  parameterObjects: OpenApiV31.ParameterObject[] | undefined,
 ): Parameters {
   const parameters: Parameters = {
     headers: {},
@@ -49,21 +49,21 @@ export function processParameterObjects(
 }
 
 export function processParameterObject(
-  parameterObject: OpenApiV31.ParameterObject
+  parameterObject: OpenApiV31.ParameterObject,
 ): [string, Parameter] {
   let thymianSchema: ThymianSchema;
   let parameterContentType: string | undefined;
 
   if (parameterObject.schema) {
     thymianSchema = processSchema(
-      parameterObject.schema as Draft202012SchemaObject
+      parameterObject.schema as Draft202012SchemaObject,
     );
   } else if (parameterObject.content) {
     const entries = Object.entries(parameterObject.content);
 
     if (entries.length !== 1 || !entries[0]) {
       throw new Error(
-        'ParameterObject.content MUST contain exactly one entry.'
+        'ParameterObject.content MUST contain exactly one entry.',
       );
     }
 
@@ -76,14 +76,14 @@ export function processParameterObject(
     const { schema } = processMediaTypeObject(
       mediaTypeObject,
       addEncoding,
-      isMultipart
+      isMultipart,
     );
 
     if (!schema) {
       throw new Error(
         `${capitalizeFirstChar(parameterObject.in)} parameter "${
           parameterObject.name
-        }" object must define either a schema or a content property.`
+        }" object must define either a schema or a content property.`,
       );
     }
 
@@ -93,7 +93,7 @@ export function processParameterObject(
     throw new Error(
       `${capitalizeFirstChar(parameterObject.in)} parameter "${
         parameterObject.name
-      }" object must define either a schema or a content property.`
+      }" object must define either a schema or a content property.`,
     );
   }
 
@@ -102,7 +102,7 @@ export function processParameterObject(
   Object.values(parameterObject.examples ?? {}).forEach((example) => {
     addExampleToSchema(
       thymianSchema,
-      (example as OpenApiV31.ExampleObject).value
+      (example as OpenApiV31.ExampleObject).value,
     );
   });
 
@@ -112,19 +112,19 @@ export function processParameterObject(
           .withExplode(parameterObject.explode)
           .build()
       : parameterObject.in === 'query'
-      ? new QuerySerializationStyleBuilder()
-          .withStyle(parameterObject.style)
-          .withExplode(parameterObject.explode)
-          .build()
-      : parameterObject.in === 'path'
-      ? new PathSerializationStyleBuilder()
-          .withStyle(parameterObject.style)
-          .withExplode(parameterObject.explode)
-          .build()
-      : new CookieSerializationStyleBuilder()
-          .withStyle(parameterObject.style)
-          .withExplode(parameterObject.explode)
-          .build();
+        ? new QuerySerializationStyleBuilder()
+            .withStyle(parameterObject.style)
+            .withExplode(parameterObject.explode)
+            .build()
+        : parameterObject.in === 'path'
+          ? new PathSerializationStyleBuilder()
+              .withStyle(parameterObject.style)
+              .withExplode(parameterObject.explode)
+              .build()
+          : new CookieSerializationStyleBuilder()
+              .withStyle(parameterObject.style)
+              .withExplode(parameterObject.explode)
+              .build();
 
   const param: Parameter = {
     required: parameterObject.required ?? false,

--- a/plugins/openapi/src/processors/request-body-object.processor.ts
+++ b/plugins/openapi/src/processors/request-body-object.processor.ts
@@ -16,7 +16,7 @@ export function processRequestBodyObjet(
     host: string;
     port: number;
     protocol: 'http' | 'https';
-  }
+  },
 ): PartialBy<ThymianHttpRequest, 'label'>[] {
   if (!requestBodyObject) {
     return [
@@ -44,7 +44,7 @@ export function processRequestBodyObjet(
       .filter(
         ([mediaType]) =>
           !/^multipart\/.*/i.test(mediaType) &&
-          mediaType !== 'application/x-www-form-urlencoded'
+          mediaType !== 'application/x-www-form-urlencoded',
       )
       .map(([mediaType, mediaTypeObject]) => {
         const isMultipart = /^multipart\/.*/i.test(mediaType);
@@ -54,7 +54,7 @@ export function processRequestBodyObjet(
         const { schema } = processMediaTypeObject(
           mediaTypeObject,
           addEncoding,
-          isMultipart
+          isMultipart,
         );
 
         const location = context.operationId

--- a/plugins/openapi/src/processors/response-object.processor.ts
+++ b/plugins/openapi/src/processors/response-object.processor.ts
@@ -13,13 +13,13 @@ export type ResponsesWithLinks = {
 export function processResponseObject(
   responseObject: OpenApiV31.ResponseObject,
   statusCode: number,
-  parameters: Parameters
+  parameters: Parameters,
 ): ResponsesWithLinks {
   const headerParameters = processHeadersObject(
-    responseObject.headers as Record<string, OpenApiV31.HeaderObject>
+    responseObject.headers as Record<string, OpenApiV31.HeaderObject>,
   );
   const links = Object.entries(responseObject.links ?? {}).map(
-    ([name, linkObj]) => ({ name, linkObj })
+    ([name, linkObj]) => ({ name, linkObj }),
   ) as { name: string; linkObj: OpenApiV31.LinkObject }[];
 
   const responses: PartialBy<ThymianHttpResponse, 'label'>[] = [];
@@ -30,7 +30,7 @@ export function processResponseObject(
         .filter(
           ([mediaType]) =>
             !/^multipart\/.*/i.test(mediaType) &&
-            mediaType !== 'application/x-www-form-urlencoded'
+            mediaType !== 'application/x-www-form-urlencoded',
         )
         .map(([mediaType, mediaTypeObject]) => {
           const { schema } = processMediaTypeObject(mediaTypeObject);
@@ -46,7 +46,7 @@ export function processResponseObject(
             statusCode,
             schema,
           } satisfies PartialBy<ThymianHttpResponse, 'label'>;
-        })
+        }),
     );
   } else {
     responses.push({

--- a/plugins/openapi/src/processors/responses-object.processor.ts
+++ b/plugins/openapi/src/processors/responses-object.processor.ts
@@ -13,7 +13,7 @@ import type { Parameters } from './utils.js';
 
 export function processResponsesObject(
   responsesObject: OpenApiV31.ResponsesObject | undefined,
-  parameters: Parameters
+  parameters: Parameters,
 ): ResponsesWithLinks[] {
   const responses: Record<
     string,
@@ -24,7 +24,7 @@ export function processResponsesObject(
   > = {};
 
   for (const [statusCode, responseObject] of Object.entries(
-    responsesObject ?? {}
+    responsesObject ?? {},
   )) {
     if (statusCode === 'default') {
       /* ignored */
@@ -36,7 +36,7 @@ export function processResponsesObject(
           responses[strCode] = processResponseObject(
             responseObject as OpenApiV31.ResponseObject,
             code,
-            parameters
+            parameters,
           );
         }
       });
@@ -45,14 +45,14 @@ export function processResponsesObject(
 
       if (statusCodeNumber < 100 || statusCodeNumber > 599) {
         throw new Error(
-          `Invalid status code. Status code must be a valid http status code or status code range (e.g. 2XX), but is ${statusCode}.`
+          `Invalid status code. Status code must be a valid http status code or status code range (e.g. 2XX), but is ${statusCode}.`,
         );
       }
 
       responses[statusCode] = processResponseObject(
         responseObject as OpenApiV31.ResponseObject,
         statusCodeNumber,
-        parameters
+        parameters,
       );
     }
   }

--- a/plugins/openapi/src/processors/runtime-expression.processor.ts
+++ b/plugins/openapi/src/processors/runtime-expression.processor.ts
@@ -1,7 +1,7 @@
 import type { RunExpression } from '../runtime-expression.js';
 
 export function processOpenApiRuntimeExpression(
-  expression: RunExpression
+  expression: RunExpression,
 ): string {
   if (expression === '$url') {
     return '$request/url';
@@ -27,7 +27,7 @@ export function processOpenApiRuntimeExpression(
 }
 
 export function isOpenApiRuntimeExpression(
-  expression: unknown
+  expression: unknown,
 ): expression is RunExpression {
   return (
     typeof expression === 'string' &&

--- a/plugins/openapi/src/processors/security-scheme-object.processor.ts
+++ b/plugins/openapi/src/processors/security-scheme-object.processor.ts
@@ -8,7 +8,7 @@ import type {
 import type { OpenAPIV3_1 as OpenApiV31 } from 'openapi-types';
 
 export function processSecuritySchemes(
-  schemes: Record<string, OpenApiV31.SecuritySchemeObject>
+  schemes: Record<string, OpenApiV31.SecuritySchemeObject>,
 ): PartialBy<SecurityScheme, 'label'>[] {
   return Object.entries(schemes)
     .filter(([, scheme]) => scheme.type === 'http' || scheme.type === 'apiKey')
@@ -51,7 +51,7 @@ export function processSecuritySchemes(
         }
       } else {
         throw new Error(
-          'Property "scheme" is required for security scheme type "http".'
+          'Property "scheme" is required for security scheme type "http".',
         );
       }
     });

--- a/plugins/openapi/test/fixtures/circular-reference.yml
+++ b/plugins/openapi/test/fixtures/circular-reference.yml
@@ -6,16 +6,16 @@ paths:
   /test:
     get:
       responses:
-        "200":
+        '200':
           description: foobar
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Test"
+                $ref: '#/components/schemas/Test'
 components:
   schemas:
     Test:
       type: object
       properties:
         test:
-          $ref: "#/components/schemas/Test"
+          $ref: '#/components/schemas/Test'

--- a/plugins/openapi/test/fixtures/swagger_with_global_and_path_parameters.json
+++ b/plugins/openapi/test/fixtures/swagger_with_global_and_path_parameters.json
@@ -1,8 +1,6 @@
 {
   "swagger": "2.0",
-  "produces": [
-    "application/json"
-  ],
+  "produces": ["application/json"],
   "parameters": {
     "globalHeader": {
       "description": "a global defined header",

--- a/plugins/openapi/test/load-openapi.test.ts
+++ b/plugins/openapi/test/load-openapi.test.ts
@@ -14,7 +14,7 @@ describe('loadOpenapi', () => {
           fetchExternalRefs: false,
           filePath: join(
             import.meta.dirname,
-            'fixtures/circular-reference.yml'
+            'fixtures/circular-reference.yml',
           ),
           serverInfo: {
             port: 8080,
@@ -22,7 +22,7 @@ describe('loadOpenapi', () => {
             basePath: '',
             protocol: 'http',
           },
-        })
+        }),
     ).not.toThrowError();
   });
 });

--- a/plugins/openapi/test/processors/headers-object.processor.test.ts
+++ b/plugins/openapi/test/processors/headers-object.processor.test.ts
@@ -51,7 +51,7 @@ describe('processHeadersObject', () => {
           },
         },
       },
-      false
+      false,
     );
 
     expect(Object.keys(result)).toHaveLength(2);

--- a/plugins/request-dispatcher/src/decode-body.ts
+++ b/plugins/request-dispatcher/src/decode-body.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream';
 
 export function decodeBody(
   body?: string,
-  encoding?: string
+  encoding?: string,
 ): string | Buffer | Uint8Array | Readable | null {
   if (typeof body !== 'string') {
     return null;

--- a/plugins/request-dispatcher/src/dispatch.ts
+++ b/plugins/request-dispatcher/src/dispatch.ts
@@ -1,7 +1,8 @@
-import { request } from 'undici';
-import type { HttpMethod } from './types.js';
-import { decodeBody } from './decode-body.js';
 import type { HttpRequest, HttpResponse } from '@thymian/core';
+import { request } from 'undici';
+
+import { decodeBody } from './decode-body.js';
+import type { HttpMethod } from './types.js';
 
 export function isValidHttpMethod(method: string): method is HttpMethod {
   return [
@@ -23,7 +24,7 @@ export type HttpRequestDispatchOptions = {
 
 export async function dispatchHttpRequest(
   httpRequest: HttpRequest,
-  options: Partial<HttpRequestDispatchOptions> = {}
+  options: Partial<HttpRequestDispatchOptions> = {},
 ): Promise<HttpResponse> {
   const opts = {
     timeout: 5000,
@@ -46,7 +47,7 @@ export async function dispatchHttpRequest(
       body: decodeBody(httpRequest.body, httpRequest.bodyEncoding),
       bodyTimeout: opts.timeout,
       headersTimeout: opts.timeout,
-    }
+    },
   );
 
   const res: HttpResponse = {

--- a/plugins/request-dispatcher/src/index.ts
+++ b/plugins/request-dispatcher/src/index.ts
@@ -1,15 +1,16 @@
 import {
-  type ThymianPlugin,
-  type HttpResponse,
   type HttpRequest,
+  type HttpResponse,
   type JSONSchemaType,
   ThymianBaseError,
+  type ThymianPlugin,
 } from '@thymian/core';
-import { httpResponseSchema } from './types.js';
+
 import {
   dispatchHttpRequest,
   type HttpRequestDispatchOptions,
 } from './dispatch.js';
+import { httpResponseSchema } from './types.js';
 
 declare module '@thymian/core' {
   interface ThymianActions {
@@ -101,11 +102,11 @@ export const dispatcherPlugin: ThymianPlugin = {
               `Error while dispatching request: ${request.method.toUpperCase()} ${
                 request.origin
               }.`,
-              { cause: e }
-            )
+              { cause: e },
+            ),
           );
         }
-      }
+      },
     );
   },
 };

--- a/plugins/sampler/src/content-generator/content-generator.ts
+++ b/plugins/sampler/src/content-generator/content-generator.ts
@@ -15,12 +15,12 @@ export type ContentGeneratorResult =
 export class ContentGenerator {
   constructor(
     private readonly strategies: ContentTypeStrategy[],
-    private readonly fallbackStrategy: ContentTypeStrategy
+    private readonly fallbackStrategy: ContentTypeStrategy,
   ) {}
 
   generate(
     contentType: string,
-    schema: ThymianSchema
+    schema: ThymianSchema,
   ): Promise<ContentGeneratorResult> {
     const strategy =
       this.strategies.find((strategy) => strategy.matches(contentType)) ??

--- a/plugins/sampler/src/content-generator/content-type-strategy.ts
+++ b/plugins/sampler/src/content-generator/content-type-strategy.ts
@@ -7,6 +7,6 @@ export interface ContentTypeStrategy {
 
   generate(
     schema: ThymianSchema,
-    contentType: string
+    contentType: string,
   ): Promise<ContentGeneratorResult>;
 }

--- a/plugins/sampler/src/content-generator/hook.content-type-strategy.ts
+++ b/plugins/sampler/src/content-generator/hook.content-type-strategy.ts
@@ -16,7 +16,7 @@ export class HookContentTypeStrategy implements ContentTypeStrategy {
 
   async generate(
     schema: ThymianSchema,
-    contentType: string
+    contentType: string,
   ): Promise<ContentGeneratorResult> {
     const content = await this.emitter.emitAction(
       'sampler.unknown-type',
@@ -26,12 +26,12 @@ export class HookContentTypeStrategy implements ContentTypeStrategy {
       },
       {
         strategy: 'first',
-      }
+      },
     );
 
     if (!content) {
       throw new ThymianBaseError(
-        `Cannot sample data for content type ${contentType}.`
+        `Cannot sample data for content type ${contentType}.`,
       );
     }
 

--- a/plugins/sampler/src/content-generator/image.content-type-strategy.ts
+++ b/plugins/sampler/src/content-generator/image.content-type-strategy.ts
@@ -26,7 +26,7 @@ export class ImageContentTypeStrategy implements ContentTypeStrategy {
   }
   async generate(
     schema: ThymianSchema,
-    contentType: string
+    contentType: string,
   ): Promise<ContentGeneratorResult> {
     let content = sharp(this.randomPixelsBuffer(), {
       raw: {

--- a/plugins/sampler/src/content-generator/xml.content-type-strategy.ts
+++ b/plugins/sampler/src/content-generator/xml.content-type-strategy.ts
@@ -16,7 +16,7 @@ export class XmlContentTypeStrategy implements ContentTypeStrategy {
       encoding: 'utf-8',
       ext: 'xml',
       buffer: Buffer.from(
-        sample(schema as SamplerSchema, { format: 'xml' }) as string
+        sample(schema as SamplerSchema, { format: 'xml' }) as string,
       ),
     };
   }

--- a/plugins/sampler/src/index.ts
+++ b/plugins/sampler/src/index.ts
@@ -107,7 +107,7 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
           new XmlContentTypeStrategy(),
           new ImageContentTypeStrategy(),
         ],
-        new HookContentTypeStrategy(emitter)
+        new HookContentTypeStrategy(emitter),
       );
 
       const outputWriter = new FileOutputWriter(basePath, opts.forceOverride);
@@ -118,7 +118,7 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
           parsedFormat,
           transaction,
           contentGenerator,
-          outputWriter
+          outputWriter,
         );
       }
 

--- a/plugins/sampler/src/output-writer/create-path-for-transaction.ts
+++ b/plugins/sampler/src/output-writer/create-path-for-transaction.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import type { ThymianHttpTransaction } from '@thymian/core';
 
 export function createPathForTransaction(
-  transaction: ThymianHttpTransaction
+  transaction: ThymianHttpTransaction,
 ): string {
   const paths: string[] = [];
 
@@ -13,8 +13,8 @@ export function createPathForTransaction(
     ...transaction.thymianReq.path
       .split('/')
       .map((part) =>
-        /^\{.*}$/.test(part) ? '_' + part.substring(1, part.length - 1) : part
-      )
+        /^\{.*}$/.test(part) ? '_' + part.substring(1, part.length - 1) : part,
+      ),
   );
 
   if (transaction.thymianReq.mediaType) {

--- a/plugins/sampler/src/output-writer/file.output-writer.ts
+++ b/plugins/sampler/src/output-writer/file.output-writer.ts
@@ -15,17 +15,17 @@ export function hash(input: string): string {
 export class FileOutputWriter implements OutputWriter {
   constructor(
     private readonly basePath: string,
-    private readonly force: boolean
+    private readonly force: boolean,
   ) {}
 
   async writeAssetFor(
     value: Buffer,
     ext: string,
-    sample: HttpRequestSample
+    sample: HttpRequestSample,
   ): Promise<string> {
     const path = join(
       this.basePath,
-      createPathForTransaction(sample.meta.source)
+      createPathForTransaction(sample.meta.source),
     );
 
     await mkdir(path, { recursive: true });
@@ -46,7 +46,7 @@ export class FileOutputWriter implements OutputWriter {
   async writeSample(sample: HttpRequestSample): Promise<string> {
     const path = join(
       this.basePath,
-      createPathForTransaction(sample.meta.source)
+      createPathForTransaction(sample.meta.source),
     );
     await mkdir(path, { recursive: true });
 

--- a/plugins/sampler/src/output-writer/output-writer.ts
+++ b/plugins/sampler/src/output-writer/output-writer.ts
@@ -5,6 +5,6 @@ export interface OutputWriter {
   writeAssetFor(
     buffer: Buffer,
     ext: string,
-    sample: HttpRequestSample
+    sample: HttpRequestSample,
   ): Promise<string>;
 }

--- a/plugins/sampler/src/request-generators/abstract-request-generator.ts
+++ b/plugins/sampler/src/request-generators/abstract-request-generator.ts
@@ -13,7 +13,7 @@ export abstract class AbstractRequestGenerator {
     protected readonly format: ThymianFormat,
     protected readonly transaction: ThymianHttpTransaction,
     protected readonly contentGenerator: ContentGenerator,
-    protected readonly writer: OutputWriter
+    protected readonly writer: OutputWriter,
   ) {}
 
   abstract matches(): boolean;
@@ -38,7 +38,7 @@ export abstract class AbstractRequestGenerator {
     if (this.shouldGenerateBody() && this.transaction.thymianReq.body) {
       const result = await this.contentGenerator.generate(
         this.transaction.thymianReq.mediaType,
-        this.transaction.thymianReq.body
+        this.transaction.thymianReq.body,
       );
 
       if ('buffer' in result) {
@@ -46,7 +46,7 @@ export abstract class AbstractRequestGenerator {
         requestSample.meta.bodyPath = await this.writer.writeAssetFor(
           result.buffer,
           result.ext,
-          requestSample
+          requestSample,
         );
       } else {
         requestSample.request.body = result.content;
@@ -78,14 +78,14 @@ export abstract class AbstractRequestGenerator {
   }
 
   protected async generateParameters(
-    parameters: Record<string, Parameter>
+    parameters: Record<string, Parameter>,
   ): Promise<Record<string, unknown>> {
     const generated = {} as Record<string, unknown>;
 
     for (const [name, parameter] of Object.entries(parameters)) {
       const result = await this.contentGenerator.generate(
         parameter.contentType ?? 'application/json',
-        parameter.schema
+        parameter.schema,
       );
 
       if ('buffer' in result) {
@@ -100,7 +100,7 @@ export abstract class AbstractRequestGenerator {
 
   protected async generateHeaders(): Promise<Record<string, unknown>> {
     const headers = await this.generateParameters(
-      this.transaction.thymianReq.headers
+      this.transaction.thymianReq.headers,
     );
 
     const { mediaType } = this.transaction.thymianReq;

--- a/plugins/sampler/src/request-generators/generate.ts
+++ b/plugins/sampler/src/request-generators/generate.ts
@@ -9,7 +9,7 @@ export async function generate(
   format: ThymianFormat,
   transaction: ThymianHttpTransaction,
   contentGenerator: ContentGenerator,
-  writer: OutputWriter
+  writer: OutputWriter,
 ): Promise<void> {
   const generators = [
     new RangeRequestGenerator(format, transaction, contentGenerator, writer),

--- a/plugins/sampler/src/sampler.ts
+++ b/plugins/sampler/src/sampler.ts
@@ -19,7 +19,7 @@ export class Sampler {
       HttpRequestTemplate
     > = new LRUCache({
       max: 500,
-    })
+    }),
   ) {}
 
   async checkIfIsInitialized(): Promise<void> {
@@ -35,7 +35,7 @@ export class Sampler {
   }
 
   async sample(
-    transaction: ThymianHttpTransaction
+    transaction: ThymianHttpTransaction,
   ): Promise<HttpRequestTemplate> {
     const transactionId = transaction.transactionId;
 
@@ -58,19 +58,19 @@ export class Sampler {
           name: 'SamplerError',
           suggestions: ['Did you run thymian sampler:init?'],
           cause: err,
-        }
+        },
       );
     }
 
     const requestSample = JSON.parse(
-      await readFile(filePath, 'utf-8')
+      await readFile(filePath, 'utf-8'),
     ) as HttpRequestSample;
 
     if (requestSample.meta.bodyPath) {
       const bodyFilePath = join(path, requestSample.meta.bodyPath);
       requestSample.request.body = await readFile(
         bodyFilePath,
-        (requestSample.request.bodyEncoding as BufferEncoding) ?? 'utf-8'
+        (requestSample.request.bodyEncoding as BufferEncoding) ?? 'utf-8',
       );
     }
 

--- a/plugins/sampler/test/request-generators/generate.test.ts
+++ b/plugins/sampler/test/request-generators/generate.test.ts
@@ -123,7 +123,7 @@ describe('generate', () => {
 
     const g = new ContentGenerator(
       [new XmlContentTypeStrategy()],
-      new ImageContentTypeStrategy()
+      new ImageContentTypeStrategy(),
     );
 
     const writer = new FileOutputWriter(join(import.meta.dirname, 'tmp'), true);

--- a/plugins/sampler/tsconfig.json
+++ b/plugins/sampler/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "files": [],
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts",
-  ],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
   "references": [
     {
       "path": "../../libs/cli-common"

--- a/shared/test-utils/src/create-fastify-request-runner.ts
+++ b/shared/test-utils/src/create-fastify-request-runner.ts
@@ -2,7 +2,7 @@ import type { HttpRequest, HttpResponse } from '@thymian/core';
 import type { FastifyInstance, InjectOptions } from 'fastify';
 
 export function createFastifyRequestRunner(
-  fastify: FastifyInstance
+  fastify: FastifyInstance,
 ): (req: HttpRequest) => Promise<HttpResponse> {
   return async (req: HttpRequest) => {
     const response = await fastify.inject({
@@ -17,21 +17,24 @@ export function createFastifyRequestRunner(
       duration: 0,
       body: response.payload,
       trailers: {},
-      headers: Object.entries(response.headers).reduce((acc, [name, value]) => {
-        if (Array.isArray(value)) {
-          return {
-            ...acc,
-            [name]: value.join(', '),
-          };
-        } else if (typeof value === 'string' || typeof value === 'number') {
-          return {
-            ...acc,
-            [name]: String(value),
-          };
-        } else {
-          return acc;
-        }
-      }, {} as Record<string, string>),
+      headers: Object.entries(response.headers).reduce(
+        (acc, [name, value]) => {
+          if (Array.isArray(value)) {
+            return {
+              ...acc,
+              [name]: value.join(', '),
+            };
+          } else if (typeof value === 'string' || typeof value === 'number') {
+            return {
+              ...acc,
+              [name]: String(value),
+            };
+          } else {
+            return acc;
+          }
+        },
+        {} as Record<string, string>,
+      ),
     };
   };
 }

--- a/shared/test-utils/src/example-app/app.ts
+++ b/shared/test-utils/src/example-app/app.ts
@@ -28,7 +28,7 @@ declare module 'fastify' {
 }
 
 export function buildExampleApp(
-  opts: FastifyServerOptions = { ignoreTrailingSlash: true }
+  opts: FastifyServerOptions = { ignoreTrailingSlash: true },
 ): FastifyInstance {
   const app = Fastify(opts);
 

--- a/shared/test-utils/src/example-app/plugins/reset-content.ts
+++ b/shared/test-utils/src/example-app/plugins/reset-content.ts
@@ -18,7 +18,7 @@ export default async function resetContent(fastify: FastifyInstance) {
     },
     (req, reply) => {
       return reply.status(205).send();
-    }
+    },
   );
 
   // response body must be empty
@@ -39,7 +39,7 @@ export default async function resetContent(fastify: FastifyInstance) {
     },
     (req, reply) => {
       return reply.status(205).send(req.body);
-    }
+    },
   );
 }
 

--- a/shared/test-utils/src/example-app/plugins/todos.ts
+++ b/shared/test-utils/src/example-app/plugins/todos.ts
@@ -129,9 +129,9 @@ export default function todos(_fastify: FastifyInstance) {
       res.code(200);
 
       return todos.filter((todo) =>
-        todo.title.toLowerCase().includes(req.query.title.toLowerCase())
+        todo.title.toLowerCase().includes(req.query.title.toLowerCase()),
       );
-    }
+    },
   );
 
   fastify.get(
@@ -171,7 +171,7 @@ export default function todos(_fastify: FastifyInstance) {
           .header('cache-control', 'private')
           .send(todo)
       );
-    }
+    },
   );
 
   fastify.post(
@@ -206,7 +206,7 @@ export default function todos(_fastify: FastifyInstance) {
       reply.status(201);
 
       return todo;
-    }
+    },
   );
 }
 

--- a/shared/test-utils/src/todo-app/app.ts
+++ b/shared/test-utils/src/todo-app/app.ts
@@ -27,7 +27,7 @@ export async function buildToDoApp(
     logger: {
       level: 'error',
     },
-  }
+  },
 ): Promise<FastifyInstance> {
   const app = Fastify(opts);
 

--- a/shared/test-utils/src/todo-app/plugins/projects/routes.ts
+++ b/shared/test-utils/src/todo-app/plugins/projects/routes.ts
@@ -19,7 +19,7 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
         },
       },
     },
-    async () => fastify.projects.getAll()
+    async () => fastify.projects.getAll(),
   );
 
   fastify.get(
@@ -42,7 +42,7 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
       if (!project)
         return reply.status(404).send({ error: 'Project not found' });
       return project;
-    }
+    },
   );
 
   fastify.post(
@@ -67,7 +67,7 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
       const project = fastify.projects.create(request.body);
 
       return reply.status(201).send(project);
-    }
+    },
   );
 
   fastify.delete(
@@ -92,7 +92,7 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
         return reply.status(404).send({ error: 'Project not found' });
 
       return reply.status(204).send();
-    }
+    },
   );
 
   fastify.post(
@@ -129,7 +129,7 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
       });
 
       return reply.status(201).send(todo);
-    }
+    },
   );
 
   fastify.get(
@@ -153,6 +153,6 @@ export default async function projectsRoutes(_fastify: FastifyInstance) {
     },
     async (request) => {
       return fastify.todos.getByProjectId(request.params.id);
-    }
+    },
   );
 }

--- a/shared/test-utils/src/todo-app/plugins/todos/routes.ts
+++ b/shared/test-utils/src/todo-app/plugins/todos/routes.ts
@@ -18,7 +18,7 @@ export default async function todosRoutes(_fastify: FastifyInstance) {
         },
       },
     },
-    async () => fastify.todos.getAll()
+    async () => fastify.todos.getAll(),
   );
 
   fastify.get(
@@ -45,7 +45,7 @@ export default async function todosRoutes(_fastify: FastifyInstance) {
       const todo = fastify.todos.getById(request.params.id);
       if (!todo) return reply.status(404).send({ error: 'ToDo not found' });
       return todo;
-    }
+    },
   );
 
   fastify.post(
@@ -73,7 +73,7 @@ export default async function todosRoutes(_fastify: FastifyInstance) {
       const todo = fastify.todos.create(request.body);
 
       return reply.status(201).send(todo);
-    }
+    },
   );
 
   fastify.put(
@@ -123,7 +123,7 @@ export default async function todosRoutes(_fastify: FastifyInstance) {
       }
 
       return todo;
-    }
+    },
   );
 
   fastify.delete(
@@ -147,6 +147,6 @@ export default async function todosRoutes(_fastify: FastifyInstance) {
       if (!success) return reply.status(404).send({ error: 'ToDo not found' });
 
       return reply.status(204).send();
-    }
+    },
   );
 }

--- a/shared/test-utils/src/todo-app/todo.openapi.yaml
+++ b/shared/test-utils/src/todo-app/todo.openapi.yaml
@@ -6,7 +6,7 @@ paths:
   /projects:
     get:
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -40,7 +40,7 @@ paths:
                 - name
         required: true
       responses:
-        "201":
+        '201':
           description: Default Response
           content:
             application/json:
@@ -57,7 +57,7 @@ paths:
                 required:
                   - id
                   - name
-        "400":
+        '400':
           description: Default Response
           content:
             application/json:
@@ -76,7 +76,7 @@ paths:
           name: id
           required: true
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -93,7 +93,7 @@ paths:
                 required:
                   - id
                   - name
-        "404":
+        '404':
           description: Default Response
           content:
             application/json:
@@ -110,9 +110,9 @@ paths:
           name: id
           required: true
       responses:
-        "204":
+        '204':
           description: Default Response
-        "404":
+        '404':
           description: Default Response
           content:
             application/json:
@@ -141,7 +141,7 @@ paths:
           name: id
           required: true
       responses:
-        "201":
+        '201':
           description: Default Response
           content:
             application/json:
@@ -157,13 +157,13 @@ paths:
                     type: boolean
                   projectId:
                     type:
-                      - "null"
+                      - 'null'
                       - string
                 required:
                   - id
                   - title
                   - done
-        "400":
+        '400':
           description: Default Response
           content:
             application/json:
@@ -180,7 +180,7 @@ paths:
           name: id
           required: true
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -198,7 +198,7 @@ paths:
                       type: boolean
                     projectId:
                       type:
-                        - "null"
+                        - 'null'
                         - string
                   required:
                     - id
@@ -207,7 +207,7 @@ paths:
   /todos:
     get:
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -225,7 +225,7 @@ paths:
                       type: boolean
                     projectId:
                       type:
-                        - "null"
+                        - 'null'
                         - string
                   required:
                     - id
@@ -245,7 +245,7 @@ paths:
                 - title
         required: true
       responses:
-        "201":
+        '201':
           description: Default Response
           content:
             application/json:
@@ -261,13 +261,13 @@ paths:
                     type: boolean
                   projectId:
                     type:
-                      - "null"
+                      - 'null'
                       - string
                 required:
                   - id
                   - title
                   - done
-        "400":
+        '400':
           description: Default Response
           content:
             application/json:
@@ -285,7 +285,7 @@ paths:
           name: id
           required: true
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -301,13 +301,13 @@ paths:
                     type: boolean
                   projectId:
                     type:
-                      - "null"
+                      - 'null'
                       - string
                 required:
                   - id
                   - title
                   - done
-        "404":
+        '404':
           description: Default Response
           content:
             application/json:
@@ -337,7 +337,7 @@ paths:
           name: id
           required: true
       responses:
-        "200":
+        '200':
           description: Default Response
           content:
             application/json:
@@ -353,13 +353,13 @@ paths:
                     type: boolean
                   projectId:
                     type:
-                      - "null"
+                      - 'null'
                       - string
                 required:
                   - id
                   - title
                   - done
-        "400":
+        '400':
           description: Default Response
           content:
             application/json:
@@ -368,7 +368,7 @@ paths:
                 properties:
                   error:
                     type: string
-        "404":
+        '404':
           description: Default Response
           content:
             application/json:
@@ -385,9 +385,9 @@ paths:
           name: id
           required: true
       responses:
-        "204":
+        '204':
           description: Default Response
-        "404":
+        '404':
           description: Default Response
           content:
             application/json:


### PR DESCRIPTION
This pull request primarily focuses on code cleanliness and consistency across the codebase, with a few minor improvements to the CI workflow and configuration. Most changes involve adding trailing commas to function calls and object literals, which helps with cleaner diffs and consistent formatting. Additionally, a formatter check was added to the CI workflow to enforce code style.

**CI/CD and Tooling Improvements:**
- Added a formatter check (`npx nx format:check --all`) to the CI workflow in `.github/workflows/ci.yaml` to ensure consistent code formatting in all pull requests.

**Code Style and Consistency:**
- Ran nx format on all files