### PR TITLE
feat(core-testing): initial implementation

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,6 +19,7 @@ export default {
         'sampler',
         'test-utils',
         'websocket-proxy',
+        'core-testing',
       ],
     ],
     'scope-empty': [2, 'never'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6642,6 +6642,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@thymian/core-testing": {
+      "resolved": "packages/core-testing",
+      "link": true
+    },
     "node_modules/@thymian/format-validator": {
       "resolved": "packages/format-validator",
       "link": true
@@ -24069,6 +24073,19 @@
       "devDependencies": {
         "@types/semver": "^7.7.0",
         "graphology-types": "^0.24.8"
+      }
+    },
+    "packages/core-testing": {
+      "name": "@thymian/core-testing",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "devDependencies": {
+        "@thymian/core": "^0"
+      },
+      "peerDependencies": {
+        "@thymian/core": "^0"
       }
     },
     "packages/core/node_modules/path-to-regexp": {

--- a/packages/core-testing/README.md
+++ b/packages/core-testing/README.md
@@ -1,0 +1,285 @@
+# @thymian/core-testing
+
+Testing utilities, factories, and mocks for the Thymian plugin ecosystem.
+
+## Overview
+
+`@thymian/core-testing` provides reusable testing utilities that make it easy to write tests for Thymian plugins and components. It includes:
+
+- **Factories** for creating test data with sensible defaults
+- **Mocks** for all major Thymian interfaces
+- **Type-safe** utilities that match the `@thymian/core` types exactly
+
+## Installation
+
+```bash
+npm install --save-dev @thymian/core-testing
+```
+
+## Quick Start
+
+```typescript
+import { createHttpRequest, createHttpResponse, createMockLogger, createMockEmitter, createMockPlugin } from '@thymian/core-testing';
+
+// Create test data with sensible defaults
+const request = createGetRequest({ path: '/users' });
+const response = createOkResponse();
+
+// Create test doubles
+const logger = createMockLogger();
+const emitter = createMockEmitter();
+
+// Test your plugin
+await myPlugin(emitter, logger, { cwd: '/test' });
+
+// Assert on calls
+expect(logger.info).toHaveBeenCalled();
+expect(emitter.emit).toHaveBeenCalledWith('core.register', expect.any(Object));
+```
+
+## API Reference
+
+### Factories
+
+#### Schema Factories
+
+Create ThymianSchema objects with sensible defaults:
+
+```typescript
+import { createThymianSchema, createStringSchema, createNumberSchema, createIntegerSchema, createBooleanSchema, createObjectSchema, createArraySchema } from '@thymian/core-testing';
+
+// Basic schemas
+const stringSchema = createStringSchema({ minLength: 5, maxLength: 50 });
+const numberSchema = createNumberSchema({ minimum: 0, maximum: 100 });
+const integerSchema = createIntegerSchema();
+const booleanSchema = createBooleanSchema();
+
+// Complex schemas
+const objectSchema = createObjectSchema({
+  name: createStringSchema(),
+  age: createIntegerSchema(),
+});
+
+const arraySchema = createArraySchema(createStringSchema());
+```
+
+#### Parameter Factories
+
+Create Parameter objects:
+
+```typescript
+import { createParameter, createRequiredParameter, createOptionalParameter } from '@thymian/core-testing';
+
+const param = createParameter({
+  description: 'User ID',
+  schema: createIntegerSchema(),
+});
+
+const requiredParam = createRequiredParameter({
+  schema: createStringSchema(),
+});
+```
+
+#### HTTP Request Factories
+
+Create ThymianHttpRequest objects:
+
+```typescript
+import { createHttpRequest, createGetRequest, createPostRequest, createPutRequest, createPatchRequest, createDeleteRequest } from '@thymian/core-testing';
+
+const getRequest = createGetRequest({
+  path: '/api/users',
+  queryParameters: {
+    page: createParameter({ schema: createIntegerSchema() }),
+  },
+});
+
+const postRequest = createPostRequest({
+  path: '/api/users',
+  body: createObjectSchema({
+    name: createStringSchema(),
+    email: createStringSchema(),
+  }),
+});
+```
+
+#### HTTP Response Factories
+
+Create ThymianHttpResponse objects:
+
+```typescript
+import { createHttpResponse, createOkResponse, createCreatedResponse, createNoContentResponse, createBadRequestResponse, createUnauthorizedResponse, createForbiddenResponse, createNotFoundResponse, createInternalServerErrorResponse } from '@thymian/core-testing';
+
+const okResponse = createOkResponse({
+  schema: createObjectSchema({
+    id: createIntegerSchema(),
+    name: createStringSchema(),
+  }),
+});
+
+const errorResponse = createNotFoundResponse({
+  description: 'User not found',
+});
+```
+
+#### ThymianFormat Factories
+
+Create ThymianFormat instances:
+
+```typescript
+import { createThymianFormat, createThymianFormatWithTransaction, createThymianFormatWithTransactions } from '@thymian/core-testing';
+
+// Empty format
+const format = createThymianFormat();
+
+// Format with one transaction
+const formatWithOne = createThymianFormatWithTransaction(createGetRequest({ path: '/users' }), createOkResponse());
+
+// Format with multiple transactions
+const formatWithMany = createThymianFormatWithTransactions([
+  [createGetRequest({ path: '/users' }), createOkResponse()],
+  [createPostRequest({ path: '/users' }), createCreatedResponse()],
+]);
+
+// Format with 10 transactions
+const formatWithSpecificNumber = createThymianFormatWithTransactions(10);
+```
+
+### Mocks
+
+#### Logger Mock
+
+Create mock Logger instances:
+
+```typescript
+import { createMockLogger, createVerboseMockLogger, createSilentMockLogger } from '@thymian/core-testing';
+
+// Standard mock (with vi.fn() spies)
+const logger = createMockLogger({ namespace: 'test-plugin' });
+logger.info('Starting plugin');
+expect(logger.info).toHaveBeenCalledWith('Starting plugin');
+
+// Verbose logger
+const verboseLogger = createVerboseMockLogger();
+expect(verboseLogger.verbose).toBe(true);
+
+// Silent logger (no spies, just no-ops)
+const silentLogger = createSilentMockLogger();
+```
+
+#### Emitter Mock
+
+Create mock ThymianEmitter instances:
+
+```typescript
+import { createMockEmitter, createEmitterWithHandlers, createEmitterWithActionHandlers, captureEmittedEvents } from '@thymian/core-testing';
+
+// Standard mock with spies
+const emitter = createMockEmitter();
+await emitter.emit('core.register', { plugin: myPlugin });
+expect(emitter.emit).toHaveBeenCalledWith('core.register', expect.any(Object));
+
+// Emitter with pre-configured handlers
+const emitterWithHandlers = createEmitterWithHandlers({
+  'core.error': vi.fn(),
+  'core.register': vi.fn(),
+});
+
+// Capture all emitted events
+const events = captureEmittedEvents(emitter);
+await emitter.emit('core.register', { plugin: myPlugin });
+expect(events).toHaveLength(1);
+expect(events[0][0]).toBe('core.register');
+```
+
+#### Plugin Mock
+
+Create mock ThymianPlugin instances:
+
+```typescript
+import { createMockPlugin, createSpyPluginFn, createPluginThatEmits, createPluginWithMetadata } from '@thymian/core-testing';
+
+// Basic mock plugin
+const plugin = createMockPlugin({
+  name: 'test-plugin',
+  version: '1.0.0',
+});
+
+// Plugin with spy function
+const pluginFn = createSpyPluginFn(async (emitter, logger, options) => {
+  logger.info('Plugin started');
+});
+const pluginWithSpy = createMockPlugin({ plugin: pluginFn });
+
+// Plugin that emits events
+const emittingPlugin = createPluginThatEmits('core.register', {
+  plugin: myPlugin,
+});
+
+// Plugin with metadata
+const pluginWithMeta = createPluginWithMetadata({
+  name: 'my-plugin',
+  version: '1.0.0',
+  events: {
+    emits: ['core.register'],
+    listensOn: ['core.ready'],
+  },
+});
+```
+
+## Examples
+
+### Testing a Plugin
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { createMockEmitter, createMockLogger } from '@thymian/core-testing';
+import { myPlugin } from './my-plugin.js';
+
+describe('myPlugin', () => {
+  it('should register itself', async () => {
+    const emitter = createMockEmitter();
+    const logger = createMockLogger();
+
+    await myPlugin(emitter, logger, { cwd: '/test' });
+
+    expect(emitter.emit).toHaveBeenCalledWith(
+      'core.register',
+      expect.objectContaining({
+        plugin: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should log startup message', async () => {
+    const emitter = createMockEmitter();
+    const logger = createMockLogger();
+
+    await myPlugin(emitter, logger, { cwd: '/test' });
+
+    expect(logger.info).toHaveBeenCalledWith('Plugin started');
+  });
+});
+```
+
+### Testing Format Transformations
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { createThymianFormat, createGetRequest, createOkResponse } from '@thymian/core-testing';
+import { transformFormat } from './transform.js';
+
+describe('transformFormat', () => {
+  it('should transform HTTP transactions', () => {
+    const format = createThymianFormat();
+    const request = createGetRequest({ path: '/users' });
+    const response = createOkResponse();
+
+    format.addHttpTransaction(request, response);
+
+    const result = transformFormat(format);
+
+    expect(result.getHttpTransactions()).toHaveLength(1);
+  });
+});
+```

--- a/packages/core-testing/eslint.config.mjs
+++ b/packages/core-testing/eslint.config.mjs
@@ -1,0 +1,23 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
+          ignoredDependencies: ['tslib', 'vitest'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+  {
+    ignores: ['**/out-tsc'],
+  },
+];

--- a/packages/core-testing/package.json
+++ b/packages/core-testing/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@thymian/core-testing",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@thymian/core": "^0"
+  },
+  "peerDependencies": {
+    "@thymian/core": "^0"
+  }
+}

--- a/packages/core-testing/project.json
+++ b/packages/core-testing/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "@thymian/core-testing",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/core-testing/src",
+  "projectType": "library",
+  "tags": ["scope:core", "type:testing"],
+  "// targets": "to see all targets run: nx show project @thymian/core-testing --web",
+  "targets": {}
+}

--- a/packages/core-testing/src/factories/http-request.factory.ts
+++ b/packages/core-testing/src/factories/http-request.factory.ts
@@ -1,0 +1,103 @@
+import type { ThymianHttpRequest } from '@thymian/core';
+
+/**
+ * Creates a ThymianHttpRequest with sensible defaults.
+ * All properties can be overridden.
+ *
+ * @param overrides - Partial request to override defaults
+ * @returns A complete ThymianHttpRequest object
+ *
+ * @example
+ * ```typescript
+ * const getRequest = createHttpRequest({ method: 'GET', path: '/users' });
+ * const postRequest = createHttpRequest({
+ *   method: 'POST',
+ *   path: '/users',
+ *   body: createObjectSchema()
+ * });
+ * ```
+ */
+export function createHttpRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return {
+    type: 'http-request',
+    label:
+      overrides.label ||
+      `${overrides.method || 'GET'} ${overrides.path || '/'}`,
+    host: 'localhost',
+    port: 443,
+    protocol: 'https',
+    path: '/',
+    method: 'GET',
+    headers: {},
+    queryParameters: {},
+    cookies: {},
+    pathParameters: {},
+    mediaType: '',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a GET request
+ */
+export function createGetRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return createHttpRequest({
+    method: 'GET',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a POST request
+ */
+export function createPostRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return createHttpRequest({
+    method: 'POST',
+    mediaType: 'application/json',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a PUT request
+ */
+export function createPutRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return createHttpRequest({
+    method: 'PUT',
+    mediaType: 'application/json',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a PATCH request
+ */
+export function createPatchRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return createHttpRequest({
+    method: 'PATCH',
+    mediaType: 'application/json',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a DELETE request
+ */
+export function createDeleteRequest(
+  overrides: Partial<ThymianHttpRequest> = {},
+): ThymianHttpRequest {
+  return createHttpRequest({
+    method: 'DELETE',
+    ...overrides,
+  });
+}

--- a/packages/core-testing/src/factories/http-response.factory.ts
+++ b/packages/core-testing/src/factories/http-response.factory.ts
@@ -1,0 +1,136 @@
+import type { ThymianHttpResponse } from '@thymian/core';
+
+/**
+ * Creates a ThymianHttpResponse with sensible defaults.
+ * All properties can be overridden.
+ *
+ * @param overrides - Partial response to override defaults
+ * @returns A complete ThymianHttpResponse object
+ *
+ * @example
+ * ```typescript
+ * const okResponse = createHttpResponse({ statusCode: 200 });
+ * const errorResponse = createHttpResponse({
+ *   statusCode: 404,
+ *   description: 'Not Found'
+ * });
+ * ```
+ */
+export function createHttpResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  const statusCode = overrides.statusCode || 200;
+  return {
+    type: 'http-response',
+    label: overrides.label || `Response ${statusCode}`,
+    statusCode,
+    headers: {},
+    mediaType: 'application/json',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a 200 OK response
+ */
+export function createOkResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 200,
+    description: 'OK',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 201 Created response
+ */
+export function createCreatedResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 201,
+    description: 'Created',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 204 No Content response
+ */
+export function createNoContentResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 204,
+    description: 'No Content',
+    mediaType: '',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 400 Bad Request response
+ */
+export function createBadRequestResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 400,
+    description: 'Bad Request',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 401 Unauthorized response
+ */
+export function createUnauthorizedResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 401,
+    description: 'Unauthorized',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 403 Forbidden response
+ */
+export function createForbiddenResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 403,
+    description: 'Forbidden',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 404 Not Found response
+ */
+export function createNotFoundResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 404,
+    description: 'Not Found',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a 500 Internal Server Error response
+ */
+export function createInternalServerErrorResponse(
+  overrides: Partial<ThymianHttpResponse> = {},
+): ThymianHttpResponse {
+  return createHttpResponse({
+    statusCode: 500,
+    description: 'Internal Server Error',
+    ...overrides,
+  });
+}

--- a/packages/core-testing/src/factories/parameter.factory.ts
+++ b/packages/core-testing/src/factories/parameter.factory.ts
@@ -1,0 +1,56 @@
+import type { Parameter } from '@thymian/core';
+
+import { createStringSchema } from './schema.factory.js';
+
+/**
+ * Creates a Parameter with sensible defaults.
+ * All properties can be overridden.
+ *
+ * @param overrides - Partial parameter to override defaults
+ * @returns A complete Parameter object
+ *
+ * @example
+ * ```typescript
+ * const requiredParam = createParameter({ required: true });
+ * const customParam = createParameter({
+ *   description: 'User ID',
+ *   required: true,
+ *   schema: createIntegerSchema()
+ * });
+ * ```
+ */
+export function createParameter(overrides: Partial<Parameter> = {}): Parameter {
+  return {
+    required: false,
+    schema: createStringSchema(),
+    style: {
+      explode: false,
+      style: 'simple',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a required Parameter
+ */
+export function createRequiredParameter(
+  overrides: Partial<Parameter> = {},
+): Parameter {
+  return createParameter({
+    required: true,
+    ...overrides,
+  });
+}
+
+/**
+ * Creates an optional Parameter
+ */
+export function createOptionalParameter(
+  overrides: Partial<Parameter> = {},
+): Parameter {
+  return createParameter({
+    required: false,
+    ...overrides,
+  });
+}

--- a/packages/core-testing/src/factories/schema.factory.ts
+++ b/packages/core-testing/src/factories/schema.factory.ts
@@ -1,0 +1,104 @@
+import type { ThymianSchema } from '@thymian/core';
+
+/**
+ * Creates a ThymianSchema with sensible defaults.
+ * All properties can be overridden.
+ *
+ * @param overrides - Partial schema to override defaults
+ * @returns A complete ThymianSchema object
+ *
+ * @example
+ * ```typescript
+ * const stringSchema = createThymianSchema({ type: 'string', minLength: 5 });
+ * const objectSchema = createThymianSchema({
+ *   type: 'object',
+ *   properties: {
+ *     name: createThymianSchema({ type: 'string' })
+ *   }
+ * });
+ * ```
+ */
+export function createThymianSchema(
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return {
+    type: 'string',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a string schema with sensible defaults
+ */
+export function createStringSchema(
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'string',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a number schema with sensible defaults
+ */
+export function createNumberSchema(
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'number',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates an integer schema with sensible defaults
+ */
+export function createIntegerSchema(
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'integer',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a boolean schema with sensible defaults
+ */
+export function createBooleanSchema(
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'boolean',
+    ...overrides,
+  });
+}
+
+/**
+ * Creates an object schema with sensible defaults
+ */
+export function createObjectSchema(
+  properties: Record<string, ThymianSchema> = {},
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'object',
+    properties,
+    ...overrides,
+  });
+}
+
+/**
+ * Creates an array schema with sensible defaults
+ */
+export function createArraySchema(
+  items: ThymianSchema = createStringSchema(),
+  overrides: Partial<ThymianSchema> = {},
+): ThymianSchema {
+  return createThymianSchema({
+    type: 'array',
+    items,
+    ...overrides,
+  });
+}

--- a/packages/core-testing/src/factories/thymian-format.factory.ts
+++ b/packages/core-testing/src/factories/thymian-format.factory.ts
@@ -1,0 +1,76 @@
+import type { ThymianHttpRequest, ThymianHttpResponse } from '@thymian/core';
+import { ThymianFormat } from '@thymian/core';
+
+import { createHttpRequest } from './http-request.factory.js';
+import { createHttpResponse } from './http-response.factory.js';
+
+/**
+ * Creates an empty ThymianFormat instance.
+ *
+ * @returns A new ThymianFormat instance
+ *
+ * @example
+ * ```typescript
+ * const format = createThymianFormat();
+ * format.addHttpTransaction(request, response);
+ * ```
+ */
+export function createThymianFormat(): ThymianFormat {
+  return new ThymianFormat();
+}
+
+/**
+ * Creates a ThymianFormat with a single HTTP transaction.
+ *
+ * @param request - Optional request override
+ * @param response - Optional response override
+ * @returns A ThymianFormat with one transaction
+ *
+ * @example
+ * ```typescript
+ * const format = createThymianFormatWithTransaction(
+ *   createGetRequest({ path: '/users' }),
+ *   createOkResponse()
+ * );
+ * ```
+ */
+export function createThymianFormatWithTransaction(
+  request: ThymianHttpRequest = createHttpRequest(),
+  response: ThymianHttpResponse = createHttpResponse(),
+): ThymianFormat {
+  const format = new ThymianFormat();
+  format.addHttpTransaction(request, response);
+  return format;
+}
+
+/**
+ * Creates a ThymianFormat with multiple HTTP transactions.
+ *
+ * @param transactions - Array of [request, response] tuples
+ * @returns A ThymianFormat with multiple transactions
+ *
+ * @example
+ * ```typescript
+ * const format = createThymianFormatWithTransactions([
+ *   [createGetRequest({ path: '/users' }), createOkResponse()],
+ *   [createPostRequest({ path: '/users' }), createCreatedResponse()],
+ * ]);
+ * ```
+ */
+export function createThymianFormatWithTransactions(
+  transactions: Array<[ThymianHttpRequest, ThymianHttpResponse]> | number,
+): ThymianFormat {
+  const format = new ThymianFormat();
+
+  if (typeof transactions === 'number') {
+    transactions = Array.from({ length: transactions }, (_, i) => [
+      createHttpRequest({ path: `/transaction-${i}` }),
+      createHttpResponse(),
+    ]);
+  }
+
+  for (const [request, response] of transactions) {
+    format.addHttpTransaction(request, response);
+  }
+  return format;
+}

--- a/packages/core-testing/src/index.ts
+++ b/packages/core-testing/src/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @thymian/core-testing
+ *
+ * Testing utilities, factories, and mocks for the Thymian plugin ecosystem.
+ *
+ * This package provides reusable testing utilities that make it easy to write
+ * tests for Thymian plugins and components.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createHttpRequest,
+ *   createHttpResponse,
+ *   createMockLogger,
+ *   createMockEmitter,
+ * } from '@thymian/core-testing';
+ *
+ * // Create test data
+ * const request = createGetRequest({ path: '/users' });
+ * const response = createOkResponse();
+ *
+ * // Create test doubles
+ * const logger = createMockLogger();
+ * const emitter = createMockEmitter();
+ *
+ * // Test your plugin
+ * await myPlugin(emitter, logger, { cwd: '/test' });
+ *
+ * expect(logger.info).toHaveBeenCalled();
+ * ```
+ */
+
+// ============================================================================
+// Factories - Data Format
+// ============================================================================
+
+export {
+  createDeleteRequest,
+  createGetRequest,
+  createHttpRequest,
+  createPatchRequest,
+  createPostRequest,
+  createPutRequest,
+} from './factories/http-request.factory.js';
+export {
+  createBadRequestResponse,
+  createCreatedResponse,
+  createForbiddenResponse,
+  createHttpResponse,
+  createInternalServerErrorResponse,
+  createNoContentResponse,
+  createNotFoundResponse,
+  createOkResponse,
+  createUnauthorizedResponse,
+} from './factories/http-response.factory.js';
+export {
+  createOptionalParameter,
+  createParameter,
+  createRequiredParameter,
+} from './factories/parameter.factory.js';
+export {
+  createArraySchema,
+  createBooleanSchema,
+  createIntegerSchema,
+  createNumberSchema,
+  createObjectSchema,
+  createStringSchema,
+  createThymianSchema,
+} from './factories/schema.factory.js';
+export {
+  createThymianFormat,
+  createThymianFormatWithTransaction,
+  createThymianFormatWithTransactions,
+} from './factories/thymian-format.factory.js';
+
+// ============================================================================
+// Mocks - Test Doubles
+// ============================================================================
+
+export {
+  captureEmittedEvents,
+  createEmitterWithActionHandlers,
+  createEmitterWithHandlers,
+  createMockEmitter,
+} from './mocks/emitter.mock.js';
+export {
+  createMockLogger,
+  createSilentMockLogger,
+  createVerboseMockLogger,
+} from './mocks/logger.mock.js';
+export {
+  createMockPlugin,
+  createPluginThatEmits,
+  createPluginWithMetadata,
+  createSpyPluginFn,
+} from './mocks/plugin.mock.js';

--- a/packages/core-testing/src/mocks/emitter.mock.ts
+++ b/packages/core-testing/src/mocks/emitter.mock.ts
@@ -1,0 +1,152 @@
+import type {
+  ThymianActionName,
+  ThymianActions,
+  ThymianEventName,
+  ThymianEvents,
+} from '@thymian/core';
+import { ThymianEmitter } from '@thymian/core';
+import { vi } from 'vitest';
+
+import { createMockLogger } from './logger.mock.js';
+
+/**
+ * Creates a mock ThymianEmitter with all methods stubbed using vi.fn().
+ * Useful for testing plugins and components that depend on an emitter.
+ *
+ * @returns A mock ThymianEmitter instance
+ *
+ * @example
+ * ```typescript
+ * const emitter = createMockEmitter();
+ *
+ * // Use in tests
+ * await myPlugin(emitter, logger, options);
+ *
+ * // Assert on calls
+ * expect(emitter.emit).toHaveBeenCalledWith('core.register', expect.any(Object));
+ * ```
+ */
+export function createMockEmitter(): ThymianEmitter {
+  const emitter = new ThymianEmitter(
+    createMockLogger(),
+    ThymianEmitter.newEmitterState(),
+  );
+
+  // Spy on all methods
+  vi.spyOn(emitter, 'emit');
+  vi.spyOn(emitter, 'emitAction');
+  vi.spyOn(emitter, 'on');
+  vi.spyOn(emitter, 'onAction');
+  vi.spyOn(emitter, 'onError');
+
+  return emitter;
+}
+
+/**
+ * Creates a ThymianEmitter with pre-configured event handlers.
+ * Useful for testing components that emit events.
+ *
+ * @param handlers - Map of event names to handler functions
+ * @returns A ThymianEmitter with handlers registered
+ *
+ * @example
+ * ```typescript
+ * const emitter = createEmitterWithHandlers({
+ *   'core.register': vi.fn(),
+ *   'core.error': vi.fn(),
+ * });
+ * ```
+ */
+export function createEmitterWithHandlers<K extends ThymianEventName>(
+  handlers: Partial<
+    Record<K, (event: ThymianEvents[K]) => void | Promise<void>>
+  >,
+): ThymianEmitter {
+  const emitter = new ThymianEmitter(
+    createMockLogger(),
+    ThymianEmitter.newEmitterState(),
+  );
+
+  for (const [eventName, handler] of Object.entries(handlers) as Array<
+    [K, (event: ThymianEvents[K]) => void | Promise<void>]
+  >) {
+    emitter.on(eventName, handler as any);
+  }
+
+  return emitter;
+}
+
+/**
+ * Creates a ThymianEmitter with pre-configured action handlers.
+ * Useful for testing components that request actions.
+ *
+ * @param handlers - Map of action names to handler functions
+ * @returns A ThymianEmitter with action handlers registered
+ *
+ * @example
+ * ```typescript
+ * const emitter = createEmitterWithActionHandlers({
+ *   'core.load-format': async (event) => ({ format: createThymianFormat() }),
+ * });
+ * ```
+ */
+export function createEmitterWithActionHandlers<K extends ThymianActionName>(
+  handlers: Partial<
+    Record<
+      K,
+      (
+        event: ThymianActions[K]['event'],
+      ) => Promise<ThymianActions[K]['response']>
+    >
+  >,
+): ThymianEmitter {
+  const emitter = new ThymianEmitter(
+    createMockLogger(),
+    ThymianEmitter.newEmitterState(),
+  );
+
+  for (const [actionName, handler] of Object.entries(handlers) as Array<
+    [
+      K,
+      (
+        event: ThymianActions[K]['event'],
+      ) => Promise<ThymianActions[K]['response']>,
+    ]
+  >) {
+    emitter.on(actionName as ThymianEventName, handler as any);
+  }
+
+  return emitter;
+}
+
+/**
+ * Helper to capture all events emitted by an emitter.
+ * Returns an array that will be populated with emitted events.
+ *
+ * @param emitter - The emitter to capture events from
+ * @returns An array that captures [eventName, event] tuples
+ *
+ * @example
+ * ```typescript
+ * const emitter = createMockEmitter();
+ * const events = captureEmittedEvents(emitter);
+ *
+ * await emitter.emit('core.register', { plugin: myPlugin });
+ *
+ * expect(events).toHaveLength(1);
+ * expect(events[0][0]).toBe('core.register');
+ * ```
+ */
+export function captureEmittedEvents(
+  emitter: ThymianEmitter,
+): Array<[ThymianEventName | ThymianActionName, any]> {
+  const capturedEvents: Array<[ThymianEventName | ThymianActionName, any]> = [];
+
+  const originalEmit = emitter.emit.bind(emitter);
+  emitter.emit = vi.fn(async (eventName: any, event: any) => {
+    capturedEvents.push([eventName, event]);
+    return originalEmit(eventName, event);
+  }) as any;
+
+  return capturedEvents;
+}

--- a/packages/core-testing/src/mocks/logger.mock.ts
+++ b/packages/core-testing/src/mocks/logger.mock.ts
@@ -1,0 +1,84 @@
+import type { Logger } from '@thymian/core';
+import { vi } from 'vitest';
+
+/**
+ * Creates a mock Logger with all methods stubbed using vi.fn().
+ * Useful for testing plugins and components that depend on a Logger.
+ *
+ * @param overrides - Partial logger to override defaults
+ * @returns A mock Logger instance
+ *
+ * @example
+ * ```typescript
+ * const logger = createMockLogger({ namespace: 'test-plugin' });
+ *
+ * // Use in tests
+ * myPlugin(emitter, logger, options);
+ *
+ * // Assert on calls
+ * expect(logger.info).toHaveBeenCalledWith('Starting plugin');
+ * ```
+ */
+export function createMockLogger(overrides: Partial<Logger> = {}): Logger {
+  const logger: Logger = {
+    namespace: 'mock-logger',
+    verbose: false,
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    out: vi.fn(),
+    child: vi.fn((name: string, verbose?: boolean) =>
+      createMockLogger({
+        namespace: `${logger.namespace}:${name}`,
+        verbose: verbose ?? logger.verbose,
+      }),
+    ),
+    ...overrides,
+  };
+  return logger;
+}
+
+/**
+ * Creates a verbose mock Logger (with verbose: true).
+ *
+ * @param overrides - Partial logger to override defaults
+ * @returns A mock Logger instance with verbose enabled
+ */
+export function createVerboseMockLogger(
+  overrides: Partial<Logger> = {},
+): Logger {
+  return createMockLogger({
+    verbose: true,
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a silent mock Logger that doesn't call any functions.
+ * Useful when you don't want to spy on logger calls.
+ *
+ * @param overrides - Partial logger to override defaults
+ * @returns A mock Logger instance with no-op functions
+ */
+export function createSilentMockLogger(
+  overrides: Partial<Logger> = {},
+): Logger {
+  return {
+    namespace: 'silent-logger',
+    verbose: false,
+    debug: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+    trace: () => undefined,
+    warn: () => undefined,
+    out: () => undefined,
+    child: (name: string, verbose?: boolean) =>
+      createSilentMockLogger({
+        namespace: `silent-logger:${name}`,
+        verbose: verbose ?? false,
+      }),
+    ...overrides,
+  };
+}

--- a/packages/core-testing/src/mocks/plugin.mock.ts
+++ b/packages/core-testing/src/mocks/plugin.mock.ts
@@ -1,0 +1,123 @@
+import type { ThymianPlugin, ThymianPluginFn } from '@thymian/core';
+import { vi } from 'vitest';
+
+/**
+ * Creates a mock ThymianPlugin with sensible defaults.
+ * All properties can be overridden.
+ *
+ * @param overrides - Partial plugin to override defaults
+ * @returns A complete ThymianPlugin object
+ *
+ * @example
+ * ```typescript
+ * const plugin = createMockPlugin({
+ *   name: 'test-plugin',
+ *   plugin: async (emitter, logger, options) => {
+ *     // Plugin logic
+ *   }
+ * });
+ * ```
+ */
+export function createMockPlugin<
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
+>(overrides: Partial<ThymianPlugin<Options>> = {}): ThymianPlugin<Options> {
+  const defaultPlugin: ThymianPluginFn<Options & { cwd: string }> = vi.fn(
+    async () => {
+      // Default no-op plugin
+    },
+  );
+
+  return {
+    name: 'mock-plugin',
+    version: '0.0.1',
+    plugin: defaultPlugin,
+    ...overrides,
+  } as ThymianPlugin<Options>;
+}
+
+/**
+ * Creates a spy plugin function that can be used with createMockPlugin.
+ * Useful when you want to test what arguments are passed to the plugin.
+ *
+ * @param implementation - Optional plugin implementation
+ * @returns A spy function compatible with ThymianPluginFn
+ *
+ * @example
+ * ```typescript
+ * const pluginFn = createSpyPluginFn(async (emitter, logger, options) => {
+ *   logger.info('Plugin started');
+ * });
+ *
+ * const plugin = createMockPlugin({ plugin: pluginFn });
+ *
+ * await plugin.plugin(emitter, logger, options);
+ * expect(pluginFn).toHaveBeenCalledWith(emitter, logger, options);
+ * ```
+ */
+export function createSpyPluginFn<
+  Options extends Record<PropertyKey, unknown> & { cwd: string } = {
+    cwd: string;
+  },
+>(implementation?: ThymianPluginFn<Options>): ThymianPluginFn<Options> {
+  return vi.fn(implementation || (() => Promise.resolve()));
+}
+
+/**
+ * Creates a plugin that emits a specific event when executed.
+ * Useful for testing event flow between plugins.
+ *
+ * @param eventName - The event name to emit
+ * @param eventData - The event data to emit
+ * @param overrides - Additional plugin overrides
+ * @returns A ThymianPlugin that emits the specified event
+ *
+ * @example
+ * ```typescript
+ * const plugin = createPluginThatEmits('core.register', {
+ *   plugin: somePlugin
+ * });
+ * ```
+ */
+export function createPluginThatEmits<
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
+>(
+  eventName: string,
+  eventData: any,
+  overrides: Partial<ThymianPlugin<Options>> = {},
+): ThymianPlugin<Options> {
+  return createMockPlugin<Options>({
+    plugin: async (emitter, logger, options) => {
+      await emitter.emit(eventName as any, eventData);
+    },
+    ...overrides,
+  });
+}
+
+/**
+ * Creates a plugin with event and action metadata configured.
+ * Useful for testing plugin registration and capability declaration.
+ *
+ * @param config - Plugin configuration including events and actions
+ * @returns A ThymianPlugin with metadata
+ *
+ * @example
+ * ```typescript
+ * const plugin = createPluginWithMetadata({
+ *   name: 'my-plugin',
+ *   events: {
+ *     emits: ['core.register'],
+ *     listensOn: ['core.ready']
+ *   },
+ *   actions: {
+ *     provides: {
+ *       'core.load-format': { event: {}, response: {} }
+ *     }
+ *   }
+ * });
+ * ```
+ */
+export function createPluginWithMetadata<
+  Options extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
+>(config: Partial<ThymianPlugin<Options>>): ThymianPlugin<Options> {
+  return createMockPlugin<Options>(config);
+}

--- a/packages/core-testing/test/factories/schema.factory.test.ts
+++ b/packages/core-testing/test/factories/schema.factory.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createArraySchema,
+  createBooleanSchema,
+  createIntegerSchema,
+  createNumberSchema,
+  createObjectSchema,
+  createStringSchema,
+  createThymianSchema,
+} from '../../src/factories/schema.factory.js';
+
+describe('Schema Factory', () => {
+  describe('createThymianSchema', () => {
+    it('should create a schema with default type string', () => {
+      const schema = createThymianSchema();
+      expect(schema.type).toBe('string');
+    });
+
+    it('should allow overriding properties', () => {
+      const schema = createThymianSchema({
+        type: 'number',
+        minimum: 0,
+        maximum: 100,
+      });
+      expect(schema.type).toBe('number');
+      expect(schema.minimum).toBe(0);
+      expect(schema.maximum).toBe(100);
+    });
+  });
+
+  describe('createStringSchema', () => {
+    it('should create a string schema', () => {
+      const schema = createStringSchema();
+      expect(schema.type).toBe('string');
+    });
+
+    it('should allow string-specific properties', () => {
+      const schema = createStringSchema({
+        minLength: 5,
+        maxLength: 50,
+        pattern: '^[a-z]+$',
+      });
+      expect(schema.type).toBe('string');
+      expect(schema.minLength).toBe(5);
+      expect(schema.maxLength).toBe(50);
+      expect(schema.pattern).toBe('^[a-z]+$');
+    });
+  });
+
+  describe('createNumberSchema', () => {
+    it('should create a number schema', () => {
+      const schema = createNumberSchema();
+      expect(schema.type).toBe('number');
+    });
+
+    it('should allow number-specific properties', () => {
+      const schema = createNumberSchema({
+        minimum: 0,
+        maximum: 100,
+        multipleOf: 5,
+      });
+      expect(schema.type).toBe('number');
+      expect(schema.minimum).toBe(0);
+      expect(schema.maximum).toBe(100);
+      expect(schema.multipleOf).toBe(5);
+    });
+  });
+
+  describe('createIntegerSchema', () => {
+    it('should create an integer schema', () => {
+      const schema = createIntegerSchema();
+      expect(schema.type).toBe('integer');
+    });
+  });
+
+  describe('createBooleanSchema', () => {
+    it('should create a boolean schema', () => {
+      const schema = createBooleanSchema();
+      expect(schema.type).toBe('boolean');
+    });
+  });
+
+  describe('createObjectSchema', () => {
+    it('should create an object schema with empty properties', () => {
+      const schema = createObjectSchema();
+      expect(schema.type).toBe('object');
+      expect(schema.properties).toEqual({});
+    });
+
+    it('should create an object schema with properties', () => {
+      const schema = createObjectSchema({
+        name: createStringSchema(),
+        age: createIntegerSchema(),
+      });
+      expect(schema.type).toBe('object');
+      expect(schema.properties?.name).toBeDefined();
+      expect(schema.properties?.age).toBeDefined();
+    });
+
+    it('should allow additional overrides', () => {
+      const schema = createObjectSchema(
+        { name: createStringSchema() },
+        { required: ['name'], minProperties: 1 },
+      );
+      expect(schema.required).toEqual(['name']);
+      expect(schema.minProperties).toBe(1);
+    });
+  });
+
+  describe('createArraySchema', () => {
+    it('should create an array schema with string items by default', () => {
+      const schema = createArraySchema();
+      expect(schema.type).toBe('array');
+      expect(schema.items).toBeDefined();
+      expect(schema.items?.type).toBe('string');
+    });
+
+    it('should create an array schema with custom items', () => {
+      const schema = createArraySchema(createIntegerSchema());
+      expect(schema.type).toBe('array');
+      expect(schema.items?.type).toBe('integer');
+    });
+
+    it('should allow array-specific properties', () => {
+      const schema = createArraySchema(createStringSchema(), {
+        minItems: 1,
+        maxItems: 10,
+        uniqueItems: true,
+      });
+      expect(schema.minItems).toBe(1);
+      expect(schema.maxItems).toBe(10);
+      expect(schema.uniqueItems).toBe(true);
+    });
+  });
+});

--- a/packages/core-testing/test/mocks/logger.mock.test.ts
+++ b/packages/core-testing/test/mocks/logger.mock.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createMockLogger,
+  createSilentMockLogger,
+  createVerboseMockLogger,
+} from '../../src/mocks/logger.mock.js';
+
+describe('Logger Mock', () => {
+  describe('createMockLogger', () => {
+    it('should create a logger with default namespace', () => {
+      const logger = createMockLogger();
+      expect(logger.namespace).toBe('mock-logger');
+      expect(logger.verbose).toBe(false);
+    });
+
+    it('should allow overriding properties', () => {
+      const logger = createMockLogger({
+        namespace: 'custom-logger',
+        verbose: true,
+      });
+      expect(logger.namespace).toBe('custom-logger');
+      expect(logger.verbose).toBe(true);
+    });
+
+    it('should stub all logging methods with vi.fn()', () => {
+      const logger = createMockLogger();
+      expect(vi.isMockFunction(logger.debug)).toBe(true);
+      expect(vi.isMockFunction(logger.info)).toBe(true);
+      expect(vi.isMockFunction(logger.error)).toBe(true);
+      expect(vi.isMockFunction(logger.trace)).toBe(true);
+      expect(vi.isMockFunction(logger.warn)).toBe(true);
+      expect(vi.isMockFunction(logger.out)).toBe(true);
+    });
+
+    it('should allow spying on logging calls', () => {
+      const logger = createMockLogger();
+      logger.info('test message', 'arg1', 'arg2');
+
+      expect(logger.info).toHaveBeenCalledWith('test message', 'arg1', 'arg2');
+      expect(logger.info).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create child loggers with proper namespace', () => {
+      const logger = createMockLogger({ namespace: 'parent' });
+      const child = logger.child('child');
+
+      expect(child.namespace).toBe('parent:child');
+    });
+
+    it('should pass verbose flag to child loggers', () => {
+      const logger = createMockLogger({ verbose: true });
+      const child = logger.child('child');
+
+      expect(child.verbose).toBe(true);
+    });
+
+    it('should allow overriding verbose in child', () => {
+      const logger = createMockLogger({ verbose: false });
+      const child = logger.child('child', true);
+
+      expect(child.verbose).toBe(true);
+    });
+  });
+
+  describe('createVerboseMockLogger', () => {
+    it('should create a logger with verbose enabled', () => {
+      const logger = createVerboseMockLogger();
+      expect(logger.verbose).toBe(true);
+    });
+
+    it('should allow overriding other properties', () => {
+      const logger = createVerboseMockLogger({
+        namespace: 'verbose-logger',
+      });
+      expect(logger.namespace).toBe('verbose-logger');
+      expect(logger.verbose).toBe(true);
+    });
+  });
+
+  describe('createSilentMockLogger', () => {
+    it('should create a logger with default namespace', () => {
+      const logger = createSilentMockLogger();
+      expect(logger.namespace).toBe('silent-logger');
+      expect(logger.verbose).toBe(false);
+    });
+
+    it('should have no-op functions that do not throw', () => {
+      const logger = createSilentMockLogger();
+
+      expect(() => logger.debug('test')).not.toThrow();
+      expect(() => logger.info('test')).not.toThrow();
+      expect(() => logger.error('test')).not.toThrow();
+      expect(() => logger.trace('test')).not.toThrow();
+      expect(() => logger.warn('test')).not.toThrow();
+      expect(() => logger.out('test')).not.toThrow();
+    });
+
+    it('should create silent child loggers', () => {
+      const logger = createSilentMockLogger();
+      const child = logger.child('child');
+
+      expect(child.namespace).toBe('silent-logger:child');
+      expect(() => child.info('test')).not.toThrow();
+    });
+  });
+});

--- a/packages/core-testing/tsconfig.json
+++ b/packages/core-testing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/core-testing/tsconfig.lib.json
+++ b/packages/core-testing/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "moduleResolution": "nodenext",
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../core/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/core-testing/vitest.config.ts
+++ b/packages/core-testing/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
     },
     {
       "path": "./packages/test-utils"
+    },
+    {
+      "path": "./packages/core-testing"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the `@thymian/core-testing` lib. This lib provides testing utilities for testing core components. It allows to create mock `ThymianEmitter`, mock logger, to create test HTTP requests/responses, etc.