### PR TITLE
Mk/feat/http identifiers

### DIFF
--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/automated-client-must-log-error-to-audit-log-for-bad-certificate',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
+  )
+  .description(
+    'Automated clients MUST log the error to an appropriate audit log (if available).',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
+  )
+  .description(
+    'Automated clients MUST log the error to an appropriate audit log (if available).',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -3,7 +3,7 @@ import { httpRule } from '@thymian/http-linter';
 export default httpRule(
   'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
 )
-  .severity('error')
+  .severity('warn')
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -9,7 +9,7 @@ export default httpRule(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description(
-    'Automated clients MUST log the error to an appropriate audit log (if available).',
+    'Automated clients SHOULD terminate the connection if HTTPS certificate verification fails.',
   )
   .appliesTo('client')
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/automated-clients-may-provide-setting-to-disable-certificate-check',
+)
+  .severity('hint')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
+  )
+  .description(
+    'Automated clients MAY provide a configuration setting that disables certificate checking.',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/automated-clients-must-provide-setting-to-enable-certificate-check',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
+  )
+  .description(
+    'Automated clients MUST provide a configuration setting that enables certificate checking.',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/client-may-access-by-resolving-host-to-ip-address',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html0#name-http-origins')
+  .description(
+    "A client MAY attempt access by resolving the host identifier to an IP address, establishing a TCP connection to that address on the indicated port, and sending over that connection an HTTP request message containing a request target that matches the client's target URI",
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
 )
   .severity('hint')
   .type('informational')
-  .url('https://www.rfc-editor.org/rfc/rfc9110.html0#name-http-origins')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-origins')
   .description(
     "A client MAY attempt access by resolving the host identifier to an IP address, establishing a TCP connection to that address on the indicated port, and sending over that connection an HTTP request message containing a request target that matches the client's target URI",
   )

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/client-must-construct-reference-identity')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+  )
+  .description(
+    "A client MUST construct a reference identity from the service's host when verifying a secure HTTP connection: If the host is an IP address, use an IP-ID; if a registered name, use a DNS-ID.\n\nContext: This is required for proper service identity verification (RFC 6125), as specified in RFC 9110 section 4.3.4.",
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -1,0 +1,11 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+  )
+  .description('A client MUST NOT use a reference identity of type CN-ID.')
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/client-must-use-rfc6125-verification')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+  )
+  .description(
+    'A client MUST verify the service identity using the verification process defined in Section 6 of RFC 6125 when establishing a secure HTTP connection.\n\nContext: This ensures that connections are only made to servers whose identities match the expected reference identity, preventing impersonation attacks as required in RFC 9110 section 4.3.4.',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/client-must-verify-service-identity')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+  )
+  .description(
+    "A client MUST verify that the service's identity is an acceptable match for the URI's origin server when establishing a secured connection to dereference a URI.\n\nContext: This verification ensures that an attacker cannot impersonate the server, supporting confidentiality and integrity for secure HTTP communication (HTTPS), as specified in RFC 9110 section 4.3.4.",
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+  )
+  .description(
+    "If a certificate is not valid for the target URI's origin, a user agent MUST either obtain confirmation from the user before proceeding or terminate the connection with a bad certificate error..",
+  )
+  .appliesTo('user-agent')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
   )
   .description(
-    "If a certificate is not valid for the target URI's origin, a user agent MUST either obtain confirmation from the user before proceeding or terminate the connection with a bad certificate error..",
+    "If a certificate is not valid for the target URI's origin, a user agent MUST either obtain confirmation from the user before proceeding or terminate the connection with a bad certificate error.",
   )
   .appliesTo('user-agent')
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -8,12 +8,17 @@ export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
-  .rule((ctx) =>
+  .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(protocol('http'), (req, res) => {
-      return (
-        new URL(req.path, req.origin).host === '' &&
-        !(res.statusCode >= 400 && res.statusCode < 500)
-      );
+      try {
+        return (
+          new URL(req.path, req.origin).host === '' &&
+          !(res.statusCode >= 400 && res.statusCode < 500)
+        );
+      } catch (e) {
+        logger.error('Cannot run rule because of invalid URL:', e);
+        return false;
+      }
     }),
   )
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -1,0 +1,19 @@
+import { protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
+  .description(
+    `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(protocol('http'), (req, res) => {
+      return (
+        new URL(req.path, req.origin).host === '' &&
+        !(res.statusCode >= 400 && res.statusCode < 500)
+      );
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -1,0 +1,19 @@
+import { protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
+  .description(
+    `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      protocol('http'),
+      (req) => new URL(req.path, req.origin).host === '',
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -10,10 +10,14 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
-  .rule((ctx) =>
-    ctx.validateHttpTransactions(
-      protocol('http'),
-      (req) => new URL(req.path, req.origin).host === '',
-    ),
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(protocol('http'), (req) => {
+      try {
+        return new URL(req.path, req.origin).host === '';
+      } catch (e) {
+        logger.error('Cannot run rule because of invalid URL:', e);
+        return false;
+      }
+    }),
   )
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/client-must-secure-https-requests-and-responses',
+)
+  .severity('error')
+  .type('static')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
+  .description(
+    "A client MUST ensure that its HTTP requests for an 'https' resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.\n\nContext: This requirement applies whenever a client is sending requests to, or receiving responses from, an 'https' URI. The client must not send unencrypted requests or accept unencrypted responses for 'https' resources.",
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -8,12 +8,16 @@ export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
-  .rule((ctx) =>
+  .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(protocol('https'), (req, res) => {
-      return (
-        new URL(req.path, req.origin).host === '' &&
-        !(res.statusCode >= 400 && res.statusCode < 500)
-      );
+      try {
+        return (
+          new URL(req.path, req.origin).host === '' &&
+          !(res.statusCode >= 400 && res.statusCode < 500)
+        );
+      } catch (e) {
+        return false;
+      }
     }),
   )
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -1,0 +1,19 @@
+import { protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
+  .description(
+    `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(protocol('https'), (req, res) => {
+      return (
+        new URL(req.path, req.origin).host === '' &&
+        !(res.statusCode >= 400 && res.statusCode < 500)
+      );
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -10,10 +10,14 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
-  .rule((ctx) =>
-    ctx.validateHttpTransactions(
-      protocol('https'),
-      (req) => new URL(req.path, req.origin).host === '',
-    ),
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(protocol('https'), (req) => {
+      try {
+        return new URL(req.path, req.origin).host === '';
+      } catch (e) {
+        logger.error('Cannot run rule because of invalid URL:', e);
+        return false;
+      }
+    }),
   )
   .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -1,0 +1,19 @@
+import { protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
+  .description(
+    `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      protocol('https'),
+      (req) => new URL(req.path, req.origin).host === '',
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/authority-should-not-use-equivalent-uris-for-distinct-resources',
+)
+  .severity('warn')
+  .type('static')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',
+  )
+  .description(
+    `Distinct resources SHOULD NOT be identified by HTTP URIs that are equivalent after normalization.`,
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
@@ -1,0 +1,10 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/http-component-may-perform-normalization')
+  .severity('warn')
+  .type('static')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',
+  )
+  .description(`Any HTTP component MAY perform normalization.`)
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -10,14 +10,18 @@ export default httpRule(
   .description(
     'It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.',
   )
-  .rule((ctx) =>
+  .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(statusCode(414), (req) => {
-      const url = new URL(req.path, req.origin);
+      try {
+        const url = new URL(req.path, req.origin);
 
-      if (new TextEncoder().encode(url.toString()).length <= 8000) {
-        return {
-          message: 'URI length is less than 8000 octets',
-        };
+        if (new TextEncoder().encode(url.toString()).length <= 8000) {
+          return {
+            message: 'URI length is less than 8000 octets',
+          };
+        }
+      } catch (e) {
+        logger.error('Cannot run rule because of invalid URL:', e);
       }
 
       return false;

--- a/packages/rfc-9110-rules/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -1,0 +1,26 @@
+import { statusCode } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-recipient-should-support-8000-octet-uris',
+)
+  .severity('warn')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-references')
+  .description(
+    'It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.',
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(statusCode(414), (req) => {
+      const url = new URL(req.path, req.origin);
+
+      if (new TextEncoder().encode(url.toString()).length <= 8000) {
+        return {
+          message: 'URI length is less than 8000 octets',
+        };
+      }
+
+      return false;
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -12,16 +12,21 @@ export default httpRule(
   .description(
     `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
   )
-  .rule((ctx) =>
+  .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       or(protocol('http'), protocol('https')),
       (req, res) => {
-        const url = new URL(req.path, req.origin);
+        try {
+          const url = new URL(req.path, req.origin);
 
-        return (
-          (!!url.username || !!url.password) &&
-          !(res.statusCode >= 400 && res.statusCode < 500)
-        );
+          return (
+            (!!url.username || !!url.password) &&
+            !(res.statusCode >= 400 && res.statusCode < 500)
+          );
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return false;
+        }
       },
     ),
   )

--- a/packages/rfc-9110-rules/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -1,0 +1,28 @@
+import { or, protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
+)
+  .severity('warn')
+  .type('analytics')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
+  )
+  .description(
+    `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
+  )
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      or(protocol('http'), protocol('https')),
+      (req, res) => {
+        const url = new URL(req.path, req.origin);
+
+        return (
+          (!!url.username || !!url.password) &&
+          !(res.statusCode >= 400 && res.statusCode < 500)
+        );
+      },
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -1,0 +1,23 @@
+import { or, protocol } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
+  .severity('error')
+  .type('static', 'analytics')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
+  )
+  .description(
+    "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
+  )
+  .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(
+      or(protocol('http'), protocol('https')),
+      (req) => {
+        const url = new URL(req.path, req.origin);
+
+        return !!url.username || !!url.password;
+      },
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -10,13 +10,18 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .description(
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
-  .rule((ctx) =>
+  .rule((ctx, opts, logger) =>
     ctx.validateCommonHttpTransactions(
       or(protocol('http'), protocol('https')),
       (req) => {
-        const url = new URL(req.path, req.origin);
+        try {
+          const url = new URL(req.path, req.origin);
 
-        return !!url.username || !!url.password;
+          return !!url.username || !!url.password;
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return false;
+        }
       },
     ),
   )


### PR DESCRIPTION
* Adds `opencode.json` to configure skill paths for the project.
* Adds rule from the Identifiers for HTTP chapter of RFC 9110 and closes https://github.com/thymianofficial/thymian-internal/issues/85