### PR TITLE
Mk/feat/feedback command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16432,7 +16432,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -28530,7 +28529,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -35167,6 +35165,7 @@
         "@thymian/rfc-9110-rules": "0.0.0-PLACEHOLDER",
         "@thymian/sampler": "0.0.0-PLACEHOLDER",
         "@thymian/websocket-proxy": "0.0.0-PLACEHOLDER",
+        "open": "^8.4.2",
         "ora": "^5.3.0",
         "tslib": "^2.3.0"
       },

--- a/packages/cli-common/src/base-cli-run-command.ts
+++ b/packages/cli-common/src/base-cli-run-command.ts
@@ -15,6 +15,8 @@ import {
   type ThymianPlugin,
 } from '@thymian/core';
 
+import { ErrorCache } from './error-cache.js';
+import { Feedback } from './feedback.js';
 import { filterFlag } from './flags/filter-flag.js';
 import { optionFlag, optionRegexp } from './flags/option-flag.js';
 import { getConfig } from './get-config.js';
@@ -86,6 +88,11 @@ export abstract class BaseCliRunCommand<
       description: 'Set current working directory.',
     }),
     filter: filterFlag(),
+    ['suppress-feedback']: Flags.boolean({
+      default: false,
+      description: 'Suppress feedback messages from Thymian.',
+      helpGroup: 'BASE',
+    }),
   };
 
   protected flags!: CommandFlags<T>;
@@ -94,6 +101,8 @@ export abstract class BaseCliRunCommand<
   protected thymianConfig!: ThymianConfig;
   protected thymian!: Thymian;
   public filter!: HttpFilterExpression;
+  protected feedback!: Feedback;
+  protected errorCache!: ErrorCache;
 
   public override async init(): Promise<void> {
     await super.init();
@@ -114,6 +123,9 @@ export abstract class BaseCliRunCommand<
       cwd: this.flags.cwd,
       idleTimeout: this.flags['idle-timeout'],
     });
+    this.feedback = Feedback.forCommand(this);
+    this.errorCache = ErrorCache.forCommand(this);
+
     this.thymianConfig = await getConfig(this.flags.config, this.flags.cwd);
     this.overridePluginOptions();
 
@@ -128,9 +140,35 @@ export abstract class BaseCliRunCommand<
       await this.addPluginsToThymianConfig();
       await this.registerPluginsFromConfig();
     }
+
+    await this.feedback.run();
   }
 
-  protected override catch(err: CommandError): Promise<void> {
+  protected override async catch(err: CommandError): Promise<void> {
+    await this.feedback.error();
+    const versionDetails = this.config.versionDetails;
+
+    const pluginVersions = Object.entries(versionDetails.pluginVersions ?? {})
+      .filter(([name]) => !name.startsWith('@oclif'))
+      .map(([name, version]) => ({ name, version: version.version }));
+
+    await this.errorCache.write({
+      name: err.name,
+      message: err.message,
+      commandName: this.id ?? 'unknown command',
+      timestamp: Date.now(),
+      cause: err.cause,
+      stack: err.stack,
+      argv: process.argv,
+      version: {
+        architecture: versionDetails.architecture,
+        cliVersion: versionDetails.cliVersion,
+        nodeVersion: versionDetails.nodeVersion,
+        osVersion: versionDetails.osVersion,
+      },
+      pluginVersions,
+    });
+
     if (err instanceof ThymianBaseError) {
       const cliError = new CLIError(err.message, {
         suggestions: err.options.suggestions,
@@ -291,5 +329,9 @@ export abstract class BaseCliRunCommand<
     for (const name of Object.keys(this.thymianConfig.plugins)) {
       await this.registerPlugin(name);
     }
+  }
+
+  public shouldSuppressFeedback(): boolean {
+    return this.flags['suppress-feedback'];
   }
 }

--- a/packages/cli-common/src/error-cache.ts
+++ b/packages/cli-common/src/error-cache.ts
@@ -1,0 +1,69 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { Command } from '@oclif/core';
+
+import type { BaseCliRunCommand } from './base-cli-run-command.js';
+import type { ThymianBaseCommand } from './thymian-base-command.js';
+
+export type CachedError = {
+  name: string;
+  message: string;
+  stack?: string | undefined;
+  cause?: unknown | undefined;
+  commandName: string;
+  timestamp: number;
+  argv: string[];
+  version: {
+    architecture: string;
+    cliVersion: string;
+    nodeVersion: string;
+    osVersion?: string;
+  };
+  pluginVersions: {
+    name: string;
+    version: string;
+  }[];
+};
+
+export class ErrorCache {
+  constructor(private readonly dir: string) {}
+
+  async write(error: CachedError): Promise<void> {
+    const cacheFile = path.join(this.dir, 'last_error.json');
+
+    try {
+      await fs.mkdir(this.dir, { recursive: true });
+
+      await fs.writeFile(cacheFile, JSON.stringify(error));
+    } catch (err) {
+      /* empty */
+    }
+  }
+
+  async read(): Promise<CachedError | undefined> {
+    const cacheFile = path.join(this.dir, 'last_error.json');
+
+    try {
+      const error = await fs.readFile(cacheFile, 'utf-8');
+
+      return JSON.parse(error);
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  async reset(): Promise<void> {
+    const cacheFile = path.join(this.dir, 'last_error.json');
+
+    await fs.unlink(cacheFile);
+  }
+
+  static forCommand(
+    command:
+      | ThymianBaseCommand<typeof Command>
+      | BaseCliRunCommand<typeof Command>,
+  ): ErrorCache {
+    return new ErrorCache(command.config.cacheDir);
+  }
+}

--- a/packages/cli-common/src/feedback.ts
+++ b/packages/cli-common/src/feedback.ts
@@ -18,7 +18,7 @@ export class Feedback {
       return;
     }
 
-    if (Math.random() < 0.2) {
+    if (this.shouldPrintFeedback()) {
       this.wasRun = true;
       await this.onRun();
     }
@@ -28,6 +28,11 @@ export class Feedback {
     if (!this.wasRun) {
       await this.onRun();
     }
+  }
+
+  // print the feedback hint in 20% of the cases
+  shouldPrintFeedback(): boolean {
+    return Math.random() < 0.2;
   }
 
   static forCommand(

--- a/packages/cli-common/src/feedback.ts
+++ b/packages/cli-common/src/feedback.ts
@@ -1,0 +1,43 @@
+import type { Command } from '@oclif/core';
+
+import type { BaseCliRunCommand } from './base-cli-run-command.js';
+import type { ThymianBaseCommand } from './thymian-base-command.js';
+
+export class Feedback {
+  private wasRun = false;
+
+  constructor(
+    initial: boolean,
+    private readonly onRun: () => Promise<unknown>,
+  ) {
+    this.wasRun = initial;
+  }
+
+  async run(): Promise<void> {
+    if (this.wasRun) {
+      return;
+    }
+
+    if (Math.random() < 0.2) {
+      this.wasRun = true;
+      await this.onRun();
+    }
+  }
+
+  async error(): Promise<void> {
+    if (!this.wasRun) {
+      await this.onRun();
+    }
+  }
+
+  static forCommand(
+    command:
+      | ThymianBaseCommand<typeof Command>
+      | BaseCliRunCommand<typeof Command>,
+  ): Feedback {
+    return new Feedback(
+      command.jsonEnabled() || command.shouldSuppressFeedback(),
+      () => command.config.runHook('thymian.feedback', {}),
+    );
+  }
+}

--- a/packages/cli-common/src/index.ts
+++ b/packages/cli-common/src/index.ts
@@ -1,9 +1,11 @@
 export * from './base-cli-run-command.js';
 export * from './default-config.js';
+export * from './error-cache.js';
 export * as oclif from './oclif.js';
 export * from './plugin-hook.js';
 export * as prompts from './prompts.js';
 export * from './read-plugins.js';
+export * from './thymian-base-command.js';
 export * from './thymian-config.js';
 export * from './thymian-config-schema.js';
 export * as yaml from './yaml.js';

--- a/packages/cli-common/src/plugin-hook.ts
+++ b/packages/cli-common/src/plugin-hook.ts
@@ -6,6 +6,9 @@ declare module '@oclif/core/interfaces' {
       options: ThymianPluginInitOptions;
       return: ThymianPluginInitResult;
     };
+    'thymian.feedback': {
+      options: Record<PropertyKey, unknown>;
+    };
   }
 }
 
@@ -25,3 +28,5 @@ export type ThymianPluginInitResult<
 export type ThymianPluginInitHook<
   T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>,
 > = (options: ThymianPluginInitOptions) => Promise<ThymianPluginInitResult<T>>;
+
+export type ThymianFeedbackHook = () => Promise<void>;

--- a/packages/cli-common/src/thymian-base-command.ts
+++ b/packages/cli-common/src/thymian-base-command.ts
@@ -1,0 +1,77 @@
+import { Command, Flags, Interfaces } from '@oclif/core';
+import type { CommandError } from '@oclif/core/interfaces';
+
+import { ErrorCache } from './error-cache.js';
+import { Feedback } from './feedback.js';
+
+type Flags<T extends typeof Command> = Interfaces.InferredFlags<
+  (typeof ThymianBaseCommand)['baseFlags'] & T['flags']
+>;
+type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>;
+
+export abstract class ThymianBaseCommand<
+  T extends typeof Command,
+> extends Command {
+  static override enableJsonFlag = true;
+
+  static override baseFlags = {
+    ['suppress-feedback']: Flags.boolean({
+      default: false,
+      description: 'Suppress feedback messages from Thymian.',
+      helpGroup: 'BASE',
+    }),
+  };
+
+  protected flags!: Flags<T>;
+  protected args!: Args<T>;
+  protected feedback!: Feedback;
+  protected errorCache!: ErrorCache;
+
+  public override async init(): Promise<void> {
+    await super.init();
+    const { args, flags } = await this.parse({
+      flags: this.ctor.flags,
+      baseFlags: (super.ctor as typeof ThymianBaseCommand).baseFlags,
+      enableJsonFlag: this.ctor.enableJsonFlag,
+      args: this.ctor.args,
+      strict: this.ctor.strict,
+    });
+    this.flags = flags as Flags<T>;
+    this.args = args as Args<T>;
+    this.feedback = Feedback.forCommand(this);
+    this.errorCache = ErrorCache.forCommand(this);
+
+    await this.feedback.run();
+  }
+
+  protected override async catch(err: CommandError): Promise<void> {
+    await this.feedback.error();
+    const versionDetails = this.config.versionDetails;
+
+    const pluginVersions = Object.entries(versionDetails.pluginVersions ?? {})
+      .filter(([name]) => !name.startsWith('@oclif'))
+      .map(([name, version]) => ({ name, version: version.version }));
+
+    await this.errorCache.write({
+      name: err.name,
+      message: err.message,
+      commandName: this.id ?? 'unknown command',
+      timestamp: Date.now(),
+      cause: err.cause,
+      stack: err.stack,
+      argv: process.argv,
+      version: {
+        architecture: versionDetails.architecture,
+        cliVersion: versionDetails.cliVersion,
+        nodeVersion: versionDetails.nodeVersion,
+        osVersion: versionDetails.osVersion,
+      },
+      pluginVersions,
+    });
+    return super.catch(err);
+  }
+
+  public shouldSuppressFeedback(): boolean {
+    return this.flags['suppress-feedback'];
+  }
+}

--- a/packages/cli-common/test/error-cache.test.ts
+++ b/packages/cli-common/test/error-cache.test.ts
@@ -1,0 +1,252 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type CachedError, ErrorCache } from '../src/error-cache.js';
+
+describe('ErrorCache', () => {
+  let tempDir: string;
+  let errorCache: ErrorCache;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'error-cache-test-'));
+    errorCache = new ErrorCache(tempDir);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('write', () => {
+    it('should write error data to cache file', async () => {
+      const error: CachedError = {
+        name: 'TestError',
+        message: 'Test error message',
+        commandName: 'test:command',
+        timestamp: Date.now(),
+        argv: ['node', 'thymian', 'test'],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+          osVersion: 'Linux',
+        },
+        pluginVersions: [],
+      };
+
+      await errorCache.write(error);
+
+      const cacheFile = join(tempDir, 'last_error.json');
+      const content = await readFile(cacheFile, 'utf-8');
+      const cached = JSON.parse(content);
+
+      expect(cached).toEqual(error);
+    });
+
+    it('should create directory if it does not exist', async () => {
+      const nestedDir = join(tempDir, 'nested', 'path');
+      const nestedCache = new ErrorCache(nestedDir);
+
+      const error: CachedError = {
+        name: 'TestError',
+        message: 'Test',
+        commandName: 'test',
+        timestamp: Date.now(),
+        argv: [],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      await nestedCache.write(error);
+
+      const cacheFile = join(nestedDir, 'last_error.json');
+      const content = await readFile(cacheFile, 'utf-8');
+
+      expect(content).toBeDefined();
+    });
+
+    it('should overwrite existing cache file', async () => {
+      const error1: CachedError = {
+        name: 'FirstError',
+        message: 'First',
+        commandName: 'test1',
+        timestamp: 1000,
+        argv: [],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      const error2: CachedError = {
+        name: 'SecondError',
+        message: 'Second',
+        commandName: 'test2',
+        timestamp: 2000,
+        argv: [],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      await errorCache.write(error1);
+      await errorCache.write(error2);
+
+      const cached = await errorCache.read();
+      expect(cached?.name).toBe('SecondError');
+      expect(cached?.timestamp).toBe(2000);
+    });
+
+    it('should handle write failures gracefully', async () => {
+      const invalidCache = new ErrorCache('/invalid/readonly/path');
+      const error: CachedError = {
+        name: 'TestError',
+        message: 'Test',
+        commandName: 'test',
+        timestamp: Date.now(),
+        argv: [],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      // Should not throw
+      await expect(invalidCache.write(error)).resolves.toBeUndefined();
+    });
+
+    it('should include optional fields', async () => {
+      const error: CachedError = {
+        name: 'TestError',
+        message: 'Test error',
+        stack: 'Error: Test\n  at test.ts:10',
+        cause: { reason: 'underlying cause' },
+        commandName: 'test',
+        timestamp: Date.now(),
+        argv: ['node', 'thymian'],
+        version: {
+          architecture: 'arm64',
+          cliVersion: '2.0.0',
+          nodeVersion: 'v20.0.0',
+          osVersion: 'Darwin 23.0.0',
+        },
+        pluginVersions: [
+          { name: '@thymian/openapi', version: '1.0.0' },
+          { name: '@thymian/http-linter', version: '2.0.0' },
+        ],
+      };
+
+      await errorCache.write(error);
+      const cached = await errorCache.read();
+
+      expect(cached?.stack).toBe(error.stack);
+      expect(cached?.cause).toEqual(error.cause);
+      expect(cached?.version.osVersion).toBe('Darwin 23.0.0');
+      expect(cached?.pluginVersions).toHaveLength(2);
+    });
+  });
+
+  describe('read', () => {
+    it('should return undefined when cache file does not exist', async () => {
+      const result = await errorCache.read();
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should read and parse cached error', async () => {
+      const error: CachedError = {
+        name: 'ReadTestError',
+        message: 'Read test',
+        commandName: 'read:test',
+        timestamp: 123456,
+        argv: ['test'],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      await errorCache.write(error);
+      const cached = await errorCache.read();
+
+      expect(cached).toEqual(error);
+    });
+
+    it('should return undefined on JSON parse errors', async () => {
+      const cacheFile = join(tempDir, 'last_error.json');
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(cacheFile, '{ invalid json }');
+
+      const result = await errorCache.read();
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle file read failures gracefully', async () => {
+      const invalidCache = new ErrorCache('/invalid/readonly/path');
+
+      const result = await invalidCache.read();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('should delete cache file', async () => {
+      const error: CachedError = {
+        name: 'TestError',
+        message: 'Test',
+        commandName: 'test',
+        timestamp: Date.now(),
+        argv: [],
+        version: {
+          architecture: 'x64',
+          cliVersion: '1.0.0',
+          nodeVersion: 'v18.0.0',
+        },
+        pluginVersions: [],
+      };
+
+      await errorCache.write(error);
+      expect(await errorCache.read()).toBeDefined();
+
+      await errorCache.reset();
+
+      expect(await errorCache.read()).toBeUndefined();
+    });
+
+    it('should handle missing file when resetting', async () => {
+      // Should not throw when file doesn't exist
+      await expect(errorCache.reset()).rejects.toThrow();
+    });
+  });
+
+  describe('forCommand', () => {
+    it('should create ErrorCache with command cache directory', () => {
+      const mockCommand = {
+        config: {
+          cacheDir: '/test/cache/dir',
+        },
+      } as any;
+
+      const cache = ErrorCache.forCommand(mockCommand);
+
+      expect(cache).toBeInstanceOf(ErrorCache);
+    });
+  });
+});

--- a/packages/cli-common/test/feedback.test.ts
+++ b/packages/cli-common/test/feedback.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Feedback } from '../src/feedback.js';
+
+describe('Feedback', () => {
+  let mockOnRun: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOnRun = vi.fn().mockResolvedValue(undefined);
+  });
+
+  describe('run', () => {
+    it('should not execute hook if wasRun is true', async () => {
+      const feedback = new Feedback(true, mockOnRun);
+
+      await feedback.run();
+
+      expect(mockOnRun).not.toHaveBeenCalled();
+    });
+
+    it('should execute hook with probability when wasRun is false', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should not execute hook when random value is >= 0.2', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.3);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+
+      expect(mockOnRun).not.toHaveBeenCalled();
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should execute hook when random value is exactly at threshold', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.19);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should set wasRun to true after execution', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+      await feedback.run();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should not execute multiple times even when called multiple times', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+      await feedback.run();
+      await feedback.run();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should handle async onRun correctly', async () => {
+      let resolved = false;
+      const asyncOnRun = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        resolved = true;
+      });
+
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = new Feedback(false, asyncOnRun);
+
+      await feedback.run();
+
+      expect(asyncOnRun).toHaveBeenCalled();
+      expect(resolved).toBe(true);
+      mathRandomSpy.mockRestore();
+    });
+  });
+
+  describe('error', () => {
+    it('should execute hook if not already run', async () => {
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.error();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not re-execute if already run', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+      await feedback.error();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should execute even if run was called but did not trigger', async () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const feedback = new Feedback(false, mockOnRun);
+
+      await feedback.run();
+      await feedback.error();
+
+      expect(mockOnRun).toHaveBeenCalledTimes(1);
+      mathRandomSpy.mockRestore();
+    });
+
+    it('should handle errors from onRun', async () => {
+      const errorOnRun = vi.fn().mockRejectedValue(new Error('Hook failed'));
+
+      const feedback = new Feedback(false, errorOnRun);
+
+      await expect(feedback.error()).rejects.toThrow('Hook failed');
+    });
+  });
+
+  describe('forCommand', () => {
+    it('should create Feedback with wasRun=true when JSON output enabled', () => {
+      const mockCommand = {
+        jsonEnabled: () => true,
+        shouldSuppressFeedback: () => false,
+        config: {
+          runHook: vi.fn(),
+        },
+      } as any;
+
+      const feedback = Feedback.forCommand(mockCommand);
+
+      expect(feedback).toBeInstanceOf(Feedback);
+    });
+
+    it('should create Feedback with wasRun=true when suppress-feedback flag is set', () => {
+      const mockCommand = {
+        jsonEnabled: () => false,
+        shouldSuppressFeedback: () => true,
+        config: {
+          runHook: vi.fn(),
+        },
+      } as any;
+
+      const feedback = Feedback.forCommand(mockCommand);
+
+      expect(feedback).toBeInstanceOf(Feedback);
+    });
+
+    it('should create Feedback with wasRun=false otherwise', () => {
+      const mockCommand = {
+        jsonEnabled: () => false,
+        shouldSuppressFeedback: () => false,
+        config: {
+          runHook: vi.fn(),
+        },
+      } as any;
+
+      const feedback = Feedback.forCommand(mockCommand);
+
+      expect(feedback).toBeInstanceOf(Feedback);
+    });
+
+    it('should bind correct hook callback', async () => {
+      const runHookMock = vi.fn().mockResolvedValue(undefined);
+      const mockCommand = {
+        jsonEnabled: () => false,
+        shouldSuppressFeedback: () => false,
+        config: {
+          runHook: runHookMock,
+        },
+      } as any;
+
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+      const feedback = Feedback.forCommand(mockCommand);
+      await feedback.run();
+
+      expect(runHookMock).toHaveBeenCalledWith('thymian.feedback', {});
+      mathRandomSpy.mockRestore();
+    });
+  });
+});

--- a/packages/http-linter/src/cli/commands/http-linter/generate.ts
+++ b/packages/http-linter/src/cli/commands/http-linter/generate.ts
@@ -1,6 +1,7 @@
 import { EOL } from 'node:os';
 
-import { Command, Flags } from '@thymian/cli-common/oclif';
+import { ThymianBaseCommand } from '@thymian/cli-common';
+import { Flags } from '@thymian/cli-common/oclif';
 import { checkbox, input, select } from '@thymian/cli-common/prompts';
 import type { JSONSchemaType } from '@thymian/core';
 
@@ -63,7 +64,7 @@ ${cjs ? 'module.exports =' : 'export default'} httpRule('${meta.name}')
   return template + '  .done()' + EOL;
 }
 
-export default class Generate extends Command {
+export default class Generate extends ThymianBaseCommand<typeof Generate> {
   static override flags = {
     cjs: Flags.boolean({
       description: 'Generate HTTP linter rule for CommonJs.',
@@ -79,10 +80,8 @@ export default class Generate extends Command {
   };
 
   override async run(): Promise<void> {
-    const { flags } = await this.parse(Generate);
-
     const name =
-      flags.prefix +
+      this.flags.prefix +
       (await input({ message: 'What is the name of your rule?' }));
 
     const severity = await select<RuleSeverity>({
@@ -91,7 +90,7 @@ export default class Generate extends Command {
     });
 
     const url =
-      flags.url ??
+      this.flags.url ??
       (await input({
         message: 'Url:',
         default: '',
@@ -150,6 +149,6 @@ export default class Generate extends Command {
       ruleMeta.appliesTo = appliesTo;
     }
 
-    this.log(createRuleTemplate(ruleMeta, flags.cjs));
+    this.log(createRuleTemplate(ruleMeta, this.flags.cjs));
   }
 }

--- a/packages/thymian/package.json
+++ b/packages/thymian/package.json
@@ -27,6 +27,7 @@
     "@oclif/plugin-version": "^2.2.30",
     "@thymian/cli-common": "0.0.0-PLACEHOLDER",
     "@thymian/core": "0.0.0-PLACEHOLDER",
+    "@thymian/evaluation": "0.0.0-PLACEHOLDER",
     "@thymian/format-validator": "0.0.0-PLACEHOLDER",
     "@thymian/http-linter": "0.0.0-PLACEHOLDER",
     "@thymian/openapi": "0.0.0-PLACEHOLDER",
@@ -34,7 +35,7 @@
     "@thymian/rfc-9110-rules": "0.0.0-PLACEHOLDER",
     "@thymian/sampler": "0.0.0-PLACEHOLDER",
     "@thymian/websocket-proxy": "0.0.0-PLACEHOLDER",
-    "@thymian/evaluation": "0.0.0-PLACEHOLDER",
+    "open": "^8.4.2",
     "ora": "^5.3.0",
     "tslib": "^2.3.0"
   },
@@ -44,6 +45,9 @@
   "oclif": {
     "bin": "thymian",
     "commands": "./dist/commands",
+    "hooks": {
+      "thymian.feedback": "./dist/hooks/feedback"
+    },
     "dirname": "thymian",
     "topicSeparator": ":",
     "plugins": [

--- a/packages/thymian/src/commands/feedback.ts
+++ b/packages/thymian/src/commands/feedback.ts
@@ -1,0 +1,121 @@
+import {
+  type CachedError,
+  oclif,
+  prompts,
+  ThymianBaseCommand,
+} from '@thymian/cli-common';
+import open from 'open';
+
+import { createEmailReport } from '../create-email-issue-for-error.js';
+import { createGithubIssueUrlForError } from '../create-github-issue-url-for-error.js';
+
+export class Feedback extends ThymianBaseCommand<typeof Feedback> {
+  protected static CONTACT = 'c3VwcG9ydEB0aHltaWFuLmRldg==';
+
+  override shouldSuppressFeedback(): boolean {
+    return true;
+  }
+
+  override async run(): Promise<void> {
+    const lastError = await this.errorCache.read();
+
+    this.log('✨ Thank you for your feedback! ✨');
+    this.log();
+
+    if (lastError) {
+      this.log(
+        `${oclif.ux.colorize('yellow', '⚠')} It looks like you encountered an error while running the ${oclif.ux.colorize('cyan', lastError.commandName)} command recently.`,
+      );
+      this.log();
+
+      const reportError = await prompts.confirm({
+        message: 'Do you want to report this error?',
+      });
+
+      if (reportError) {
+        await this.errorCache.reset();
+
+        await this.reportError(lastError);
+      } else {
+        await this.provideFeedback();
+      }
+    } else {
+      await this.provideFeedback();
+    }
+  }
+
+  private async reportError(error: CachedError): Promise<void> {
+    const choices = [
+      {
+        name: 'Via GitHub',
+        description: 'Report the error on GitHub via a new issue.',
+        value: 'github',
+      },
+      {
+        name: 'Via Email',
+        description: 'Contact the Thymian Core team via Email.',
+        value: 'email',
+      },
+      {
+        name: 'Not at all ',
+        description: "I don't want to report this error.",
+        value: 'none',
+      },
+    ] as const;
+
+    const choice = await prompts.select({
+      message: 'How do you want to report this error?',
+      choices,
+    });
+    this.log();
+
+    if (choice === 'github') {
+      await open(createGithubIssueUrlForError(error));
+    } else if (choice === 'email') {
+      await open(
+        createEmailReport(
+          Buffer.from(Feedback.CONTACT, 'base64').toString('utf-8'),
+          error,
+        ),
+      );
+    }
+  }
+
+  private async provideFeedback(): Promise<void> {
+    const choices = [
+      {
+        name: 'Via GitHub',
+        description: 'Open a GitHub issue to provide feedback.',
+        value: 'github',
+      },
+      {
+        name: 'Via Email',
+        description: 'Contact the Thymian Core team via Email.',
+        value: 'email',
+      },
+      {
+        name: 'Not at all ',
+        description: "I don't want to give feedback.",
+        value: 'none',
+      },
+    ] as const;
+
+    const choice = await prompts.select({
+      message: 'How would you like to provide feedback?',
+      choices,
+    });
+
+    if (choice === 'github') {
+      await open('https://github.com/thymianofficial/thymian/issues/new');
+    } else if (choice === 'email') {
+      const recipient = Buffer.from(Feedback.CONTACT, 'base64').toString(
+        'utf-8',
+      );
+      const subject = 'Thymian CLI Feedback';
+      const body = `Hi Support Team,\n\nI'd like to provide some feedback regarding the CLI.\n\n[Please enter your message here]\n\nBest regards,\n[Your Name]`;
+      await open(
+        `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`,
+      );
+    }
+  }
+}

--- a/packages/thymian/src/commands/init.ts
+++ b/packages/thymian/src/commands/init.ts
@@ -1,12 +1,16 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { defaultConfig, type ThymianConfig } from '@thymian/cli-common';
-import { Command, Flags } from '@thymian/cli-common/oclif';
+import {
+  defaultConfig,
+  ThymianBaseCommand,
+  type ThymianConfig,
+} from '@thymian/cli-common';
+import { Flags } from '@thymian/cli-common/oclif';
 import { stringify } from '@thymian/cli-common/yaml';
 import { type Logger, TextLogger } from '@thymian/core';
 
-export default class Init extends Command {
+export default class Init extends ThymianBaseCommand<typeof Init> {
   static override description = 'Initialize Thymian in your project.';
   static override examples = ['<%= config.bin %> <%= command.id %>'];
 
@@ -32,15 +36,9 @@ export default class Init extends Command {
   private readonly thymianConfig: ThymianConfig = defaultConfig;
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(Init);
-
-    if (flags['no-input']) {
-      return this.printConfig(flags.yaml);
-    }
-
     const hookResults = await this.config.runHook('thymian-plugin.init', {
-      cwd: flags.cwd,
-      interactive: !flags.yes,
+      cwd: this.flags.cwd,
+      interactive: !this.flags.yes,
     });
 
     if (hookResults.failures.length > 0) {
@@ -65,12 +63,12 @@ export default class Init extends Command {
     }
 
     const configFilePath = join(
-      flags.cwd,
-      `${flags['config-file']}${flags.yaml ? '.yaml' : '.json'}`,
+      this.flags.cwd,
+      `${this.flags['config-file']}${this.flags.yaml ? '.yaml' : '.json'}`,
     );
 
     try {
-      await writeFile(configFilePath, this.getConfig(flags.yaml), {
+      await writeFile(configFilePath, this.getConfig(this.flags.yaml), {
         encoding: 'utf-8',
         flag: 'wx',
       });

--- a/packages/thymian/src/create-email-issue-for-error.ts
+++ b/packages/thymian/src/create-email-issue-for-error.ts
@@ -1,0 +1,39 @@
+import type { CachedError } from '@thymian/cli-common';
+
+export function createEmailReport(
+  recipient: string,
+  errorData: CachedError,
+): string {
+  const subject = `CLI Error Report: ${errorData.commandName}`;
+
+  const body = `
+Hi Support Team,
+
+I'd like to provide some feedback regarding the CLI.
+
+${
+  errorData
+    ? `--- ERROR REPORT ---
+Command: ${errorData.commandName}
+Timestamp: ${new Date(errorData.timestamp).toLocaleString()}
+
+ENVIRONMENT:
+- CLI: ${errorData.version.cliVersion}
+- Node: ${errorData.version.nodeVersion}
+- OS: ${errorData.version.osVersion} (${errorData.version.architecture})
+
+PLUGINS:
+${errorData.pluginVersions.map((p) => `  - ${p.name}: ${p.version}`).join('\n')}
+
+STACKTRACE:
+${errorData.stack?.replaceAll(process.env.HOME || '', '~') || 'No stacktrace available'}
+--------------------`
+    : 'Description of my feedback:\n\n[Please enter your message here]'
+}
+
+Best regards,
+[Your Name]
+`.trim();
+
+  return `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}

--- a/packages/thymian/src/create-github-issue-url-for-error.ts
+++ b/packages/thymian/src/create-github-issue-url-for-error.ts
@@ -1,0 +1,54 @@
+import type { CachedError } from '@thymian/cli-common';
+
+export function createGithubIssueUrlForError(error: CachedError): string {
+  const baseUrl = 'https://github.com/thymianofficial/thymian/issues/new';
+
+  const title = `${error.name} while running in command \`${error.commandName}\``;
+
+  const pluginTable =
+    error?.pluginVersions
+      .map((p) => `| ${p.name} | ${p.version} |`)
+      .join('\n') || '| none | - |';
+
+  const body = `
+### 📝 Description
+### 💻 Environment
+- **CLI Version:** \`${error.version.cliVersion || 'N/A'}\`
+- **Node Version:** \`${error.version.nodeVersion || 'N/A'}\`
+- **OS:** \`${error?.version.osVersion || 'N/A'}\` (${error.version.architecture})
+- **Command:** \`${error?.commandName} || ''}\`
+- **Timestamp:** ${error ? new Date(error.timestamp).toLocaleString() : 'N/A'}
+
+<details>
+<summary><b>🔌 Installed Plugins</b></summary>
+
+| Plugin | Version |
+| :--- | :--- |
+${pluginTable}
+</details>
+
+### 🔍 Error Details
+${
+  error.stack
+    ? `
+<details>
+<summary><b>Click to expand Stacktrace</b></summary>
+
+\`\`\`text
+${error.stack.replaceAll(process.env.HOME || '', '~')}
+\`\`\`
+</details>
+`
+    : '_No stacktrace available._'
+}
+
+---
+*Reported via \`thymian feedback\`*`.trim();
+
+  const url = new URL(baseUrl);
+  url.searchParams.set('title', title);
+  url.searchParams.set('body', body);
+  url.searchParams.set('labels', 'bug');
+
+  return url.toString();
+}

--- a/packages/thymian/src/hooks/feedback.ts
+++ b/packages/thymian/src/hooks/feedback.ts
@@ -1,0 +1,10 @@
+import { oclif, type ThymianFeedbackHook } from '@thymian/cli-common';
+
+const hook: ThymianFeedbackHook = async () => {
+  const message = `${oclif.ux.colorize('blueBright', `🚀  Tip: Found a bug or wanna give feedback? Run ${oclif.ux.colorize('bold', 'thymian feedback')}.`)}`;
+
+  console.log(message);
+  console.log();
+};
+
+export default hook;

--- a/packages/thymian/test/create-email-issue-for-error.test.ts
+++ b/packages/thymian/test/create-email-issue-for-error.test.ts
@@ -1,0 +1,355 @@
+import { type CachedError } from '@thymian/cli-common';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createEmailReport } from '../src/create-email-issue-for-error.js';
+
+describe('createEmailReport', () => {
+  const originalHome = process.env.HOME;
+  const testRecipient = 'support@example.com';
+
+  beforeEach(() => {
+    process.env.HOME = '/home/testuser';
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+  });
+
+  it('should generate proper mailto URL', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test error message',
+      commandName: 'test:command',
+      timestamp: Date.now(),
+      argv: ['node', 'thymian', 'test'],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+        osVersion: 'Linux',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+
+    expect(url).toMatch(/^mailto:support@example\.com\?subject=.*&body=.*/);
+  });
+
+  it('should URL-encode subject', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test:command',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+
+    expect(url).toContain('subject=CLI%20Error%20Report%3A%20test%3Acommand');
+  });
+
+  it('should URL-encode body', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('Hi Support Team,');
+  });
+
+  it('should include error details when errorData provided', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test error',
+      commandName: 'test:command',
+      timestamp: 1234567890000,
+      argv: ['node', 'thymian'],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+        osVersion: 'Linux',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('--- ERROR REPORT ---');
+    expect(decodedUrl).toContain('Command: test:command');
+  });
+
+  it('should include environment information', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'arm64',
+        cliVersion: '2.0.0',
+        nodeVersion: 'v20.0.0',
+        osVersion: 'Darwin 23.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('ENVIRONMENT:');
+    expect(decodedUrl).toContain('- CLI: 2.0.0');
+    expect(decodedUrl).toContain('- Node: v20.0.0');
+    expect(decodedUrl).toContain('- OS: Darwin 23.0.0 (arm64)');
+  });
+
+  it('should include plugin versions', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [
+        { name: '@thymian/openapi', version: '1.0.0' },
+        { name: '@thymian/http-linter', version: '2.0.0' },
+      ],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('PLUGINS:');
+    expect(decodedUrl).toContain('- @thymian/openapi: 1.0.0');
+    expect(decodedUrl).toContain('- @thymian/http-linter: 2.0.0');
+  });
+
+  it('should include stack trace with HOME replaced by ~', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      stack: `Error: Test\n  at /home/testuser/project/src/test.ts:10\n  at /home/testuser/.config/test.js:20`,
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('STACKTRACE:');
+    expect(decodedUrl).toContain('~/project/src/test.ts:10');
+    expect(decodedUrl).toContain('~/.config/test.js:20');
+    expect(decodedUrl).not.toContain('/home/testuser');
+  });
+
+  it('should handle missing stack trace', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('STACKTRACE:');
+    expect(decodedUrl).toContain('No stacktrace available');
+  });
+
+  it('should format timestamp correctly', () => {
+    const timestamp = 1234567890000;
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp,
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    const expectedTimestamp = new Date(timestamp).toLocaleString();
+    expect(decodedUrl).toContain(`Timestamp: ${expectedTimestamp}`);
+  });
+
+  it('should include feedback message header', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('Hi Support Team,');
+    expect(decodedUrl).toContain(
+      "I'd like to provide some feedback regarding the CLI.",
+    );
+  });
+
+  it('should include footer with signature placeholder', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('Best regards,');
+    expect(decodedUrl).toContain('[Your Name]');
+  });
+
+  it('should handle empty plugin list', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    expect(decodedUrl).toContain('PLUGINS:');
+    // Empty array should result in empty plugins section
+    expect(decodedUrl).toMatch(/PLUGINS:\s+STACKTRACE:/);
+  });
+
+  it('should use correct subject format', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'custom:command',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+
+    expect(url).toContain('subject=CLI%20Error%20Report%3A%20custom%3Acommand');
+  });
+
+  it('should include recipient in mailto URL', () => {
+    const customRecipient = 'custom@support.com';
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(customRecipient, error);
+
+    expect(url).toContain('mailto:custom@support.com?');
+  });
+
+  it('should trim body content', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createEmailReport(testRecipient, error);
+    const decodedUrl = decodeURIComponent(url);
+
+    // Body should start with Hi Support Team (no leading whitespace)
+    expect(decodedUrl).toContain('body=Hi Support Team,');
+  });
+});

--- a/packages/thymian/test/create-github-issue-url-for-error.test.ts
+++ b/packages/thymian/test/create-github-issue-url-for-error.test.ts
@@ -1,0 +1,329 @@
+import { type CachedError } from '@thymian/cli-common';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createGithubIssueUrlForError } from '../src/create-github-issue-url-for-error.js';
+
+describe('createGithubIssueUrlForError', () => {
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    process.env.HOME = '/home/testuser';
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+  });
+
+  it('should generate correct GitHub issue URL', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test error message',
+      commandName: 'test:command',
+      timestamp: 1234567890000,
+      argv: ['node', 'thymian', 'test'],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+        osVersion: 'Linux',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+
+    expect(url).toContain(
+      'https://github.com/thymianofficial/thymian/issues/new',
+    );
+  });
+
+  it('should include proper title with error name and command', () => {
+    const error: CachedError = {
+      name: 'ConfigurationError',
+      message: 'Invalid config',
+      commandName: 'init',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+
+    expect(parsedUrl.searchParams.get('title')).toBe(
+      'ConfigurationError while running in command `init`',
+    );
+  });
+
+  it('should set labels parameter to bug', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+
+    expect(parsedUrl.searchParams.get('labels')).toBe('bug');
+  });
+
+  it('should include environment details in body', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'arm64',
+        cliVersion: '2.0.0',
+        nodeVersion: 'v20.0.0',
+        osVersion: 'Darwin 23.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('**CLI Version:** `2.0.0`');
+    expect(body).toContain('**Node Version:** `v20.0.0`');
+    expect(body).toContain('**OS:** `Darwin 23.0.0` (arm64)');
+    expect(body).toContain('**Command:** `test');
+  });
+
+  it('should include plugin table in collapsible section', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [
+        { name: '@thymian/openapi', version: '1.0.0' },
+        { name: '@thymian/http-linter', version: '2.0.0' },
+      ],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('🔌 Installed Plugins');
+    expect(body).toContain('| @thymian/openapi | 1.0.0 |');
+    expect(body).toContain('| @thymian/http-linter | 2.0.0 |');
+  });
+
+  it('should show "none" when no plugins installed', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('| none | - |');
+  });
+
+  it('should include stack trace in collapsible code block', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test error',
+      stack: 'Error: Test error\n  at test.ts:10\n  at run.ts:20',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('Click to expand Stacktrace');
+    expect(body).toContain('```text');
+    expect(body).toContain('Error: Test error');
+    expect(body).toContain('at test.ts:10');
+  });
+
+  it('should handle missing stack trace gracefully', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('_No stacktrace available._');
+    expect(body).not.toContain('Click to expand Stacktrace');
+  });
+
+  it('should replace HOME directory with ~ in stack traces', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      stack: `Error: Test\n  at /home/testuser/project/src/test.ts:10\n  at /home/testuser/.config/test.js:20`,
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('~/project/src/test.ts:10');
+    expect(body).toContain('~/.config/test.js:20');
+    expect(body).not.toContain('/home/testuser');
+  });
+
+  it('should handle missing osVersion gracefully', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('**OS:** `N/A` (x64)');
+  });
+
+  it('should format timestamp correctly', () => {
+    const timestamp = 1234567890000;
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp,
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    const expectedTimestamp = new Date(timestamp).toLocaleString();
+    expect(body).toContain(`**Timestamp:** ${expectedTimestamp}`);
+  });
+
+  it('should include markdown formatting for body', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('### 📝 Description');
+    expect(body).toContain('### 💻 Environment');
+    expect(body).toContain('### 🔍 Error Details');
+    expect(body).toContain('*Reported via `thymian feedback`*');
+  });
+
+  it('should include details tags for collapsible sections', () => {
+    const error: CachedError = {
+      name: 'TestError',
+      message: 'Test',
+      stack: 'Error: Test\n  at test.ts:10',
+      commandName: 'test',
+      timestamp: Date.now(),
+      argv: [],
+      version: {
+        architecture: 'x64',
+        cliVersion: '1.0.0',
+        nodeVersion: 'v18.0.0',
+      },
+      pluginVersions: [{ name: '@thymian/openapi', version: '1.0.0' }],
+    };
+
+    const url = createGithubIssueUrlForError(error);
+    const parsedUrl = new URL(url);
+    const body = parsedUrl.searchParams.get('body');
+
+    expect(body).toContain('<details>');
+    expect(body).toContain('<summary>');
+    expect(body).toContain('</details>');
+    expect(body).toContain('</summary>');
+  });
+});


### PR DESCRIPTION
Implements:
* error caching (e.g. for macos in the `/Library/Caches/thymian` folder)
* the `feedback` command
* suggests the feedback command for every error and with a probability of 20% for each command

How can you test the new functionality?

1. checkout the the branch
2. build thymian
3. from root dir run `./packages/thymian/bin/run.js init --yes` 
5. then `./packages/thymian/bin/run.js run`
6. You should then see an error and the tip to run the `feedback command`. Do this via `./packages/thymian/bin/run.js feedback`

Closes https://github.com/thymianofficial/thymian-internal/issues/111