### PR TITLE
ci: add automatic canary releases on main pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+# NOTE: Do not rename this file. A single workflow file is required for npm trusted publishing.
+# Future release types (standard, beta, etc.) will be added to this workflow.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  canary-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm
+    if: "!contains(github.event.head_commit.message, '[skip-canary]')"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish canary release
+        run: node ./scripts/release.ts --version canary --no-dry-run --no-local
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -102,5 +102,6 @@
     "Invoke-Expression": false,
     "iex": false
   },
-  "chat.agent.maxRequests": 200
+  "chat.agent.maxRequests": 200,
+  "terminal.integrated.scrollback": 10000
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Thymian
 
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
+
+## Getting Started
+
 You want to try out Thymian? Run the following commands in the specific order:
 
 - `npm i`
@@ -28,3 +32,7 @@ There are different kinds of documentation:
 - [Astro documentation](astro-docs/README.md): The astro documentation is available as a website to the users. It contains general information about Thymian, How-To's and reference documentation for the plugins and the CLI. Add any kind of End-User documentation here (except for plugins, see next point).
 - Plugin documentation: The plugin documentation is part of the astro documentation. It is located in `docs` folders in the plugin projects but will be added to the astro documentation during the build process.
 - Subproject READMEs: You have technical documentation that is subproject-specific? Put it into the README of the subproject.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,7 @@
     "version": {
       "preVersionCommand": "npx nx run-many -t build --exclude astro --no-tui",
       "conventionalCommits": true,
+      "adjustSemverBumpsForZeroMajorVersion": true,
       "versionActionsOptions": {
         "skipLockFileUpdate": true
       },

--- a/packages/cli-common/README.md
+++ b/packages/cli-common/README.md
@@ -1,7 +1,11 @@
-# cli-common
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/cli-common
 
-Run `nx build cli-common` to build the library.
+Shared utilities and helpers for Thymian CLI tools.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/core-testing/README.md
+++ b/packages/core-testing/README.md
@@ -1,8 +1,8 @@
-# @thymian/core-testing
+# Thymian
 
-Testing utilities, factories, and mocks for the Thymian plugin ecosystem.
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Overview
+## @thymian/core-testing
 
 `@thymian/core-testing` provides reusable testing utilities that make it easy to write tests for Thymian plugins and components. It includes:
 
@@ -16,7 +16,7 @@ Testing utilities, factories, and mocks for the Thymian plugin ecosystem.
 npm install --save-dev @thymian/core-testing
 ```
 
-## Quick Start
+### Quick Start
 
 ```typescript
 import { createHttpRequest, createHttpResponse, createMockLogger, createMockEmitter, createMockPlugin } from '@thymian/core-testing';
@@ -37,11 +37,11 @@ expect(logger.info).toHaveBeenCalled();
 expect(emitter.emit).toHaveBeenCalledWith('core.register', expect.any(Object));
 ```
 
-## API Reference
+### API Reference
 
-### Factories
+#### Factories
 
-#### Schema Factories
+##### Schema Factories
 
 Create ThymianSchema objects with sensible defaults:
 
@@ -63,7 +63,7 @@ const objectSchema = createObjectSchema({
 const arraySchema = createArraySchema(createStringSchema());
 ```
 
-#### Parameter Factories
+##### Parameter Factories
 
 Create Parameter objects:
 
@@ -80,7 +80,7 @@ const requiredParam = createRequiredParameter({
 });
 ```
 
-#### HTTP Request Factories
+##### HTTP Request Factories
 
 Create ThymianHttpRequest objects:
 
@@ -103,7 +103,7 @@ const postRequest = createPostRequest({
 });
 ```
 
-#### HTTP Response Factories
+##### HTTP Response Factories
 
 Create ThymianHttpResponse objects:
 
@@ -122,7 +122,7 @@ const errorResponse = createNotFoundResponse({
 });
 ```
 
-#### ThymianFormat Factories
+##### ThymianFormat Factories
 
 Create ThymianFormat instances:
 
@@ -145,9 +145,9 @@ const formatWithMany = createThymianFormatWithTransactions([
 const formatWithSpecificNumber = createThymianFormatWithTransactions(10);
 ```
 
-### Mocks
+#### Mocks
 
-#### Logger Mock
+##### Logger Mock
 
 Create mock Logger instances:
 
@@ -167,7 +167,7 @@ expect(verboseLogger.verbose).toBe(true);
 const silentLogger = createSilentMockLogger();
 ```
 
-#### Emitter Mock
+##### Emitter Mock
 
 Create mock ThymianEmitter instances:
 
@@ -192,7 +192,7 @@ expect(events).toHaveLength(1);
 expect(events[0][0]).toBe('core.register');
 ```
 
-#### Plugin Mock
+##### Plugin Mock
 
 Create mock ThymianPlugin instances:
 
@@ -227,9 +227,9 @@ const pluginWithMeta = createPluginWithMetadata({
 });
 ```
 
-## Examples
+### Examples
 
-### Testing a Plugin
+#### Testing a Plugin
 
 ```typescript
 import { describe, it, expect } from 'vitest';
@@ -262,7 +262,7 @@ describe('myPlugin', () => {
 });
 ```
 
-### Testing Format Transformations
+#### Testing Format Transformations
 
 ```typescript
 import { describe, it, expect } from 'vitest';
@@ -283,3 +283,7 @@ describe('transformFormat', () => {
   });
 });
 ```
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,7 +1,11 @@
-# core
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/core
 
-Run `nx build core` to build the library.
+Core framework for Thymian's plugin system.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/evaluation/README.md
+++ b/packages/evaluation/README.md
@@ -1,7 +1,11 @@
-# evaluation
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/evaluation
 
-Run `nx build evaluation` to build the library.
+Framework for evaluating API quality and conformance.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/format-validator/README.md
+++ b/packages/format-validator/README.md
@@ -1,7 +1,11 @@
-# format-validator
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/format-validator
 
-Run `nx build format-validator` to build the library.
+Validates JSON and YAML format structures.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/http-linter/README.md
+++ b/packages/http-linter/README.md
@@ -1,7 +1,11 @@
-# http-linter
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/http-linter
 
-Run `nx build http-linter` to build the library.
+HTTP-based linting and rule checking for APIs.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/http-testing/README.md
+++ b/packages/http-testing/README.md
@@ -1,9 +1,13 @@
-# @thymian/http-testing
+# Thymian
+
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
+
+## @thymian/http-testing
 
 `@thymian/http-testing` is a HTTP testing library which proposes a new testing approach. Instead of writing tests
 for each of your HTTP-based APIs, define them once and run it against all your APIs.
 
-## The fundamental concept of API-unspecific tests
+### The fundamental concept of API-unspecific tests
 
 If you normally write End-to-end (E2E) tests for your HTTP API, it looks something like this:
 
@@ -53,7 +57,7 @@ httpTest('every GET response should contain a Cache-Control header', (transactio
 
 As you can see the test definition does not include any path oder API specific information.
 
-## How does this work?
+### How does this work?
 
 To say it in the most complicated way: With `@thymian/http-testing` you won't define your tests imperatively but
 declaratively. You don't describe **how** to call and test HTTP API endpoints but sets of endpoints end their expected properties.
@@ -66,8 +70,14 @@ you are totally free to do whatever you want in this pipeline, the result of it 
 or failed test cases. To define and run these test cases `@thymian/http-testing` provides a number of operators
 additional to the built-in ones from RxJS itself.
 
+```
     +-------------------+     +------+             +------+     +------------+
     | HTTP Transactions | --> | Step | --> ... --> | Step | --> | Test Cases |
     +-------------------+     +------+             +------+     +------------+
+```
 
 To align with the approach of RxJS, the list of HTTP transactions is an [Observable](https://rxjs.dev/guide/observable).
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -1,7 +1,11 @@
-# openapi
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/openapi
 
-Run `nx build openapi` to build the library.
+OpenAPI document parsing and validation utilities.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -1,1 +1,11 @@
-# @thymian/reporter
+# Thymian
+
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
+
+## @thymian/reporter
+
+Event-based reporting for test results and issues.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/request-dispatcher/README.md
+++ b/packages/request-dispatcher/README.md
@@ -1,7 +1,11 @@
-# runner
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/request-dispatcher
 
-Run `nx build runner` to build the library.
+HTTP request dispatching and management.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/rfc-9110-rules/README.md
+++ b/packages/rfc-9110-rules/README.md
@@ -1,7 +1,11 @@
-# rfc-9110-rules
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/rfc-9110-rules
 
-Run `nx build rfc-9110-rules` to build the library.
+Reusable HTTP rules based on RFC 9110.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/sampler/README.md
+++ b/packages/sampler/README.md
@@ -1,7 +1,11 @@
-# data-generator
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/sampler
 
-Run `nx build data-generator` to build the library.
+Generates sample implementations from API specifications.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,17 +1,25 @@
-# @thymian/test-utils
+# Thymian
 
-What is in here?
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Fixtures
+## @thymian/test-utils
 
-Things like OpenAPI/Swagger documents.
+Test utilities, fixtures, and example applications.
 
-## Example app
+### Fixtures
+
+Test fixtures including OpenAPI/Swagger documents.
+
+### Example app
 
 This is a Fastify application containing intended erroneous implementations for testing purposes. To add implementations
 add a new file in the `plugins` folder. All routes will be included automatically.
 
-## ToDo app
+### ToDo app
 
 In contrast to the example app, the ToDo app tries to mimic a real world application also for testing purposes. For
 some tests it is advantageous not to have an erroneous implementation.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/thymian/README.md
+++ b/packages/thymian/README.md
@@ -1,7 +1,11 @@
-# thymian
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/cli
 
-Run `nx build thymian` to build the library.
+Main CLI entry point for Thymian.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/packages/websocket-proxy/README.md
+++ b/packages/websocket-proxy/README.md
@@ -1,7 +1,11 @@
-# websocket-proxy
+# Thymian
 
-This library was generated with [Nx](https://nx.dev).
+Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
 
-## Building
+## @thymian/websocket-proxy
 
-Run `nx build websocket-proxy` to build the library.
+WebSocket proxy integration for APIs.
+
+## Documentation
+
+For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'node:child_process';
+
 import { ReleaseClient } from 'nx/release/index.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -44,7 +46,10 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     })
     .parseAsync();
 
-  console.log('\n📋 Release Configuration:');
+  const isCanary = isCanaryRelease(argv.version);
+
+  console.log(`\n${isCanary ? '🐤' : '📋'} Release Configuration:`);
+  console.log(`  mode: ${isCanary ? 'CANARY' : 'STANDARD'}`);
   console.log(`  version: ${argv.version || 'conventional commits'}`);
   console.log(`  dryRun: ${argv.dryRun}`);
   console.log(`  firstRelease: ${argv.firstRelease}`);
@@ -52,7 +57,7 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
   console.log(`  local: ${argv.local}`);
   console.log(`  registry: ${argv.local ? 'http://localhost:4873' : 'npm'}\n`);
 
-  if (argv.local) {
+  if (argv.local && !argv.dryRun) {
     const isRunning = await isVerdaccioRunning('http://localhost:4873/');
     if (!isRunning) {
       console.error(
@@ -65,16 +70,48 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
 
   const client = new ReleaseClient({});
 
+  // For canary releases, first get the next version using conventional commits
+  let versionSpecifier = argv.version;
+  let canaryVersionString: string | undefined;
+
+  if (isCanary) {
+    console.log('🔍 Determining next version from conventional commits...\n');
+
+    const { workspaceVersion: nextVersion } = await client.releaseVersion({
+      specifier: undefined, // Let conventional commits determine version
+      dryRun: true, // Don't actually version yet
+      firstRelease: argv.firstRelease,
+      verbose: argv.verbose,
+      gitTag: false,
+    });
+
+    if (!nextVersion) {
+      console.log(
+        'ℹ️  No release needed (no relevant commits since last release)',
+      );
+      console.log('   Exiting gracefully.\n');
+      process.exit(0);
+    }
+
+    const commitHash = getCurrentCommitHash();
+    canaryVersionString = getCanaryVersion(nextVersion, commitHash);
+    versionSpecifier = canaryVersionString;
+
+    console.log(`📦 Canary version: ${canaryVersionString}`);
+    console.log(`   Base version: ${nextVersion}`);
+    console.log(`   Commit hash: ${commitHash}\n`);
+  }
+
   const { workspaceVersion, projectsVersionData, releaseGraph } =
     await client.releaseVersion({
-      specifier: argv.version,
+      specifier: versionSpecifier,
       dryRun: argv.dryRun,
       firstRelease: argv.firstRelease,
       verbose: argv.verbose,
-      gitTag: !argv.local,
+      gitTag: isCanary ? false : !argv.local,
     });
 
-  if (!argv.local) {
+  if (!argv.local && !isCanary) {
     await client.releaseChangelog({
       releaseGraph,
       versionData: projectsVersionData,
@@ -92,7 +129,7 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     verbose: argv.verbose,
     access: 'restricted', // publish privately for now
     registry: argv.local ? 'http://localhost:4873' : undefined,
-    tag: 'latest',
+    tag: isCanary ? 'canary' : 'latest',
   });
 
   if (!argv.dryRun) {
@@ -105,3 +142,23 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1,
   );
 })();
+
+function getCurrentCommitHash(): string {
+  try {
+    const hash = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+    return hash.substring(0, 7);
+  } catch (error) {
+    console.error('❌ Error: Failed to get current commit hash');
+    throw error;
+  }
+}
+
+function getCanaryVersion(baseVersion: string, commitHash: string): string {
+  const date = new Date();
+  const yyyymmdd = date.toISOString().slice(0, 10).replace(/-/g, '');
+  return `${baseVersion}-canary.${yyyymmdd}-${commitHash}`;
+}
+
+function isCanaryRelease(version: string | undefined): boolean {
+  return version === 'canary';
+}


### PR DESCRIPTION
## Summary
Implement automated canary releases to npm published on every push to main, following the format `[version]-canary.[YYYYMMDD]-[commit-hash]`. No git/GitHub changes are made (no tags, commits, bumps, or releases).

## Changes
- **scripts/release.ts**: Added canary release mode with `--version canary` flag
  - `getCurrentCommitHash()`: Extracts current commit hash (first 7 chars)
  - `getCanaryVersion()`: Formats version as `{base}-canary.{YYYYMMDD}-{hash}`
  - `isCanaryRelease()`: Detects canary mode
  - Canary flow: Determines next version from conventional commits, exits gracefully if no release needed, publishes to `canary` npm tag

- **.github/workflows/release.yaml**: New workflow for automated releases (canary + future release types)
  - Currently handles canary releases triggered on push to main
  - Triggers on push to main (and feature/canary-releases for testing)
  - Runs release script with `--version canary --no-dry-run --no-local`
  - Publishes to npm with `canary` tag
  - 15-minute timeout
  - Requires `npm` environment with `NPM_TOKEN` secret
  - **Note**: Using a single workflow file for npm trusted publishing; other release types will be added to this file later

## Example
A push with commits triggering a 0.0.3 release would generate:
- Canary version: `0.0.3-canary.20260125-4ea6209`
- Published to npm as `@thymian/package@canary`

## Testing
```bash
# Local test with dry-run
node ./scripts/release.ts --version canary --dry-run --local

# Local test with verdaccio
npm run local-registry &
node ./scripts/release.ts --version canary --no-dry-run --local
```

## Related
Closes thymianofficial/thymian-internal#76