### PR TITLE
chore(repo): update vite version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "5.9.2",
         "typescript-eslint": "8.44.0",
         "verdaccio": "^6.1.0",
-        "vite": "7.1.6",
+        "vite": "^7.1.6",
         "vitest": "^3.0.9"
       }
     },
@@ -21454,9 +21454,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.6.tgz",
-      "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "5.9.2",
     "typescript-eslint": "8.44.0",
     "verdaccio": "^6.1.0",
-    "vite": "7.1.6",
+    "vite": "^7.1.6",
     "vitest": "^3.0.9"
   },
   "workspaces": [


### PR DESCRIPTION
Currently, `npm audit` finds 20 vulnerabilities. The change in this PR fixes one. The remaining 19 are coming from:

* **glob  10.2.0 - 10.4.5**: used by **npm** which again is used by **@oclif/plugin-plugins**. The vulnerability of glob only affects the command line interface of it and npm uses its programmaticly (see https://github.com/npm/cli/issues/8741)
* **js-yaml  4.0.0 - 4.1.0** and **validator  <13.15.20**: both used by verdaccio. We just have to wait unitl verdaccio publishs a version with the fixed versions. The fixes are already commited to main but not released yet.

So for now just the vitest fix :)