### PR TITLE
docs: Enhance README with quick start guide and enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,85 @@
+<div align="center">
+  <img src="./astro-docs/src/assets/logo.svg" alt="Thymian Logo" width="200"/>
+
 # Thymian
 
-Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
+**Add resilience and HTTP conformance to your API development workflow**
 
-## Getting Started
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-green.svg)](./LICENSE)
+[![CI](https://github.com/thymianofficial/thymian/actions/workflows/ci.yaml/badge.svg)](https://github.com/thymianofficial/thymian/actions/workflows/ci.yaml)
+[![Documentation](https://img.shields.io/badge/docs-thymian.dev-green.svg)](https://thymian.dev)
+[![Discord](https://img.shields.io/discord/1440702693768429791?logo=discord&label=Discord&color=5865F2)](https://discord.gg/TRSwCxbz9f)
+[![Reddit](https://img.shields.io/badge/Reddit-ThymianOfficial-FF4500?logo=reddit)](https://www.reddit.com/r/ThymianOfficial/)
+[![Twitter](https://img.shields.io/badge/Twitter-@thymiandev-1DA1F2?logo=x)](https://x.com/thymiandev)
 
-You want to try out Thymian? Run the following commands in the specific order:
+</div>
 
-- `npm i`
-- `nx build cli`
-- `npx tsx shared/test-utils/src/example-app/server.ts`
-- `cd cli`
-- `./bin/run.js run -o @thymian/openapi.filePath=../shared/test-utils/src/example-app/example-app.openapi.yaml -p test/fixtures/my-thymian-plugin.js`
+Thymian is an innovative, language-agnostic open-source library that revolutionizes **API development** by combining **resilience testing and HTTP conformance linting** into a single, robust workflow. By integrating static analysis with runtime testing, it ensures your APIs strictly adhere to **RFC/IETF standards and industry best practices** throughout their entire lifecycle.
 
-## local publish
+## Key Capabilities:
 
-1. Start verdaccio: `npm run local-registry`
-2. Publish to local registry: `npx nx release publish --registry http://localhost:4873` or `npm run local-publish`
+- **Standards-First:** Validates against official HTTP specifications.
+- **API Lifecycle Testing:** Apply the same rules from static analysis to runtime testing and traffic analysis.
+- **Language-Agnostic:** Built to fit into any tech stack without friction.
+- **Extensible:** Easily customize your analysis with custom rules and plugins.
 
-## How to run and build the astro documentation
+## 🚀 Quick Installation
 
-Don't call astro targets directly but always use the nx commands!
+### Installation
 
-- run: `nx run astro:serve`
-- build: `nx run astro:build`
+You won't need to install Thymian locally, we will just use `npx` for this.
 
-## Documentation Guidelines
+Check if you can run Thymian by running the following command:
 
-There are different kinds of documentation:
+```bash
+npx @thymian/cli --version
+```
 
-- [Architecture documentation](docs/arc42/README.md): Here you find the architecture documentation of Thymian. If you make any kind of decisions that are hard to change and have a long-lasting impact, document them here.
-- [Astro documentation](astro-docs/README.md): The astro documentation is available as a website to the users. It contains general information about Thymian, How-To's and reference documentation for the plugins and the CLI. Add any kind of End-User documentation here (except for plugins, see next point).
-- Plugin documentation: The plugin documentation is part of the astro documentation. It is located in `docs` folders in the plugin projects but will be added to the astro documentation during the build process.
-- Subproject READMEs: You have technical documentation that is subproject-specific? Put it into the README of the subproject.
+### Initialization
 
-## Documentation
+Now navigate to your project's root directory and run the following command to initialize Thymian:
 
-For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).
+```bash
+npx @thymian/cli init --yes
+```
+
+The [`init`](https://thymian.dev/references/cli/#thymian-init) command sets up Thymian in your project. The `--yes` flag will skip
+interactive prompts and use default settings. This command will:
+
+1. Detect your OpenAPI specification file
+2. Create a `thymian.config.yaml` configuration file in your project
+
+### Running Your First Analysis
+
+Run your first analysis by navigating to your project's root directory and run:
+
+```bash
+npx @thymian/cli run
+```
+
+## 📚 Documentation
+
+- **[Getting Started](https://thymian.dev/introduction/getting-started)** - Set up Thymian in minutes
+- **[Documentation](https://thymian.dev)** - Comprehensive guides and API reference
+- **[CLI Reference](https://thymian.dev/references/cli)** - Complete CLI command documentation
+- **[HTTP Rules](https://thymian.dev/guides/http-rules/how-to-use-rules)** - Learn about HTTP conformance validation
+
+## 🏢 Enterprise Support
+
+Get professional consulting and dedicated support from the creators of Thymian. We offer:
+
+- API design and governance strategies
+- HTTP standards compliance auditing
+- Custom plugin development
+- Custom rule development
+- Team training and workshops
+
+**[Learn more about Enterprise Support](https://thymian.dev/enterprise)** | **Email: [support@thymian.dev](mailto:support@thymian.com)**
+
+---
+
+<div align="center">
+
+**Shipped with 🌱 by [qupaya](https://qupaya.com)**
+
+</div>

--- a/packages/thymian/README.md
+++ b/packages/thymian/README.md
@@ -1,11 +1,19 @@
-# Thymian
+# @thymian/cli
 
-Add resilience and HTTP conformance to your API development workflow. Thymian is a lightweight, language-agnostic library that helps you build robust APIs.
+Main CLI entry point for Thymian - a lightweight, language-agnostic library that helps you build robust APIs by adding resilience testing and HTTP conformance validation to your development workflow.
 
-## @thymian/cli
+## Installation
 
-Main CLI entry point for Thymian.
+```bash
+npm install @thymian/cli
+```
+
+## Quick Start
+
+```bash
+npx thymian run
+```
 
 ## Documentation
 
-For comprehensive documentation, visit [Thymian Documentation](https://thymian.dev/).
+For comprehensive documentation, guides, and API reference, visit [Thymian Documentation](https://thymian.dev/).


### PR DESCRIPTION
## Summary
Update to the main README and CLI package README to improve user onboarding and showcase enterprise offerings.

## Changes
- **Enhanced main README structure**:
  - Added logo and badge section (license, CI, docs, social links)
  - Expanded introduction with key capabilities
  - Added quick installation section using `npx` (no local install needed)
  - Added initialization guide with `thymian init --yes`
  - Added "Running Your First Analysis" section
  - Added links to documentation sections (Getting Started, CLI Reference, HTTP Rules)
  - Added Enterprise Support section with contact information
  - Improved visual layout with centered sections

- **Updated CLI package README**:
  - Added clearer package description
  - Added installation instructions
  - Added quick start example
  - Improved documentation link formatting

## Impact
- Lowers barrier to entry for new users with `npx` workflow
- Better visibility of enterprise support options
- More professional appearance with badges and structured layout
- Clearer path from discovery to first successful run

Preview: https://github.com/thymianofficial/thymian/blob/pm/feat/readme/README.md