### PR TITLE
feat(release): implement interactive latest release with approval gates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: "!contains(github.event.head_commit.message, '[skip-canary]')"
+    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -35,5 +37,42 @@ jobs:
 
       - name: Publish canary release
         run: node ./scripts/release.ts --version canary --no-dry-run --no-local
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-latest-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Check out repository at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract version from release tag
+        id: extract-version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${TAG_NAME#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Publish to npm
+        run: node ./scripts/release.ts --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Release script - requires review from core maintainers
+/scripts/release.ts @Markus-Ende @BaggersIO
+
+# Workflow - requires review from core maintainers
+/.github/workflows/release.yaml @Markus-Ende @BaggersIO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Triggered automatically on every push to `main`:
 
 ```bash
 # Happens automatically via GitHub Actions
-# Publishes to npm with tag @canary
+# Publishes to npm with dist-tag `canary`
 # Version format: X.Y.Z-canary.YYYYMMDD-{hash}
 ```
 
@@ -98,7 +98,7 @@ node ./scripts/release.ts --version latest --no-local
 **What happens:**
 
 1. Script determines next version using conventional commits
-2. Displays changelog and prompts for confirmation
+2. Displays version and project list, then prompts for confirmation
 3. On approval: creates git tag and GitHub Release
 4. GitHub Release triggers CI workflow
 5. CI workflow publishes to npm (requires environment approval)
@@ -138,8 +138,8 @@ git checkout main && git pull
 # 2. Preview the release (optional but recommended)
 node ./scripts/release.ts --version latest --no-local --dry-run
 
-# 3. Create the release (interactive)
-node ./scripts/release.ts --version latest --no-local
+# 3. Create the release (interactive, will ask for approval for new versions and changelog)
+node ./scripts/release.ts --version latest --no-local --no-dry-run
 # Review the version and changelog
 # Type 'yes' to confirm
 
@@ -160,7 +160,7 @@ node ./scripts/release.ts --version latest --no-local
 1. Build all packages
 2. Version with canary format
 3. Create changelog
-4. Publish to npm with `@canary` tag
+4. Publish to npm with dist-tag `canary`
 5. Requires `npm` environment approval
 
 #### Latest Release Workflow
@@ -173,7 +173,7 @@ node ./scripts/release.ts --version latest --no-local
 2. Checkout repository at release tag
 3. Build all packages
 4. Validate user is in allowlist
-5. Publish to npm with `@latest` tag
+5. Publish to npm with dist-tag `latest`
 6. Requires `npm` environment approval
 
 ### Release Configuration
@@ -222,4 +222,4 @@ Check:
 
 ### ADR Compliance
 
-This release system follows [ADR-0005](docs/arc42/adr/0005-no-version-commits.md) - no version commits are created. Version information lives only in git tags and GitHub Releases.
+This release system follows [ADR-0005](docs/arc42/adr/0005-tags-over-source-version-bumps.md) - no version commits are created. Version information lives only in git tags and GitHub Releases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Refer to this list when contributing to ensure consistent commit messages.
 | `type:app`         | All types                      | Executable packages or nx apps                                                                               |
 | `type:lib`         | `type:lib`                     | A library                                                                                                    |
 | `type:lib-feature` | `type:lib`, `type:lib-feature` | Features add functionality to libraries. E.g. publishable config, rule-sets or just splitted out source code |
+| `type:testing`     | All types                      | Testing libraries that should be accessible to all other projects for testing purposes                       |
 | `type:e2e`         | All types                      | End-to-end tests and testing utilities                                                                       |
 
 ## Releases
@@ -138,7 +139,7 @@ git checkout main && git pull
 # 2. Preview the release (optional but recommended)
 node ./scripts/release.ts --version latest --no-local --dry-run
 
-# 3. Create the release (interactive, will ask for approval for new versions and changelog)
+# 3. Create the release (interactive, will ask for approval; requires --no-dry-run to actually execute)
 node ./scripts/release.ts --version latest --no-local --no-dry-run
 # Review the version and changelog
 # Type 'yes' to confirm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,5 +50,176 @@ Refer to this list when contributing to ensure consistent commit messages.
 | `type:app`         | All types                      | Executable packages or nx apps                                                                               |
 | `type:lib`         | `type:lib`                     | A library                                                                                                    |
 | `type:lib-feature` | `type:lib`, `type:lib-feature` | Features add functionality to libraries. E.g. publishable config, rule-sets or just splitted out source code |
-| `type:testing`     | has no dependency constraints  | marker tag, to make a library accessible by test files                                                       |
 | `type:e2e`         | All types                      | End-to-end tests and testing utilities                                                                       |
+
+## Releases
+
+### Overview
+
+Thymian uses a three-tier release system:
+
+1. **Canary releases** - Automatic, triggered on every push to `main`
+2. **Latest releases** - Interactive, manually triggered with approval gates
+3. **Local releases** - For testing with local registry
+
+### Release Types
+
+#### Canary Release (Automatic)
+
+Triggered automatically on every push to `main`:
+
+```bash
+# Happens automatically via GitHub Actions
+# Publishes to npm with tag @canary
+# Version format: X.Y.Z-canary.YYYYMMDD-{hash}
+```
+
+**Skip canary release**: Include `[skip-canary]` in commit message.
+
+#### Latest Release (Interactive)
+
+For production releases with approval gates:
+
+```bash
+# Step 1: Preview what the release will look like (optional)
+node ./scripts/release.ts --version latest --no-local --dry-run
+
+# Step 2: Create the release (interactive)
+node ./scripts/release.ts --version latest --no-local
+
+# The script will:
+# - Calculate version from conventional commits
+# - Show version and changelog
+# - Ask for your confirmation
+# - Create git tag and GitHub Release (if confirmed)
+# - Trigger CI to publish to npm
+```
+
+**What happens:**
+
+1. Script determines next version using conventional commits
+2. Displays changelog and prompts for confirmation
+3. On approval: creates git tag and GitHub Release
+4. GitHub Release triggers CI workflow
+5. CI workflow publishes to npm (requires environment approval)
+
+**Authorization**: Only users in `VALID_AUTHORS_FOR_LATEST` in [scripts/release.ts](scripts/release.ts) can publish to npm.
+
+#### Local Release (Testing)
+
+For testing with local Verdaccio registry:
+
+```bash
+# Start local registry
+npm run local-registry
+
+# In another terminal, publish to local registry
+node ./scripts/release.ts --version patch --no-dry-run
+
+# Or specify exact version
+node ./scripts/release.ts --version 1.2.3 --no-dry-run
+```
+
+### Version Strategies
+
+- **`latest`** - Use conventional commits (recommended for production)
+- **`canary`** - Automatic canary version with date and commit hash
+- **`patch`** - Increment patch version (0.0.X)
+- **`minor`** - Increment minor version (0.X.0)
+- **`major`** - Increment major version (X.0.0)
+- **`1.2.3`** - Explicit semver version
+
+### Release Workflow for Maintainers
+
+```bash
+# 1. Ensure all changes are merged to main
+git checkout main && git pull
+
+# 2. Preview the release (optional but recommended)
+node ./scripts/release.ts --version latest --no-local --dry-run
+
+# 3. Create the release (interactive)
+node ./scripts/release.ts --version latest --no-local
+# Review the version and changelog
+# Type 'yes' to confirm
+
+# 4. Wait for GitHub Release to be created
+# 5. CI will trigger and wait for environment approval
+# 6. Approve the deployment in GitHub Actions
+# 7. Release is published to npm
+```
+
+### CI/CD Pipeline
+
+#### Canary Release Workflow
+
+**Trigger:** Push to `main` (skip with `[skip-canary]`)
+
+**Steps:**
+
+1. Build all packages
+2. Version with canary format
+3. Create changelog
+4. Publish to npm with `@canary` tag
+5. Requires `npm` environment approval
+
+#### Latest Release Workflow
+
+**Trigger:** GitHub Release published
+
+**Steps:**
+
+1. Extract version from release tag
+2. Checkout repository at release tag
+3. Build all packages
+4. Validate user is in allowlist
+5. Publish to npm with `@latest` tag
+6. Requires `npm` environment approval
+
+### Release Configuration
+
+Release behavior is configured in [nx.json](nx.json):
+
+```json
+{
+  "release": {
+    "git": {
+      "tag": true,
+      "commit": false,
+      "stageChanges": false
+    },
+    "changelog": {
+      "createRelease": "github"
+    }
+  }
+}
+```
+
+### Troubleshooting
+
+#### "Unauthorized user for latest release"
+
+Your GitHub username is not in `VALID_AUTHORS_FOR_LATEST`. Contact a maintainer to be added.
+
+#### "Local verdaccio is not running"
+
+```bash
+npm run local-registry
+```
+
+#### "No release needed"
+
+No commits since last release match conventional commit format or no changes detected.
+
+#### CI publish fails
+
+Check:
+
+1. `npm` environment is configured with approval gates
+2. `NPM_TOKEN` secret is set
+3. User is in allowlist
+4. Release tag format is valid semver
+
+### ADR Compliance
+
+This release system follows [ADR-0005](docs/arc42/adr/0005-no-version-commits.md) - no version commits are created. Version information lives only in git tags and GitHub Releases.

--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -15,3 +15,70 @@ TODO
 ## 8.4 Rules and Rulesets
 
 TODO
+
+## 8.5 Release and Versioning Process
+
+Thymian follows a tag-based release process that maintains clean version control history without committing version bumps (see [ADR-0005](adr/0005-tags-over-source-version-bumps.md)).
+
+### 8.5.1 Release Types
+
+**Canary Releases:**
+
+- Automatically triggered on every push to `main` branch
+- Published to npm with `@canary` tag
+- Version format: `{base-version}-canary.{YYYYMMDD}-{git-hash}`
+- Non-interactive, immediate publishing
+- Skipped when commit message contains `[skip-canary]`
+
+**Latest Releases:**
+
+- Manually triggered by developers using `--version latest`
+- Interactive approval flow with local review
+- Published to npm with `@latest` tag
+- Two-phase process: local creation of tag/release, CI publishing to npm
+- Requires GitHub environment approval and allowlist validation
+
+### 8.5.2 Latest Release Workflow
+
+**Local Phase (Developer):**
+
+1. Run `node ./scripts/release.ts --version latest --no-local`
+2. Script calculates next version using conventional commits
+3. Interactive prompt displays version and changelog
+4. Developer approves or declines
+5. If approved: Git tag and GitHub Release are created (no npm publish)
+6. If declined: Exit gracefully, no changes made
+
+**CI Phase (Automation):**
+
+1. GitHub Release publication triggers workflow (`on.release.types: [published]`)
+2. Workflow waits for GitHub environment approval (required reviewer)
+3. Script validates:
+   - `GITHUB_ACTOR` is in allowlist
+   - Registry is not localhost
+   - Version is exact semver (e.g., `1.2.3`)
+4. Publishes packages to npm
+5. No versioning or tagging occurs (already done locally)
+
+### 8.5.3 Version Management
+
+- **No version commits:** Package versions in `package.json` remain as placeholders in source control
+- **Git tags as source of truth:** Releases are identified by git tags (format: `{version}`)
+- **Conventional commits:** Automatic version calculation based on commit messages
+- **Nx release:** Leverages Nx release tooling for versioning, changelog, and publishing
+
+### 8.5.4 Security and Authorization
+
+- **Allowlist:** Hardcoded list of GitHub usernames authorized to publish to `@latest`
+- **Environment protection:** GitHub Environment (`npm`) can enforce required reviewer approval when configured in repository settings
+- **Trusted publishing:** Uses OIDC token authentication for npm publishing
+
+### 8.5.5 Key Configuration
+
+- `nx.json`: Release configuration with `git.tag: true`, `changelog.createRelease: 'github'`, and `git.commit: false`
+- `scripts/release.ts`: Release automation script with CI detection and interactive prompts
+- `.github/workflows/release.yaml`: CI workflows for canary and latest releases
+
+### 8.5.6 Related Documentation
+
+- [ADR-0005: Tags over Source Version Bumps](adr/0005-tags-over-source-version-bumps.md)

--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -25,7 +25,7 @@ Thymian follows a tag-based release process that maintains clean version control
 **Canary Releases:**
 
 - Automatically triggered on every push to `main` branch
-- Published to npm with `@canary` tag
+- Published to npm with dist-tag `canary`
 - Version format: `{base-version}-canary.{YYYYMMDD}-{git-hash}`
 - Non-interactive, immediate publishing
 - Skipped when commit message contains `[skip-canary]`
@@ -34,7 +34,7 @@ Thymian follows a tag-based release process that maintains clean version control
 
 - Manually triggered by developers using `--version latest`
 - Interactive approval flow with local review
-- Published to npm with `@latest` tag
+- Published to npm with dist-tag `latest`
 - Two-phase process: local creation of tag/release, CI publishing to npm
 - Requires GitHub environment approval and allowlist validation
 

--- a/docs/arc42/09-architectural-decisions.md
+++ b/docs/arc42/09-architectural-decisions.md
@@ -6,12 +6,13 @@ This chapter documents the significant architectural decisions made for Thymian.
 
 ## ADR Index
 
-| ADR                                              | Title                              | Status   | Date       | Related Quality Requirements                                                                                           |
-| ------------------------------------------------ | ---------------------------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
-| [ADR-0001](adr/0001-core-features-as-plugins.md) | Core features are plugins          | Accepted | 2024-11-07 | [10.2.2](10-quality-requirements.md#102-quality-scenarios), [10.2.3](10-quality-requirements.md#102-quality-scenarios) |
-| [ADR-0002](adr/0002-communication-as-plugin.md)  | Communication as a plugin          | Proposed | 2024-11-07 | [10.2.4](10-quality-requirements.md#102-quality-scenarios)                                                             |
-| [ADR-0003](adr/0003-plugins-allow-streaming.md)  | Plugins should allow for streaming | Proposed | 2024-11-07 | [10.2.1](10-quality-requirements.md#102-quality-scenarios), [10.2.2](10-quality-requirements.md#102-quality-scenarios) |
-| [ADR-0004](adr/0004-plugins-run-isolated.md)     | Plugins should run isolated        | Proposed | 2024-11-07 | [10.2.3](10-quality-requirements.md#102-quality-scenarios)                                                             |
+| ADR                                                    | Title                              | Status   | Date       | Related Quality Requirements                                                                                           |
+| ------------------------------------------------------ | ---------------------------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [ADR-0001](adr/0001-core-features-as-plugins.md)       | Core features are plugins          | Accepted | 2024-11-07 | [10.2.2](10-quality-requirements.md#102-quality-scenarios), [10.2.3](10-quality-requirements.md#102-quality-scenarios) |
+| [ADR-0002](adr/0002-communication-as-plugin.md)        | Communication as a plugin          | Proposed | 2024-11-07 | [10.2.4](10-quality-requirements.md#102-quality-scenarios)                                                             |
+| [ADR-0003](adr/0003-plugins-allow-streaming.md)        | Plugins should allow for streaming | Proposed | 2024-11-07 | [10.2.1](10-quality-requirements.md#102-quality-scenarios), [10.2.2](10-quality-requirements.md#102-quality-scenarios) |
+| [ADR-0004](adr/0004-plugins-run-isolated.md)           | Plugins should run isolated        | Proposed | 2024-11-07 | [10.2.3](10-quality-requirements.md#102-quality-scenarios)                                                             |
+| [ADR-0005](adr/0005-tags-over-source-version-bumps.md) | Use git tags for release versions  | Accepted | 2026-01-31 | —                                                                                                                      |
 
 ## Creating New ADRs
 

--- a/docs/arc42/adr/0005-tags-over-source-version-bumps.md
+++ b/docs/arc42/adr/0005-tags-over-source-version-bumps.md
@@ -1,0 +1,43 @@
+# ADR-0005: Use git tags for release versions
+
+| Status   | Date       | Supersedes | Superseded by |
+| -------- | ---------- | ---------- | ------------- |
+| Accepted | 2026-01-31 | —          | —             |
+
+## Context
+
+Thymian is a monorepo with multiple published packages. The release process uses Nx Release to calculate versions from conventional commits and publish to npm, including canary releases. Committing version bumps in each package.json would create noisy release commits and frequent merge conflicts.
+
+## Decision
+
+We will not commit version bumps to source control. Release versions will be recorded via git tags and the npm registry. Package.json files will keep a placeholder version (e.g., 0.0.0-PLACEHOLDER) to make it clear the source version is not authoritative.
+
+## Consequences
+
+**Positive:**
+
+- Git history remains clean and focused on functional changes.
+- No recurring merge conflicts in package.json files across packages.
+- Canary releases do not pollute history with temporary versions.
+
+**Negative:**
+
+- Developers must rely on git tags or npm registry to determine the current released version.
+- Local package.json does not reflect the published version.
+
+**Neutral:**
+
+- Release automation must continue to handle tagging and publishing consistently.
+
+## Related
+
+- [Chapter 04](../04-solution-strategy.md): Solution strategy
+
+---
+
+## Status History
+
+| Date       | Status   | Notes                         |
+| ---------- | -------- | ----------------------------- |
+| 2026-01-31 | Proposed | Initial draft                 |
+| 2026-01-31 | Accepted | Approved after team agreement |

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -45,12 +45,6 @@ function validateCIPublishMode(
     process.exit(1);
   }
 
-  // Validate registry is not localhost
-  if (isLocal) {
-    console.error('❌ Error: CI publish mode cannot use local registry');
-    process.exit(1);
-  }
-
   // Validate GitHub actor against allowlist
   const actor = process.env.GITHUB_ACTOR;
   if (!actor) {
@@ -99,7 +93,7 @@ async function promptUserConfirmation(
   const rl = readline.createInterface({ input, output });
   try {
     const answer = await rl.question(
-      '🤔 Do you want to proceed with this release? (yes/no): ',
+      '🤔 Do you want to proceed with this release? (yes/no or y/n): ',
     );
     return answer.toLowerCase() === 'yes' || answer.toLowerCase() === 'y';
   } finally {
@@ -219,7 +213,7 @@ async function promptUserConfirmation(
     console.log('🔍 Determining next version from conventional commits...\n');
     versionSpecifier = undefined; // Let conventional commits determine version
 
-    // Interactive confirmation for latest releases (local only, not dry-run)
+    // Interactive confirmation for latest releases
     // Run a dry-run first to get version info, then prompt, then execute
     if (!argv.local && !argv.dryRun && !isInCI()) {
       const previewResult = await client.releaseVersion({
@@ -286,8 +280,17 @@ async function promptUserConfirmation(
 
   // Skip publish for latest releases (will be triggered by GitHub Release)
   if (isLatest && !argv.local) {
-    console.log('\n✅ Tag and GitHub Release created successfully!');
-    console.log('   Publishing to npm will be triggered by GitHub Release.\n');
+    if (argv.dryRun) {
+      console.log('\n📋 DRY-RUN MODE: No changes were made.');
+      console.log(
+        '   In actual run: Tag and GitHub Release would be created, triggering CI to publish to npm.\n',
+      );
+    } else {
+      console.log('\n✅ Tag and GitHub Release created successfully!');
+      console.log(
+        '   Publishing to npm will be triggered by GitHub Release.\n',
+      );
+    }
     process.exit(0);
   }
 
@@ -301,7 +304,11 @@ async function promptUserConfirmation(
     tag: isCanary ? 'canary' : 'latest',
   });
 
-  if (!argv.dryRun) {
+  if (argv.dryRun) {
+    console.log(
+      '\n📋 DRY-RUN MODE: This was a dry-run. No changes were made.\n',
+    );
+  } else {
     console.log(
       '\n⚠️  WARNING: Do not commit the versioned package.json files. They have to be reverted after the release process.\n',
     );

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,8 +1,18 @@
 import { execSync } from 'node:child_process';
+import { stdin as input, stdout as output } from 'node:process';
+import * as readline from 'node:readline/promises';
 
 import { ReleaseClient } from 'nx/release/index.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+
+// Allowlist of GitHub usernames authorized to publish latest releases
+const VALID_AUTHORS_FOR_LATEST: string[] = [
+  'matthyk', // Matthias Keckl
+  'Markus-Ende', // Markus Ende
+  'BaggersIO', // Peter Müller
+  'atennert', // Andreas Tennert
+];
 
 async function isVerdaccioRunning(url: string): Promise<boolean> {
   try {
@@ -10,6 +20,90 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     return response.ok;
   } catch {
     return false;
+  }
+}
+
+function isInCI(): boolean {
+  return process.env.GITHUB_ACTIONS === 'true';
+}
+
+function validateCIPublishMode(
+  version: string | undefined,
+  isLocal: boolean,
+): void {
+  // CI publish-only mode validation
+  if (!isInCI() || isLocal) {
+    return; // Not in CI or local mode - skip validation
+  }
+
+  // Require exact semver version in CI
+  const semverRegex = /^\d+\.\d+\.\d+(-[a-z0-9.-]+)?(\+[a-z0-9.-]+)?$/i;
+  if (!version || !semverRegex.test(version)) {
+    console.error('❌ Error: CI publish mode requires exact semver version');
+    console.error(`   Received: ${version || 'undefined'}`);
+    console.error('   Expected: exact semver (e.g., 1.2.3, 1.0.0-beta.1)');
+    process.exit(1);
+  }
+
+  // Validate registry is not localhost
+  if (isLocal) {
+    console.error('❌ Error: CI publish mode cannot use local registry');
+    process.exit(1);
+  }
+
+  // Validate GitHub actor against allowlist
+  const actor = process.env.GITHUB_ACTOR;
+  if (!actor) {
+    console.error('❌ Error: GITHUB_ACTOR not set in CI environment');
+    process.exit(1);
+  }
+
+  if (!VALID_AUTHORS_FOR_LATEST.includes(actor)) {
+    console.error('❌ Error: Unauthorized user for latest release');
+    console.error(`   User: ${actor}`);
+    console.error(
+      `   Allowed users: ${VALID_AUTHORS_FOR_LATEST.join(', ') || 'none configured'}`,
+    );
+    process.exit(1);
+  }
+
+  console.log('✅ CI publish mode validation passed');
+  console.log(`   User: ${actor}`);
+  console.log(`   Version: ${version}\n`);
+}
+
+async function promptUserConfirmation(
+  version: string,
+  projectsVersionData: Record<string, { newVersion: string }>,
+): Promise<boolean> {
+  console.log('\n' + '='.repeat(60));
+  console.log('📦 RELEASE SUMMARY');
+  console.log('='.repeat(60));
+  console.log(`\n🏷️  Version: ${version}\n`);
+
+  // Display changelog/version data
+  if (projectsVersionData) {
+    console.log('📝 Projects to be released:');
+    for (const [project, data] of Object.entries(projectsVersionData)) {
+      console.log(`   • ${project}: ${data.newVersion}`);
+    }
+    console.log();
+  }
+
+  console.log('This will:');
+  console.log('  1. Create a git tag for this version');
+  console.log('  2. Create a GitHub Release');
+  console.log('  3. Trigger CI to publish to npm (requires approval)\n');
+  console.log('='.repeat(60) + '\n');
+
+  const rl = readline.createInterface({ input, output });
+  try {
+    const answer = await rl.question(
+      '🤔 Do you want to proceed with this release? (yes/no): ',
+    );
+    return answer.toLowerCase() === 'yes' || answer.toLowerCase() === 'y';
+  } finally {
+    rl.close();
   }
 }
 
@@ -47,9 +141,27 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     .parseAsync();
 
   const isCanary = isCanaryRelease(argv.version);
+  const isLatest = argv.version === 'latest';
+  const isCIPublishMode = isInCI() && !argv.local;
 
-  console.log(`\n${isCanary ? '🐤' : '📋'} Release Configuration:`);
-  console.log(`  mode: ${isCanary ? 'CANARY' : 'STANDARD'}`);
+  // Validate CI publish-only mode (skip for canary and dry-runs)
+  if (isCIPublishMode && !isCanary && !argv.dryRun) {
+    validateCIPublishMode(argv.version, argv.local);
+  }
+
+  let mode = 'STANDARD';
+  if (isCanary) {
+    mode = 'CANARY';
+  } else if (isLatest) {
+    mode = 'LATEST';
+  } else if (isCIPublishMode) {
+    mode = 'CI-PUBLISH';
+  }
+
+  console.log(
+    `\n${isCanary ? '🐤' : isLatest ? '🚀' : '📋'} Release Configuration:`,
+  );
+  console.log(`  mode: ${mode}`);
   console.log(`  version: ${argv.version || 'conventional commits'}`);
   console.log(`  dryRun: ${argv.dryRun}`);
   console.log(`  firstRelease: ${argv.firstRelease}`);
@@ -102,6 +214,42 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
     console.log(`   Commit hash: ${commitHash}\n`);
   }
 
+  // For latest releases, use conventional commits to determine version
+  if (isLatest) {
+    console.log('🔍 Determining next version from conventional commits...\n');
+    versionSpecifier = undefined; // Let conventional commits determine version
+  }
+
+  // CI publish-only mode: skip versioning and changelog, only publish
+  if (isCIPublishMode && !isCanary) {
+    console.log('🔄 CI publish-only mode: skipping versioning and changelog\n');
+
+    // Get the release graph from a dry-run versioning
+    const versionResult = await client.releaseVersion({
+      specifier: argv.version,
+      dryRun: true, // Don't actually version
+      firstRelease: false,
+      verbose: argv.verbose,
+      gitTag: false,
+    });
+
+    const publishResults = await client.releasePublish({
+      releaseGraph: versionResult.releaseGraph,
+      dryRun: argv.dryRun,
+      firstRelease: argv.firstRelease,
+      verbose: argv.verbose,
+      access: 'restricted',
+      registry: undefined, // Use default npm registry
+      tag: 'latest',
+    });
+
+    process.exit(
+      Object.values(publishResults).every((result) => result.code === 0)
+        ? 0
+        : 1,
+    );
+  }
+
   const { workspaceVersion, projectsVersionData, releaseGraph } =
     await client.releaseVersion({
       specifier: versionSpecifier,
@@ -111,6 +259,27 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
       gitTag: isCanary ? false : !argv.local,
     });
 
+  // Interactive confirmation for latest releases (local only, not dry-run)
+  if (isLatest && !argv.local && !argv.dryRun && !isInCI()) {
+    if (!workspaceVersion) {
+      console.error('❌ Error: Could not determine workspace version');
+      process.exit(1);
+    }
+
+    const confirmed = await promptUserConfirmation(
+      workspaceVersion,
+      projectsVersionData as Record<string, { newVersion: string }>,
+    );
+
+    if (!confirmed) {
+      console.log('\n❌ Release cancelled by user.\n');
+      process.exit(0);
+    }
+
+    console.log('\n✅ Release confirmed. Proceeding...\n');
+  }
+
+  // Create changelog for non-local, non-canary releases
   if (!argv.local && !isCanary) {
     await client.releaseChangelog({
       releaseGraph,
@@ -120,6 +289,13 @@ async function isVerdaccioRunning(url: string): Promise<boolean> {
       firstRelease: argv.firstRelease,
       verbose: argv.verbose,
     });
+  }
+
+  // Skip publish for latest releases (will be triggered by GitHub Release)
+  if (isLatest && !argv.local) {
+    console.log('\n✅ Tag and GitHub Release created successfully!');
+    console.log('   Publishing to npm will be triggered by GitHub Release.\n');
+    process.exit(0);
   }
 
   const publishResults = await client.releasePublish({

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -81,7 +81,7 @@ async function promptUserConfirmation(
   console.log('='.repeat(60));
   console.log(`\n🏷️  Version: ${version}\n`);
 
-  // Display changelog/version data
+  // Display projects and versions
   if (projectsVersionData) {
     console.log('📝 Projects to be released:');
     for (const [project, data] of Object.entries(projectsVersionData)) {
@@ -218,36 +218,49 @@ async function promptUserConfirmation(
   if (isLatest) {
     console.log('🔍 Determining next version from conventional commits...\n');
     versionSpecifier = undefined; // Let conventional commits determine version
-  }
 
-  // CI publish-only mode: skip versioning and changelog, only publish
-  if (isCIPublishMode && !isCanary) {
-    console.log('🔄 CI publish-only mode: skipping versioning and changelog\n');
+    // Interactive confirmation for latest releases (local only, not dry-run)
+    // Run a dry-run first to get version info, then prompt, then execute
+    if (!argv.local && !argv.dryRun && !isInCI()) {
+      const previewResult = await client.releaseVersion({
+        specifier: versionSpecifier,
+        dryRun: true, // Preview only
+        firstRelease: argv.firstRelease,
+        verbose: argv.verbose,
+        gitTag: false,
+      });
 
-    // Get the release graph from a dry-run versioning
-    const versionResult = await client.releaseVersion({
-      specifier: argv.version,
-      dryRun: true, // Don't actually version
-      firstRelease: false,
-      verbose: argv.verbose,
-      gitTag: false,
-    });
+      if (!previewResult.workspaceVersion) {
+        console.error('❌ Error: Could not determine workspace version');
+        process.exit(1);
+      }
 
-    const publishResults = await client.releasePublish({
-      releaseGraph: versionResult.releaseGraph,
-      dryRun: argv.dryRun,
-      firstRelease: argv.firstRelease,
-      verbose: argv.verbose,
-      access: 'restricted',
-      registry: undefined, // Use default npm registry
-      tag: 'latest',
-    });
+      // Generate changelog preview (prints to console)
+      console.log('\n📋 Changelog Preview:\n');
+      await client.releaseChangelog({
+        releaseGraph: previewResult.releaseGraph,
+        versionData: previewResult.projectsVersionData,
+        version: previewResult.workspaceVersion,
+        dryRun: true, // Preview mode - output to console only
+        firstRelease: argv.firstRelease,
+        verbose: true, // Show the full changelog output
+      });
 
-    process.exit(
-      Object.values(publishResults).every((result) => result.code === 0)
-        ? 0
-        : 1,
-    );
+      const confirmed = await promptUserConfirmation(
+        previewResult.workspaceVersion,
+        previewResult.projectsVersionData as Record<
+          string,
+          { newVersion: string }
+        >,
+      );
+
+      if (!confirmed) {
+        console.log('\n❌ Release cancelled by user.\n');
+        process.exit(0);
+      }
+
+      console.log('\n✅ Release confirmed. Proceeding...\n');
+    }
   }
 
   const { workspaceVersion, projectsVersionData, releaseGraph } =
@@ -258,26 +271,6 @@ async function promptUserConfirmation(
       verbose: argv.verbose,
       gitTag: isCanary ? false : !argv.local,
     });
-
-  // Interactive confirmation for latest releases (local only, not dry-run)
-  if (isLatest && !argv.local && !argv.dryRun && !isInCI()) {
-    if (!workspaceVersion) {
-      console.error('❌ Error: Could not determine workspace version');
-      process.exit(1);
-    }
-
-    const confirmed = await promptUserConfirmation(
-      workspaceVersion,
-      projectsVersionData as Record<string, { newVersion: string }>,
-    );
-
-    if (!confirmed) {
-      console.log('\n❌ Release cancelled by user.\n');
-      process.exit(0);
-    }
-
-    console.log('\n✅ Release confirmed. Proceeding...\n');
-  }
 
   // Create changelog for non-local, non-canary releases
   if (!argv.local && !isCanary) {


### PR DESCRIPTION
## Overview

This PR implements the interactive release workflow for manually triggered latest releases with local review and approval gating, while maintaining ADR-0005 (no version commits).

Closes thymian-internal#77

## Changes

### Phase 1: Script Enhancements (`scripts/release.ts`)
- Added `VALID_AUTHORS_FOR_LATEST` allowlist for authorized publishers
- Implemented CI publish-only mode that detects CI environment and skips versioning/changelog
- Added permission validation to check GitHub actor against allowlist
- Implemented interactive confirmation prompt using Node.js `readline` module
- Added `--version latest` option that uses conventional commits to determine next version
- Proper error handling and graceful cancellation support

### Phase 2: Workflow Updates (`.github/workflows/release.yaml`)
- Added trigger for `on.release.types: [published]`
- New `publish-latest-release` job with:
  - Environment protection gate (`environment: npm`)
  - Automatic version extraction from release tag
  - Publish-only mode for CI

### Phase 3: Security & Documentation
- Created `CODEOWNERS` file restricting release changes to core maintainers
- Integrated comprehensive release guide into `CONTRIBUTING.md`
- Added authorized publishers: matthyk, Markus-Ende, BaggersIO, atennert
## Workflow

### For Maintainers (Latest Release)

```bash
# 1. Preview the release (optional)
node ./scripts/release.ts --version latest --no-local --dry-run

# 2. Create the release (interactive)
node ./scripts/release.ts --version latest --no-local
# Review version and changelog
# Type 'yes' to confirm

# 3. Wait for GitHub Release to be created
# 4. CI automatically triggers
# 5. Approve the deployment in GitHub Actions
# 6. Release published to npm
```

### For Canary Releases
- Remains unchanged - automatic on push to main
- Include `[skip-canary]` in commit message to skip

## Key Features

- ✅ Interactive confirmation prompt with version and changelog preview
- ✅ Separation of concerns: local creates tag/release, CI publishes to npm
- ✅ GitHub environment approval gate for npm publishing
- ✅ Allowlist validation for authorized publishers
- ✅ Graceful cancellation support
- ✅ ADR-0005 compliant (no version commits)
- ✅ Comprehensive documentation

## Testing

The implementation has been tested with dry-run:
```bash
node ./scripts/release.ts --version latest --no-local --dry-run
```

Result: Version 0.0.3 calculated correctly from conventional commits, changelog generated.