### PR TITLE
feat(http-linter): add static linting action and rule name filter

### DIFF
--- a/plugins/http-linter/src/index.ts
+++ b/plugins/http-linter/src/index.ts
@@ -6,6 +6,7 @@ import {
   ThymianEmitter,
   ThymianFormat,
   type ThymianPlugin,
+  type ThymianReport,
 } from '@thymian/core';
 import type {} from '@thymian/request-dispatcher';
 import type {} from '@thymian/sampler';
@@ -61,6 +62,16 @@ declare module '@thymian/core' {
       };
       response: boolean;
     };
+
+    'http-linter.lint-static': {
+      event: {
+        format: SerializedThymianFormat;
+      };
+      response: {
+        reports: ThymianReport[];
+        valid: boolean;
+      };
+    };
   }
 }
 
@@ -72,6 +83,7 @@ export type HttpLinterPluginOptions = {
   ruleFilter?: {
     severity?: RuleSeverity;
     appliesTo?: HttpParticipantRole[];
+    names?: string[];
   };
 };
 
@@ -121,6 +133,13 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
               enum: httpParticipantRoles,
             },
             nullable: true,
+          },
+          names: {
+            nullable: true,
+            type: 'array',
+            items: {
+              type: 'string',
+            },
           },
         },
       },
@@ -229,6 +248,25 @@ export const httpLinterPlugin: ThymianPlugin<HttpLinterPluginOptions> = {
         ctx.reply(valid);
       },
     );
+
+    emitter.onAction('http-linter.lint-static', async ({ format }, ctx) => {
+      const thymianFormat = ThymianFormat.import(format);
+
+      const reports: ThymianReport[] = [];
+
+      const valid = await new StaticLinter(
+        logger,
+        loadedRules,
+        (report) => reports.push(report),
+        thymianFormat,
+        options.ruleOptions ?? {},
+      ).run();
+
+      ctx.reply({
+        valid,
+        reports,
+      });
+    });
   },
 };
 

--- a/plugins/http-linter/src/rule-filter.ts
+++ b/plugins/http-linter/src/rule-filter.ts
@@ -8,7 +8,7 @@ export function createRuleFilter(
 ): RuleFilter {
   const ruleFilters: RuleFilter[] = [];
 
-  const { severity, appliesTo } = filters ?? {};
+  const { severity, appliesTo, names } = filters ?? {};
 
   if (severity) {
     ruleFilters.push(
@@ -24,6 +24,10 @@ export function createRuleFilter(
         rule.meta.appliesTo ? rule.meta.appliesTo.includes(role) : true,
       ),
     );
+  }
+
+  if (names) {
+    ruleFilters.push((rule) => names.includes(rule.meta.name));
   }
 
   return (rule) => ruleFilters.every((filter) => filter(rule));

--- a/plugins/http-linter/test/index.test.ts
+++ b/plugins/http-linter/test/index.test.ts
@@ -1,0 +1,62 @@
+import { Thymian, ThymianFormat } from '@thymian/core';
+import { describe, expect, it } from 'vitest';
+
+import httpLinterPlugin from '../src/index.js';
+import { loadRules } from '../src/load-rules.js';
+
+describe('http-linter', () => {
+  it('http-linter.lint-static should return thymian reports', async () => {
+    const thymian = new Thymian();
+    await thymian
+      .register(httpLinterPlugin, {
+        rules: ['@thymian/rfc-9110-rules'],
+        ruleFilter: {
+          names: ['rfc9110/server-should-send-validator-fields'],
+        },
+      })
+      .ready();
+
+    const format = new ThymianFormat();
+
+    format.addHttpTransaction(
+      {
+        cookies: {},
+        headers: {},
+        host: '',
+        label: '',
+        mediaType: '',
+        method: 'get',
+        path: '',
+        pathParameters: {},
+        port: 0,
+        protocol: 'http',
+        queryParameters: {},
+        type: 'http-request',
+      },
+      {
+        headers: {},
+        mediaType: '',
+        statusCode: 200,
+        type: 'http-response',
+      },
+    );
+
+    const result = await thymian.emitter.emitAction(
+      'http-linter.lint-static',
+      {
+        format: format.export(),
+      },
+      {
+        strategy: 'first',
+      },
+    );
+
+    expect(result.valid).toBeFalsy();
+    expect(result.reports).toHaveLength(1);
+    expect(result.reports[0]?.text).includes(
+      'fc9110/server-should-send-validator-fields',
+    );
+
+    await thymian.close();
+  });
+});


### PR DESCRIPTION
This PR add the new action `http-linter.lint-static`. This action allows you to send a Thymian format instance and receive a list of ThymianReports as a result.
Additionally, a new rule filter is added. This filter allows to filter rules by their name.

Addresses thymianofficial/thymian-internal#61 