### PR TITLE
fix(release): prevent duplicate tag creation in CI publish mode

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -257,13 +257,14 @@ async function promptUserConfirmation(
     }
   }
 
+  // Version the release (skip git tagging in CI - tags already exist from local release)
   const { workspaceVersion, projectsVersionData, releaseGraph } =
     await client.releaseVersion({
       specifier: versionSpecifier,
       dryRun: argv.dryRun,
       firstRelease: argv.firstRelease,
       verbose: argv.verbose,
-      gitTag: isCanary ? false : !argv.local,
+      gitTag: isCanary ? false : !argv.local && !isInCI(),
     });
 
   // Create changelog for non-local, non-canary releases


### PR DESCRIPTION
## Problem

When the `publish-latest-release` workflow is triggered by a GitHub Release, the release script attempts to create a git tag that already exists (the tag was created during the local release process). This causes the workflow to fail with:

```
Error: Unexpected error when creating tag 0.0.3:
fatal: tag '0.0.3' already exists
```

## Solution

Modified the `gitTag` parameter in `releaseVersion()` to skip tag creation when running in CI:

```typescript
gitTag: isCanary ? false : !argv.local && !isInCI()
```

This ensures tags are only created during:
- Local non-canary releases (the intended behavior)

Tags are skipped for:
- Canary releases (already skipped)
- Local releases (`argv.local` is true)
- **CI releases (new)** - the tag already exists from the local release

## Testing

The fix prevents the CI from attempting to recreate tags that were already created locally, allowing the publish workflow to complete successfully.

## Related Issues

Refs #77
