### PR TITLE
Increase readability of release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         run: npm ci
 
       - name: Publish canary release
-        run: node ./scripts/release.ts --version canary --no-dry-run --no-local
+        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -90,6 +90,6 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Publish to npm
-        run: node ./scripts/release.ts --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
+        run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,16 @@ For production releases with approval gates:
 
 ```bash
 # Step 1: Preview what the release will look like (optional)
-node ./scripts/release.ts --version latest --no-local --dry-run
+node ./scripts/release.ts --dist-tag latest --no-local --dry-run
 
 # Step 2: Create the release (interactive)
-node ./scripts/release.ts --version latest --no-local
+node ./scripts/release.ts --dist-tag latest --no-local --no-dry-run
+
+# Or with an explicit version:
+node ./scripts/release.ts --dist-tag latest --version 1.2.3 --no-local --no-dry-run
 
 # The script will:
-# - Calculate version from conventional commits
+# - Calculate version from conventional commits (or use explicit --version)
 # - Show version and changelog
 # - Ask for your confirmation
 # - Create git tag and GitHub Release (if confirmed)
@@ -114,21 +117,28 @@ For testing with local Verdaccio registry:
 # Start local registry
 npm run local-registry
 
-# In another terminal, publish to local registry
-node ./scripts/release.ts --version patch --no-dry-run
+# In another terminal, publish to local registry with latest dist-tag
+node ./scripts/release.ts --dist-tag latest --version patch --no-dry-run
 
 # Or specify exact version
-node ./scripts/release.ts --version 1.2.3 --no-dry-run
+node ./scripts/release.ts --dist-tag latest --version 1.2.3 --no-dry-run
+
+# Test canary locally
+node ./scripts/release.ts --dist-tag canary --version 1.2.3 --local --no-dry-run
 ```
 
-### Version Strategies
+### CLI Options
 
-- **`latest`** - Use conventional commits (recommended for production)
-- **`canary`** - Automatic canary version with date and commit hash
-- **`patch`** - Increment patch version (0.0.X)
-- **`minor`** - Increment minor version (0.X.0)
-- **`major`** - Increment major version (X.0.0)
-- **`1.2.3`** - Explicit semver version
+| Option             | Description                                                                                                           |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `--dist-tag`, `-t` | **Required.** npm dist-tag to publish with (`canary` or `latest`)                                                     |
+| `--version`, `-v`  | Explicit version specifier (e.g., `1.2.3`, `patch`, `minor`, `major`). If omitted, derived from conventional commits. |
+| `--dry-run`, `-d`  | Preview changes without executing (default: `true`)                                                                   |
+| `--no-dry-run`     | Execute changes for real                                                                                              |
+| `--local`          | Publish to local Verdaccio registry (default: `true`)                                                                 |
+| `--no-local`       | Publish to npm                                                                                                        |
+| `--first-release`  | Treat as first release for the workspace                                                                              |
+| `--verbose`        | Enable verbose logging (default: `true`)                                                                              |
 
 ### Release Workflow for Maintainers
 
@@ -137,10 +147,10 @@ node ./scripts/release.ts --version 1.2.3 --no-dry-run
 git checkout main && git pull
 
 # 2. Preview the release (optional but recommended)
-node ./scripts/release.ts --version latest --no-local --dry-run
+node ./scripts/release.ts --dist-tag latest --no-local --dry-run
 
 # 3. Create the release (interactive, will ask for approval; requires --no-dry-run to actually execute)
-node ./scripts/release.ts --version latest --no-local --no-dry-run
+node ./scripts/release.ts --dist-tag latest --no-local --no-dry-run
 # Review the version and changelog
 # Type 'yes' to confirm
 

--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -32,7 +32,7 @@ Thymian follows a tag-based release process that maintains clean version control
 
 **Latest Releases:**
 
-- Manually triggered by developers using `--version latest`
+- Manually triggered by developers using `--dist-tag latest`
 - Interactive approval flow with local review
 - Published to npm with dist-tag `latest`
 - Two-phase process: local creation of tag/release, CI publishing to npm
@@ -42,8 +42,8 @@ Thymian follows a tag-based release process that maintains clean version control
 
 **Local Phase (Developer):**
 
-1. Run `node ./scripts/release.ts --version latest --no-local`
-2. Script calculates next version using conventional commits
+1. Run `node ./scripts/release.ts --dist-tag latest --no-local` (optionally add `--version X.Y.Z` to override conventional commits)
+2. Script calculates next version using conventional commits (or uses explicit `--version` if provided)
 3. Interactive prompt displays version and changelog
 4. Developer approves or declines
 5. If approved: Git tag and GitHub Release are created (no npm publish)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -14,38 +14,293 @@ const VALID_AUTHORS_FOR_LATEST: string[] = [
   'atennert', // Andreas Tennert
 ];
 
-async function isVerdaccioRunning(url: string): Promise<boolean> {
-  try {
-    const response = await fetch(url);
-    return response.ok;
-  } catch {
-    return false;
-  }
+type ReleaseMode = 'canary' | 'latest' | 'ci-publish' | 'local';
+type DistTag = 'canary' | 'latest';
+
+interface ValidatedArguments {
+  mode: ReleaseMode;
+  distTag: DistTag;
+  version: string | undefined;
+  dryRun: boolean;
+  firstRelease: boolean;
+  verbose: boolean;
+  local: boolean;
 }
 
-function isInCI(): boolean {
-  return process.env.GITHUB_ACTIONS === 'true';
-}
+/**
+ * Validates argument combinations and determines the release mode.
+ * Rejects invalid combinations with clear error messages.
+ */
+function validateAndDetermineMode(argv: {
+  distTag: DistTag;
+  version?: string;
+  dryRun: boolean;
+  firstRelease: boolean;
+  verbose: boolean;
+  local: boolean;
+}): ValidatedArguments {
+  const isCanary = argv.distTag === 'canary';
+  const isLatest = argv.distTag === 'latest';
+  const inCI = isInCI();
 
-function validateCIPublishMode(
-  version: string | undefined,
-  isLocal: boolean,
-): void {
-  // CI publish-only mode validation
-  if (!isInCI() || isLocal) {
-    return; // Not in CI or local mode - skip validation
+  // Reject: canary with local flag
+  if (isCanary && argv.local) {
+    console.error('❌ Error: Invalid argument combination');
+    console.error('   --dist-tag canary --local');
+    console.error(
+      '   Problem: Canary releases are for npm, not local testing.\n',
+    );
+    process.exit(1);
   }
 
-  // Require exact semver version in CI
+  // Reject: latest in CI without explicit version (CI must provide version from git tag)
+  if (isLatest && inCI && !argv.version) {
+    console.error('❌ Error: Invalid argument combination');
+    console.error('   --dist-tag latest in CI environment without --version');
+    console.error(
+      '   Problem: CI must provide explicit version from git tag.\n',
+    );
+    process.exit(1);
+  }
+
+  // Reject: publishing to npm outside CI (except canary which runs in CI anyway)
+  if (!argv.local && !inCI && isLatest) {
+    console.error('❌ Error: Invalid argument combination');
+    console.error('   --dist-tag latest --no-local (outside CI)');
+    console.error(
+      '   Problem: This bypasses CI authorization. Use CI for npm publishes.\n',
+    );
+    process.exit(1);
+  }
+
+  // Determine mode
+  let mode: ReleaseMode;
+  if (isCanary && !argv.local) {
+    mode = 'canary';
+  } else if (isLatest && !argv.local && !inCI) {
+    // Interactive latest release (creates tag + GitHub Release, no publish)
+    mode = 'latest';
+  } else if (inCI && !argv.local) {
+    mode = 'ci-publish';
+  } else {
+    mode = 'local';
+  }
+
+  return {
+    mode,
+    distTag: argv.distTag,
+    version: argv.version,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    local: argv.local,
+  };
+}
+
+/**
+ * Runs a canary release workflow.
+ * - Determines version from conventional commits
+ * - Generates canary version string with date and commit hash
+ * - Versions packages without git tag
+ * - Publishes with 'canary' dist-tag
+ */
+async function runCanaryRelease(
+  client: ReleaseClient,
+  argv: ValidatedArguments,
+): Promise<void> {
+  console.log('\n🐤 CANARY RELEASE MODE\n');
+
+  let baseVersion: string;
+
+  // If explicit version provided, use it as base; otherwise derive from conventional commits
+  if (argv.version) {
+    console.log(`📦 Using explicit base version: ${argv.version}\n`);
+    baseVersion = argv.version;
+  } else {
+    console.log('🔍 Determining next version from conventional commits...\n');
+
+    // Dry-run to get base version
+    const { workspaceVersion: nextVersion } = await client.releaseVersion({
+      specifier: undefined,
+      dryRun: true,
+      firstRelease: argv.firstRelease,
+      verbose: argv.verbose,
+      gitTag: false,
+    });
+
+    if (!nextVersion) {
+      console.log(
+        'ℹ️  No release needed (no relevant commits since last release)',
+      );
+      console.log('   Exiting gracefully.\n');
+      process.exit(0);
+    }
+
+    baseVersion = nextVersion;
+  }
+
+  const commitHash = getCurrentCommitHash();
+  const canaryVersionString = getCanaryVersion(baseVersion, commitHash);
+
+  console.log(`📦 Canary version: ${canaryVersionString}`);
+  console.log(`   Base version: ${baseVersion}`);
+  console.log(`   Commit hash: ${commitHash}\n`);
+
+  // Version packages
+  const { releaseGraph } = await client.releaseVersion({
+    specifier: canaryVersionString,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    gitTag: false,
+  });
+
+  // Publish with canary dist-tag (no changelog for canary)
+  const publishResults = await client.releasePublish({
+    releaseGraph,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    access: 'restricted',
+    registry: argv.local ? 'http://localhost:4873' : undefined,
+    tag: argv.distTag,
+  });
+
+  if (argv.dryRun) {
+    console.log(
+      '\n📋 DRY-RUN MODE: This was a dry-run. No changes were made.\n',
+    );
+  } else {
+    console.log('\n✅ Canary release published successfully!\n');
+  }
+
+  process.exit(
+    Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1,
+  );
+}
+
+/**
+ * Runs a latest release workflow.
+ * - Determines version from conventional commits
+ * - Generates and previews changelog
+ * - Prompts for user confirmation (if interactive)
+ * - Creates git tag and GitHub Release
+ * - Exits without publishing (GitHub Release triggers CI)
+ */
+async function runLatestRelease(
+  client: ReleaseClient,
+  argv: ValidatedArguments,
+): Promise<void> {
+  console.log('\n🚀 LATEST RELEASE MODE\n');
+
+  // If explicit version provided, use it; otherwise derive from conventional commits
+  const versionSpecifier = argv.version ?? undefined;
+  if (argv.version) {
+    console.log(`📦 Using explicit version: ${argv.version}\n`);
+  } else {
+    console.log('🔍 Determining next version from conventional commits...\n');
+  }
+
+  // Preview release to get version info
+  const previewResult = await client.releaseVersion({
+    specifier: versionSpecifier,
+    dryRun: true,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    gitTag: false,
+  });
+
+  if (!previewResult.workspaceVersion) {
+    console.error('❌ Error: Could not determine workspace version');
+    process.exit(1);
+  }
+
+  // Generate and display changelog preview
+  console.log('\n📋 Changelog Preview:\n');
+  await client.releaseChangelog({
+    releaseGraph: previewResult.releaseGraph,
+    versionData: previewResult.projectsVersionData,
+    version: previewResult.workspaceVersion,
+    dryRun: true,
+    firstRelease: argv.firstRelease,
+    verbose: true,
+  });
+
+  // Prompt for confirmation (interactive mode only)
+  if (!argv.dryRun) {
+    const confirmed = await promptUserConfirmation(
+      previewResult.workspaceVersion,
+      previewResult.projectsVersionData as Record<
+        string,
+        { newVersion: string }
+      >,
+    );
+
+    if (!confirmed) {
+      console.log('\n❌ Release cancelled by user.\n');
+      process.exit(0);
+    }
+
+    console.log('\n✅ Release confirmed. Proceeding...\n');
+  }
+
+  // Version packages with git tag
+  const { workspaceVersion, projectsVersionData, releaseGraph } =
+    await client.releaseVersion({
+      specifier: argv.version ?? undefined, // Use explicit version if provided
+      dryRun: argv.dryRun,
+      firstRelease: argv.firstRelease,
+      verbose: argv.verbose,
+      gitTag: true, // Create git tag
+    });
+
+  // Generate actual changelog and GitHub Release
+  await client.releaseChangelog({
+    releaseGraph,
+    versionData: projectsVersionData,
+    version: workspaceVersion,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+  });
+
+  // Exit without publishing - GitHub Release will trigger CI
+  if (argv.dryRun) {
+    console.log('\n📋 DRY-RUN MODE: No changes were made.');
+    console.log(
+      '   In actual run: Tag and GitHub Release would be created, triggering CI to publish to npm.\n',
+    );
+  } else {
+    console.log('\n✅ Tag and GitHub Release created successfully!');
+    console.log('   Publishing to npm will be triggered by GitHub Release.\n');
+  }
+
+  process.exit(0);
+}
+
+/**
+ * Runs a CI publish release workflow.
+ * - Validates GitHub actor against allowlist
+ * - Validates exact semver version
+ * - Versions packages without git tag
+ * - Publishes with 'latest' dist-tag to npm
+ */
+async function runCIPublishRelease(
+  client: ReleaseClient,
+  argv: ValidatedArguments,
+): Promise<void> {
+  console.log('\n📋 CI PUBLISH MODE\n');
+
+  // Validate exact semver version
   const semverRegex = /^\d+\.\d+\.\d+(-[a-z0-9.-]+)?(\+[a-z0-9.-]+)?$/i;
-  if (!version || !semverRegex.test(version)) {
+  if (!argv.version || !semverRegex.test(argv.version)) {
     console.error('❌ Error: CI publish mode requires exact semver version');
-    console.error(`   Received: ${version || 'undefined'}`);
+    console.error(`   Received: ${argv.version || 'undefined'}`);
     console.error('   Expected: exact semver (e.g., 1.2.3, 1.0.0-beta.1)');
     process.exit(1);
   }
 
-  // Validate GitHub actor against allowlist
+  // Validate GitHub actor
   const actor = process.env.GITHUB_ACTOR;
   if (!actor) {
     console.error('❌ Error: GITHUB_ACTOR not set in CI environment');
@@ -63,7 +318,218 @@ function validateCIPublishMode(
 
   console.log('✅ CI publish mode validation passed');
   console.log(`   User: ${actor}`);
-  console.log(`   Version: ${version}\n`);
+  console.log(`   Version: ${argv.version}\n`);
+
+  // Version packages without git tag (tag already exists from local release)
+  const { releaseGraph } = await client.releaseVersion({
+    specifier: argv.version,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    gitTag: false,
+  });
+
+  // Publish to npm (skip changelog - already created during local release)
+  const publishResults = await client.releasePublish({
+    releaseGraph,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    access: 'restricted',
+    registry: undefined, // Use npm
+    tag: argv.distTag,
+  });
+
+  if (argv.dryRun) {
+    console.log(
+      '\n📋 DRY-RUN MODE: This was a dry-run. No changes were made.\n',
+    );
+  } else {
+    console.log('\n✅ Published to npm successfully!\n');
+  }
+
+  process.exit(
+    Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1,
+  );
+}
+
+/**
+ * Runs a local release workflow for testing.
+ * - Checks Verdaccio is running
+ * - Versions packages without git tag
+ * - Publishes with dist-tag to local registry
+ */
+async function runLocalRelease(
+  client: ReleaseClient,
+  argv: ValidatedArguments,
+): Promise<void> {
+  console.log('\n📋 LOCAL RELEASE MODE\n');
+
+  // Check Verdaccio is running
+  if (!argv.dryRun) {
+    const isRunning = await isVerdaccioRunning('http://localhost:4873/');
+    if (!isRunning) {
+      console.error(
+        '❌ Error: Local verdaccio is not running on http://localhost:4873/',
+      );
+      console.error('Please start verdaccio with: npm run local-registry');
+      process.exit(1);
+    }
+    console.log('✅ Verdaccio is running\n');
+  }
+
+  // Determine version specifier - apply canary postfix if needed
+  let versionSpecifier = argv.version;
+  if (argv.distTag === 'canary' && argv.version) {
+    const commitHash = getCurrentCommitHash();
+    versionSpecifier = getCanaryVersion(argv.version, commitHash);
+    console.log(`📦 Local canary version: ${versionSpecifier}\n`);
+  }
+
+  // Version packages
+  const { releaseGraph } = await client.releaseVersion({
+    specifier: versionSpecifier,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    gitTag: false,
+  });
+
+  // Publish to local registry (no changelog for local testing)
+  const publishResults = await client.releasePublish({
+    releaseGraph,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    access: 'restricted',
+    registry: 'http://localhost:4873',
+    tag: argv.distTag,
+  });
+
+  if (argv.dryRun) {
+    console.log(
+      '\n📋 DRY-RUN MODE: This was a dry-run. No changes were made.\n',
+    );
+  } else {
+    console.log('\n✅ Published to local registry successfully!');
+    console.log(
+      '\n⚠️  WARNING: Do not commit the versioned package.json files. They have to be reverted after the release process.\n',
+    );
+  }
+
+  process.exit(
+    Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1,
+  );
+}
+
+/**
+ * Main function: parses arguments, validates mode, and dispatches to appropriate handler.
+ */
+(async () => {
+  const argv = await yargs(hideBin(process.argv))
+    .version(false)
+    .option('dist-tag', {
+      alias: 't',
+      description: 'npm dist-tag to publish with (canary or latest)',
+      type: 'string',
+      choices: ['canary', 'latest'] as const,
+      demandOption: true,
+    })
+    .option('version', {
+      alias: 'v',
+      description:
+        'Explicit version specifier (e.g., 1.2.3, patch, minor, major). If omitted, version is derived from conventional commits.',
+      type: 'string',
+    })
+    .option('dryRun', {
+      alias: 'd',
+      description:
+        'Whether or not to perform a dry-run of the release process, defaults to true',
+      type: 'boolean',
+      default: true,
+    })
+    .option('firstRelease', {
+      description: 'Treat this as the first release for the workspace/projects',
+      type: 'boolean',
+      default: false,
+    })
+    .option('verbose', {
+      description: 'Whether or not to enable verbose logging, defaults to true',
+      type: 'boolean',
+      default: true,
+    })
+    .option('local', {
+      description:
+        'Whether to use local registry (http://localhost:4873), defaults to true',
+      type: 'boolean',
+      default: true,
+    })
+    .parseAsync();
+
+  // Validate arguments and determine mode
+  const validatedArgs = validateAndDetermineMode({
+    distTag: argv['dist-tag'],
+    version: argv.version,
+    dryRun: argv.dryRun,
+    firstRelease: argv.firstRelease,
+    verbose: argv.verbose,
+    local: argv.local,
+  });
+
+  // Display configuration
+  const modeEmoji = {
+    canary: '🐤',
+    latest: '🚀',
+    'ci-publish': '📋',
+    local: '📋',
+  };
+
+  console.log(`\n${modeEmoji[validatedArgs.mode]} Release Configuration:`);
+  console.log(`  mode: ${validatedArgs.mode.toUpperCase()}`);
+  console.log(`  dist-tag: ${validatedArgs.distTag}`);
+  console.log(`  version: ${validatedArgs.version || 'conventional commits'}`);
+  console.log(`  dryRun: ${validatedArgs.dryRun}`);
+  console.log(`  firstRelease: ${validatedArgs.firstRelease}`);
+  console.log(`  verbose: ${validatedArgs.verbose}`);
+  console.log(`  local: ${validatedArgs.local}`);
+  console.log(
+    `  registry: ${validatedArgs.local ? 'http://localhost:4873' : 'npm'}\n`,
+  );
+
+  // Create client and dispatch to mode-specific handler
+  const client = new ReleaseClient({});
+
+  switch (validatedArgs.mode) {
+    case 'canary':
+      await runCanaryRelease(client, validatedArgs);
+      break;
+    case 'latest':
+      await runLatestRelease(client, validatedArgs);
+      break;
+    case 'ci-publish':
+      await runCIPublishRelease(client, validatedArgs);
+      break;
+    case 'local':
+      await runLocalRelease(client, validatedArgs);
+      break;
+  }
+})();
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function isInCI(): boolean {
+  return process.env.GITHUB_ACTIONS === 'true';
+}
+
+async function isVerdaccioRunning(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url);
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 async function promptUserConfirmation(
@@ -101,225 +567,6 @@ async function promptUserConfirmation(
   }
 }
 
-(async () => {
-  const argv = await yargs(hideBin(process.argv))
-    .version(false)
-    .option('version', {
-      description:
-        'Explicit version specifier to use, if overriding conventional commits',
-      type: 'string',
-    })
-    .option('dryRun', {
-      alias: 'd',
-      description:
-        'Whether or not to perform a dry-run of the release process, defaults to true',
-      type: 'boolean',
-      default: true,
-    })
-    .option('firstRelease', {
-      description: 'Treat this as the first release for the workspace/projects',
-      type: 'boolean',
-      default: false,
-    })
-    .option('verbose', {
-      description: 'Whether or not to enable verbose logging, defaults to true',
-      type: 'boolean',
-      default: true,
-    })
-    .option('local', {
-      description:
-        'Whether to use local registry (http://localhost:4873), defaults to true',
-      type: 'boolean',
-      default: true,
-    })
-    .parseAsync();
-
-  const isCanary = isCanaryRelease(argv.version);
-  const isLatest = argv.version === 'latest';
-  const isCIPublishMode = isInCI() && !argv.local;
-
-  // Validate CI publish-only mode (skip for canary and dry-runs)
-  if (isCIPublishMode && !isCanary && !argv.dryRun) {
-    validateCIPublishMode(argv.version, argv.local);
-  }
-
-  let mode = 'STANDARD';
-  if (isCanary) {
-    mode = 'CANARY';
-  } else if (isLatest) {
-    mode = 'LATEST';
-  } else if (isCIPublishMode) {
-    mode = 'CI-PUBLISH';
-  }
-
-  console.log(
-    `\n${isCanary ? '🐤' : isLatest ? '🚀' : '📋'} Release Configuration:`,
-  );
-  console.log(`  mode: ${mode}`);
-  console.log(`  version: ${argv.version || 'conventional commits'}`);
-  console.log(`  dryRun: ${argv.dryRun}`);
-  console.log(`  firstRelease: ${argv.firstRelease}`);
-  console.log(`  verbose: ${argv.verbose}`);
-  console.log(`  local: ${argv.local}`);
-  console.log(`  registry: ${argv.local ? 'http://localhost:4873' : 'npm'}\n`);
-
-  if (argv.local && !argv.dryRun) {
-    const isRunning = await isVerdaccioRunning('http://localhost:4873/');
-    if (!isRunning) {
-      console.error(
-        '❌ Error: Local verdaccio is not running on http://localhost:4873/',
-      );
-      console.error('Please start verdaccio with: npm run local-registry');
-      process.exit(1);
-    }
-  }
-
-  const client = new ReleaseClient({});
-
-  // For canary releases, first get the next version using conventional commits
-  let versionSpecifier = argv.version;
-  let canaryVersionString: string | undefined;
-
-  if (isCanary) {
-    console.log('🔍 Determining next version from conventional commits...\n');
-
-    const { workspaceVersion: nextVersion } = await client.releaseVersion({
-      specifier: undefined, // Let conventional commits determine version
-      dryRun: true, // Don't actually version yet
-      firstRelease: argv.firstRelease,
-      verbose: argv.verbose,
-      gitTag: false,
-    });
-
-    if (!nextVersion) {
-      console.log(
-        'ℹ️  No release needed (no relevant commits since last release)',
-      );
-      console.log('   Exiting gracefully.\n');
-      process.exit(0);
-    }
-
-    const commitHash = getCurrentCommitHash();
-    canaryVersionString = getCanaryVersion(nextVersion, commitHash);
-    versionSpecifier = canaryVersionString;
-
-    console.log(`📦 Canary version: ${canaryVersionString}`);
-    console.log(`   Base version: ${nextVersion}`);
-    console.log(`   Commit hash: ${commitHash}\n`);
-  }
-
-  // For latest releases, use conventional commits to determine version
-  if (isLatest) {
-    console.log('🔍 Determining next version from conventional commits...\n');
-    versionSpecifier = undefined; // Let conventional commits determine version
-
-    // Interactive confirmation for latest releases
-    // Run a dry-run first to get version info, then prompt, then execute
-    if (!argv.local && !argv.dryRun && !isInCI()) {
-      const previewResult = await client.releaseVersion({
-        specifier: versionSpecifier,
-        dryRun: true, // Preview only
-        firstRelease: argv.firstRelease,
-        verbose: argv.verbose,
-        gitTag: false,
-      });
-
-      if (!previewResult.workspaceVersion) {
-        console.error('❌ Error: Could not determine workspace version');
-        process.exit(1);
-      }
-
-      // Generate changelog preview (prints to console)
-      console.log('\n📋 Changelog Preview:\n');
-      await client.releaseChangelog({
-        releaseGraph: previewResult.releaseGraph,
-        versionData: previewResult.projectsVersionData,
-        version: previewResult.workspaceVersion,
-        dryRun: true, // Preview mode - output to console only
-        firstRelease: argv.firstRelease,
-        verbose: true, // Show the full changelog output
-      });
-
-      const confirmed = await promptUserConfirmation(
-        previewResult.workspaceVersion,
-        previewResult.projectsVersionData as Record<
-          string,
-          { newVersion: string }
-        >,
-      );
-
-      if (!confirmed) {
-        console.log('\n❌ Release cancelled by user.\n');
-        process.exit(0);
-      }
-
-      console.log('\n✅ Release confirmed. Proceeding...\n');
-    }
-  }
-
-  // Version the release (skip git tagging in CI - tags already exist from local release)
-  const { workspaceVersion, projectsVersionData, releaseGraph } =
-    await client.releaseVersion({
-      specifier: versionSpecifier,
-      dryRun: argv.dryRun,
-      firstRelease: argv.firstRelease,
-      verbose: argv.verbose,
-      gitTag: isCanary ? false : !argv.local && !isInCI(),
-    });
-
-  // Skip changelog in CI publish mode - it was already created during local release
-  if (!argv.local && !isCanary && !isCIPublishMode) {
-    await client.releaseChangelog({
-      releaseGraph,
-      versionData: projectsVersionData,
-      version: workspaceVersion,
-      dryRun: argv.dryRun,
-      firstRelease: argv.firstRelease,
-      verbose: argv.verbose,
-    });
-  }
-
-  // Skip publish for latest releases (will be triggered by GitHub Release)
-  if (isLatest && !argv.local) {
-    if (argv.dryRun) {
-      console.log('\n📋 DRY-RUN MODE: No changes were made.');
-      console.log(
-        '   In actual run: Tag and GitHub Release would be created, triggering CI to publish to npm.\n',
-      );
-    } else {
-      console.log('\n✅ Tag and GitHub Release created successfully!');
-      console.log(
-        '   Publishing to npm will be triggered by GitHub Release.\n',
-      );
-    }
-    process.exit(0);
-  }
-
-  const publishResults = await client.releasePublish({
-    releaseGraph,
-    dryRun: argv.dryRun,
-    firstRelease: argv.firstRelease,
-    verbose: argv.verbose,
-    access: 'restricted', // publish privately for now
-    registry: argv.local ? 'http://localhost:4873' : undefined,
-    tag: isCanary ? 'canary' : 'latest',
-  });
-
-  if (argv.dryRun) {
-    console.log(
-      '\n📋 DRY-RUN MODE: This was a dry-run. No changes were made.\n',
-    );
-  } else {
-    console.log(
-      '\n⚠️  WARNING: Do not commit the versioned package.json files. They have to be reverted after the release process.\n',
-    );
-  }
-
-  process.exit(
-    Object.values(publishResults).every((result) => result.code === 0) ? 0 : 1,
-  );
-})();
-
 function getCurrentCommitHash(): string {
   try {
     const hash = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
@@ -334,8 +581,4 @@ function getCanaryVersion(baseVersion: string, commitHash: string): string {
   const date = new Date();
   const yyyymmdd = date.toISOString().slice(0, 10).replace(/-/g, '');
   return `${baseVersion}-canary.${yyyymmdd}-${commitHash}`;
-}
-
-function isCanaryRelease(version: string | undefined): boolean {
-  return version === 'canary';
 }


### PR DESCRIPTION
This pull request updates the release workflow and documentation to require the explicit use of the `--dist-tag` option for all release commands, clarifies command-line options, and improves guidance for both production and local releases. The changes ensure consistency between CI scripts and documentation, and make the release process easier to understand and execute.

**Release workflow and automation:**

* Updated `.github/workflows/release.yaml` to use `--dist-tag` instead of `--version` for canary and production releases, ensuring correct npm publishing behavior. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL45-R45) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL93-R93)

**Documentation improvements:**

* Revised `CONTRIBUTING.md` to demonstrate release commands using `--dist-tag`, clarify usage for both production and local registry, and add explicit examples for canary and version overrides. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L86-R95) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L117-R141) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L140-R153)
* Added a new CLI options table in `CONTRIBUTING.md` for easier reference and understanding of available flags.

**Process clarification:**

* Updated `docs/arc42/08-crosscutting-concepts.md` to reference `--dist-tag` in release process descriptions and clarify how version calculation and overrides work. [[1]](diffhunk://#diff-948b449fd6e76fd435c5ab96324b165dd6a0e8886d9d612ef291cca699b9e25aL35-R35) [[2]](diffhunk://#diff-948b449fd6e76fd435c5ab96324b165dd6a0e8886d9d612ef291cca699b9e25aL45-R46)


see https://github.com/thymianofficial/thymian-internal/issues/77