### PR TITLE
feat(core): replace circular references with json pointers

### DIFF
--- a/packages/core/src/format/circular-references.ts
+++ b/packages/core/src/format/circular-references.ts
@@ -1,0 +1,84 @@
+const REF_KEY = '$thymian-ref';
+
+export function resolveCircularReferences<T>(obj: T): T {
+  const activeStack = new Map();
+  const REF_KEY = '$thymian-ref';
+
+  function recurse(current: any, path: string): any {
+    if (typeof current !== 'object' || current === null) {
+      return current;
+    }
+
+    if (activeStack.has(current)) {
+      return { [REF_KEY]: activeStack.get(current) };
+    }
+
+    activeStack.set(current, path);
+
+    let result: Record<string, unknown> | Array<unknown>;
+    if (Array.isArray(current)) {
+      result = current.map((item, index) => recurse(item, `${path}/${index}`));
+    } else {
+      result = {};
+      for (const [key, value] of Object.entries(current)) {
+        result[key] = recurse(value, `${path}/${key}`);
+      }
+    }
+
+    activeStack.delete(current);
+
+    return result;
+  }
+
+  return recurse(obj, '#');
+}
+
+export function resolveThymianPointers<T>(root: T): T {
+  const index = new Map();
+
+  function buildIndex(current: any, path: string): any {
+    if (current === null || typeof current !== 'object') {
+      return;
+    }
+
+    index.set(path, current);
+
+    if (Array.isArray(current)) {
+      current.forEach((item, i) => buildIndex(item, `${path}/${i}`));
+    } else {
+      for (const key in current) {
+        if (key !== REF_KEY) {
+          buildIndex(current[key], `${path}/${key}`);
+        }
+      }
+    }
+  }
+
+  function link(current: any): any {
+    if (current === null || typeof current !== 'object') {
+      return current;
+    }
+
+    if (Object.hasOwn(current, REF_KEY)) {
+      const targetPath = current[REF_KEY];
+      if (!index.has(targetPath)) {
+        throw new Error(`Pointer ${targetPath} could not be resolved.`);
+      }
+      return index.get(targetPath);
+    }
+
+    if (Array.isArray(current)) {
+      for (let i = 0; i < current.length; i++) {
+        current[i] = link(current[i]);
+      }
+    } else {
+      for (const key in current) {
+        current[key] = link(current[key]);
+      }
+    }
+    return current;
+  }
+
+  buildIndex(root, '#');
+  return link(root);
+}

--- a/packages/core/src/format/circular-references.ts
+++ b/packages/core/src/format/circular-references.ts
@@ -2,7 +2,6 @@ const REF_KEY = '$thymian-ref';
 
 export function resolveCircularReferences<T>(obj: T): T {
   const activeStack = new Map();
-  const REF_KEY = '$thymian-ref';
 
   function recurse(current: any, path: string): any {
     if (typeof current !== 'object' || current === null) {

--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -23,6 +23,10 @@ import {
   thymianRequestToOrigin,
 } from '../utils.js';
 import { matchObjects, type StringAndNumberProperties } from '../utils.js';
+import {
+  resolveCircularReferences,
+  resolveThymianPointers,
+} from './circular-references.js';
 import type { HasSample } from './edges/has-sample.edge.js';
 import type { HttpLink } from './edges/http-link.edge.js';
 import type { HttpTransaction } from './edges/http-transaction.edge.js';
@@ -655,12 +659,12 @@ export class ThymianFormat {
   }
 
   export(): SerializedThymianFormat {
-    return {
+    return resolveCircularReferences({
       ...this.graph.export(),
       attributes: {
         hash: this.toHash(),
       },
-    };
+    });
   }
 
   // TODO must implement this feature. But before we should think about the node and edge ID generation
@@ -762,7 +766,7 @@ export class ThymianFormat {
     const g = new MultiDirectedGraph<
       PartialBy<ThymianNode, 'sourceName'> | ThymianNode,
       PartialBy<ThymianEdge, 'sourceName'> | ThymianEdge
-    >().import(graph);
+    >().import(resolveThymianPointers(graph));
 
     g.forEachNode((_, node) => {
       node.sourceName ??= sourceName;

--- a/packages/core/test/format/circular-references.test.ts
+++ b/packages/core/test/format/circular-references.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveCircularReferences,
+  resolveThymianPointers,
+} from '../../src/format/circular-references';
+
+describe('resolveCircularReferences', () => {
+  it('should handle primitives without modification', () => {
+    expect(resolveCircularReferences(null)).toBe(null);
+    expect(resolveCircularReferences(42)).toBe(42);
+    expect(resolveCircularReferences('string')).toBe('string');
+    expect(resolveCircularReferences(true)).toBe(true);
+  });
+
+  it('should handle simple objects without circular references', () => {
+    const obj = { a: 1, b: 'test', c: true };
+    const result = resolveCircularReferences(obj);
+    expect(result).toStrictEqual(obj);
+  });
+
+  it('should handle nested objects without circular references', () => {
+    const obj = {
+      level1: {
+        level2: {
+          value: 'deep',
+        },
+      },
+    };
+    const result = resolveCircularReferences(obj);
+    expect(result).toStrictEqual(obj);
+  });
+
+  it('should handle arrays without circular references', () => {
+    const arr = [1, 2, { a: 3 }];
+    const result = resolveCircularReferences(arr);
+    expect(result).toStrictEqual(arr);
+  });
+
+  it('should replace self-referencing circular reference with $thymian-ref', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+
+    const result = resolveCircularReferences(obj);
+    expect(result).toStrictEqual({
+      a: 1,
+      self: { '$thymian-ref': '#' },
+    });
+  });
+
+  it('should handle nested circular references', () => {
+    const parent: Record<string, unknown> = { name: 'parent' };
+    const child = { name: 'child', parent };
+    parent.child = child;
+
+    const result = resolveCircularReferences(parent);
+    expect(result).toStrictEqual({
+      name: 'parent',
+      child: {
+        name: 'child',
+        parent: { '$thymian-ref': '#' },
+      },
+    });
+  });
+
+  it('should handle circular references in arrays', () => {
+    const arr: any[] = [1, 2];
+    arr.push(arr);
+
+    const result = resolveCircularReferences(arr);
+    expect(result).toEqual([1, 2, { '$thymian-ref': '#' }]);
+  });
+
+  it('should do not replace multiple references to the same object without circular reference', () => {
+    const shared = { value: 'shared' };
+    const obj = {
+      ref1: shared,
+      ref2: shared,
+    };
+
+    const result = resolveCircularReferences(obj);
+    expect(result).toStrictEqual({
+      ref1: { value: 'shared' },
+      ref2: { value: 'shared' },
+    });
+  });
+
+  it('should generate correct paths for deeply nested circular references', () => {
+    const obj: any = {
+      a: {
+        b: {
+          c: {},
+        },
+      },
+    };
+    obj.a.b.c.backToRoot = obj;
+    obj.a.b.c.backToA = obj.a;
+
+    const result = resolveCircularReferences(obj);
+    expect(result).toEqual({
+      a: {
+        b: {
+          c: {
+            backToRoot: { '$thymian-ref': '#' },
+            backToA: { '$thymian-ref': '#/a' },
+          },
+        },
+      },
+    });
+  });
+
+  it('should handle complex object with multiple circular references', () => {
+    const nodeA: Record<string, unknown> = { id: 'A' };
+    const nodeB: Record<string, unknown> = { id: 'B' };
+    const nodeC: Record<string, unknown> = { id: 'C' };
+
+    nodeA.next = nodeB;
+    nodeB.next = nodeC;
+    nodeC.next = nodeA;
+
+    const result = resolveCircularReferences({ root: nodeA });
+    expect(result).toEqual({
+      root: {
+        id: 'A',
+        next: {
+          id: 'B',
+          next: {
+            id: 'C',
+            next: { '$thymian-ref': '#/root' },
+          },
+        },
+      },
+    });
+  });
+
+  it('should not use references for arrays with non-circular object references', () => {
+    const item = { id: 1 };
+    const arr = [item, item];
+
+    const result = resolveCircularReferences(arr);
+    expect(result).toEqual([{ id: 1 }, { id: 1 }]);
+  });
+});
+
+describe('resolveThymianPointers', () => {
+  it('should handle primitives without modification', () => {
+    expect(resolveThymianPointers(null)).toBe(null);
+    expect(resolveThymianPointers(42)).toBe(42);
+    expect(resolveThymianPointers('string')).toBe('string');
+    expect(resolveThymianPointers(true)).toBe(true);
+  });
+
+  it('should handle objects without $thymian-ref pointers', () => {
+    const obj = { a: 1, b: { c: 2 } };
+    const result = resolveThymianPointers(obj);
+    expect(result).toEqual(obj);
+  });
+
+  it('should resolve simple $thymian-ref pointer to root', () => {
+    const obj = {
+      a: 1,
+      self: { '$thymian-ref': '#' },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.self).toBe(result);
+    expect(result.a).toBe(1);
+  });
+
+  it('should resolve $thymian-ref pointer to nested property', () => {
+    const obj = {
+      target: { value: 'shared' },
+      ref: { '$thymian-ref': '#/target' },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.ref).toBe(result.target);
+    expect(result.ref).toEqual({ value: 'shared' });
+  });
+
+  it('should resolve multiple $thymian-ref pointers', () => {
+    const obj = {
+      original: { data: 'test' },
+      ref1: { '$thymian-ref': '#/original' },
+      ref2: { '$thymian-ref': '#/original' },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.ref1).toBe(result.original);
+    expect(result.ref2).toBe(result.original);
+    expect(result.ref1).toBe(result.ref2);
+  });
+
+  it('should resolve $thymian-ref in arrays', () => {
+    const obj = {
+      item: { id: 1 },
+      list: [{ '$thymian-ref': '#/item' }],
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.list[0]).toBe(result.item);
+  });
+
+  it('should resolve deeply nested $thymian-ref pointers', () => {
+    const obj = {
+      a: {
+        b: {
+          c: { value: 'deep' },
+        },
+      },
+      ref: { '$thymian-ref': '#/a/b/c' },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.ref).toBe(result.a.b.c);
+    expect(result.ref).toEqual({ value: 'deep' });
+  });
+
+  it('should resolve $thymian-ref with array indices', () => {
+    const arr = [{ id: 0 }, { id: 1 }, { '$thymian-ref': '#/0' }];
+
+    const result = resolveThymianPointers(arr);
+    expect(result[2]).toBe(result[0]);
+    expect(result[2]).toEqual({ id: 0 });
+  });
+
+  it('should throw error for invalid $thymian-ref pointer', () => {
+    const obj = {
+      ref: { '$thymian-ref': '#/nonexistent' },
+    };
+
+    expect(() => resolveThymianPointers(obj)).toThrow(
+      'Pointer #/nonexistent could not be resolved.',
+    );
+  });
+
+  it('should throw error for invalid deeply nested pointer', () => {
+    const obj = {
+      a: { b: {} },
+      ref: { '$thymian-ref': '#/a/b/c/d' },
+    };
+
+    expect(() => resolveThymianPointers(obj)).toThrow(
+      'Pointer #/a/b/c/d could not be resolved.',
+    );
+  });
+
+  it('should restore circular structure from resolved references', () => {
+    const obj = {
+      a: {
+        b: {
+          backToRoot: { '$thymian-ref': '#' },
+        },
+      },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.a.b.backToRoot).toBe(result);
+  });
+
+  it('should handle complex circular graph restoration', () => {
+    const obj = {
+      root: {
+        id: 'A',
+        next: {
+          id: 'B',
+          next: {
+            id: 'C',
+            next: { '$thymian-ref': '#/root' },
+          },
+        },
+      },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.root.next.next.next).toBe(result.root);
+  });
+
+  it('should work as inverse of resolveCircularReferences', () => {
+    const original: any = {
+      shared: { value: 'test' },
+    };
+    original.ref1 = original.shared;
+    original.ref2 = original.shared;
+
+    const resolved = resolveCircularReferences(original);
+    const restored = resolveThymianPointers(resolved);
+
+    expect(restored.ref1).toStrictEqual(restored.shared);
+    expect(restored.ref2).toStrictEqual(restored.shared);
+  });
+
+  it('should restore self-referencing structure', () => {
+    const obj: Record<string, any> = {
+      a: 1,
+      self: { '$thymian-ref': '#' },
+    };
+
+    const result = resolveThymianPointers(obj);
+    expect(result.self).toBe(result);
+    expect(result.self.self).toBe(result);
+  });
+});

--- a/packages/core/test/format/thymian-format.test.ts
+++ b/packages/core/test/format/thymian-format.test.ts
@@ -7,6 +7,7 @@ import {
   ThymianFormat,
   type ThymianHttpRequest,
   ThymianHttpResponse,
+  ThymianSchema,
 } from '../../src';
 
 describe('ThymianFormat', () => {
@@ -556,6 +557,72 @@ describe('ThymianFormat', () => {
       expect(() =>
         format.addEdge(reqId, resId, edge, { throwIfExists: true }),
       ).toThrow();
+    });
+  });
+
+  describe('export', () => {
+    it('should be robust against circular references', () => {
+      const format = new ThymianFormat();
+      const schema: ThymianSchema = {
+        type: 'object',
+        properties: {
+          prop: { type: 'string' },
+        },
+      };
+      schema.properties['circular'] = schema;
+      format.addHttpTransaction(
+        {
+          cookies: {},
+          headers: {},
+          host: 'localhost',
+          label: '',
+          mediaType: '',
+          method: 'post',
+          path: '/',
+          pathParameters: {},
+          port: 8080,
+          protocol: 'http',
+          queryParameters: {},
+          sourceName: '',
+          type: 'http-request',
+          body: schema,
+        },
+        {
+          headers: {},
+          label: '',
+          mediaType: '',
+          sourceName: '',
+          statusCode: 0,
+          type: 'http-response',
+        },
+        'test',
+      );
+      const exported = format.export();
+
+      let serialized!: string;
+      expect(() => {
+        serialized = JSON.stringify(exported);
+      }).not.toThrowError();
+
+      console.log(serialized);
+
+      const formatAgain = ThymianFormat.import(JSON.parse(serialized));
+      const transactions = formatAgain.getThymianHttpTransactions();
+
+      expect(transactions).toHaveLength(1);
+      const expectedSchema = {
+        type: 'object',
+        properties: {
+          prop: { type: 'string' },
+        },
+      };
+      expectedSchema.properties['circular'] = expectedSchema;
+
+      expect(transactions[0].thymianReq).toMatchObject({
+        body: expectedSchema,
+      });
+
+      expect(serialized).toStrictEqual(JSON.stringify(formatAgain.export()));
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/thymianofficial/thymian-internal/issues/21

## Summary
Replace circular references in ThymianFormat with JSON pointers to enable safe serialization and deserialization.

## Changes
* Added circular reference handling: Implemented resolveCircularReferences() and resolveThymianPointers() functions in packages/core/src/format/circular-references.ts
* Integrated with ThymianFormat: Updated export() to replace circular references with JSON pointers ($thymian-ref) and import() to restore them
* Comprehensive test coverage: Added 303 lines of tests covering primitives, nested objects, arrays, self-references, and complex circular graphs

## Technical Details

The implementation uses JSON pointer syntax (#/path/to/object) to track object references during serialization. When a circular reference is detected, it's replaced with { "$thymian-ref": "#/path" }. During deserialization, these pointers are resolved back to the actual object references, fully restoring the circular structure.