### PR TITLE
feat(release): add manual trigger for publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,12 @@ on:
       - main
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -44,12 +50,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
     steps:
+      - name: Determine tag
+        id: determine-tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Using tag: $TAG"
+
       - name: Check out repository at release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ steps.determine-tag.outputs.tag }}
           fetch-depth: 0
           filter: tree:0
 
@@ -66,7 +83,7 @@ jobs:
       - name: Extract version from release tag
         id: extract-version
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ steps.determine-tag.outputs.tag }}"
           # Remove 'v' prefix if present
           VERSION="${TAG_NAME#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Add `workflow_dispatch` trigger to the release workflow to enable manual retrying of failed publish operations for specific tags.

## Changes

- Added `workflow_dispatch` trigger with a `tag` input parameter
- Updated `publish-latest-release` job to handle both automatic (release published) and manual triggers
- Added "Determine tag" step that selects the appropriate tag based on trigger type

## Usage

To manually trigger a publish for a specific tag:

1. Go to **Actions** tab in GitHub
2. Select the **Release** workflow  
3. Click **Run workflow**
4. Enter the tag name (e.g., `v1.0.0`)
5. Click **Run workflow**

The workflow will checkout the specified tag and publish it to npm, just as it would during an automatic release publish event.