### PR TITLE
Make thymian callable from any working directory directory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,7 @@ export default [
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
       'node_modules',
+      '**/.astro',
     ],
   },
   {

--- a/packages/thymian/bin/dev.js
+++ b/packages/thymian/bin/dev.js
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
 
+import path from 'node:path';
+
 import { getPluginNames, oclif } from '@thymian/cli-common';
+
+const dirname = import.meta.dirname;
+
+const thymianPath = import.meta.url.includes('node_modules')
+  ? path.join(dirname, 'node_modules', 'thymian')
+  : path.join(dirname, '..');
+
+const pluginsPath = import.meta.url.includes('node_modules')
+  ? thymianPath
+  : path.join(dirname, '..');
 
 await oclif.execute({
   development: true,
@@ -8,8 +20,8 @@ await oclif.execute({
   loadOptions: {
     pluginAdditions: {
       core: await getPluginNames(),
-      path: process.cwd(),
+      path: pluginsPath,
     },
-    root: import.meta.url,
+    root: thymianPath,
   },
 });

--- a/packages/thymian/bin/run.js
+++ b/packages/thymian/bin/run.js
@@ -4,13 +4,15 @@ import path from 'node:path';
 
 import { getPluginNames, oclif } from '@thymian/cli-common';
 
+const dirname = import.meta.dirname;
+
 const thymianPath = import.meta.url.includes('node_modules')
-  ? path.join(process.cwd(), 'node_modules', 'thymian')
-  : import.meta.url;
+  ? path.join(dirname, 'node_modules', 'thymian')
+  : path.join(dirname, '..');
 
 const pluginsPath = import.meta.url.includes('node_modules')
   ? thymianPath
-  : process.cwd();
+  : path.join(dirname, '..');
 
 await oclif.execute({
   dir: thymianPath,

--- a/packages/thymian/eslint.config.mjs
+++ b/packages/thymian/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [
             '@thymian/sampler',
             '@thymian/websocket-proxy',
             '@thymian/reporter',
+            '@thymian/evaluation',
           ],
         },
       ],

--- a/packages/thymian/test/cli.test.ts
+++ b/packages/thymian/test/cli.test.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+describe('cli', () => {
+  it.each([['run'], ['dev']])(
+    '%s.js can be called from any current working directory',
+    async (command) => {
+      expect(() =>
+        execSync(`../bin/${command}.js http-linter:overview`, {
+          stdio: 'pipe',
+          cwd: dirname(fileURLToPath(import.meta.url)),
+        }),
+      ).not.toThrow();
+    },
+  );
+});


### PR DESCRIPTION
Is related to thymianofficial/thymian-internal#26. For closing thymianofficial/thymian-internal#26 we still need to generate a `package-lock.json`.

In the `run.js` and `dev.js` files the dirname of these files is used instead of the current working directory. Because of this the `package.json` and therefore all plugins are found.