### PR TITLE
Mk/feat/rfc9110 routing messages

### DIFF
--- a/packages/http-linter/src/api-context/analytics-api-context.ts
+++ b/packages/http-linter/src/api-context/analytics-api-context.ts
@@ -15,6 +15,7 @@ import type { RuleViolation } from 'src/rule/rule-violation.js';
 import type { HttpTransactionRepository } from '../db/http-transaction-repository.js';
 import type { HttpParticipantRole } from '../rule/rule-meta.js';
 import type { RuleViolationLocation } from '../rule/rule-violation.js';
+import type { CapturedTrace, CapturedTransaction } from '../types.js';
 import { type ValidationFn } from './api-context.js';
 import type { CommonHttpRequest, CommonHttpResponse } from './common-types.js';
 import { LiveApiContext } from './live-api-context.js';
@@ -22,17 +23,28 @@ import {
   httpRequestToCommonHttpRequest,
   httpResponseToCommonHttpResponse,
 } from './utils/http-to-common.js';
+import { capturedTraceToString } from './utils/trace-to-string.js';
 
 export class AnalyticsApiContext extends LiveApiContext {
+  private readonly roles?: HttpParticipantRole[];
+
   constructor(
     readonly repository: HttpTransactionRepository,
     logger: Logger,
     format: ThymianFormat,
     reportFn?: ReportFn,
-    private readonly roles?: HttpParticipantRole[],
+    roles?: HttpParticipantRole[],
     skippedOrigins?: string[],
   ) {
     super(format, logger, reportFn, skippedOrigins);
+
+    if (roles) {
+      this.roles = roles.flatMap((role) =>
+        role === 'intermediary'
+          ? ['proxy', 'tunnel', 'gateway', 'intermediary']
+          : role,
+      );
+    }
   }
 
   private addOriginsToFilter(
@@ -102,7 +114,7 @@ export class AnalyticsApiContext extends LiveApiContext {
       }
     }
 
-    return results;
+    return results.concat(this.violations);
   }
 
   override validateGroupedCommonHttpTransactions(
@@ -189,6 +201,69 @@ export class AnalyticsApiContext extends LiveApiContext {
       }
     }
 
-    return results;
+    return results.concat(this.violations);
+  }
+
+  validateCapturedHttpTransactions(
+    filter: HttpFilterExpression,
+    validate: ValidationFn<[CapturedTransaction, string]>,
+  ): Promise<RuleFnResult> | RuleFnResult {
+    const finalFilter = this.addOriginsToFilter(filter);
+
+    const results: RuleFnResult = [];
+
+    for (const transaction of this.repository.readTransactionsByHttpFilter(
+      finalFilter,
+      this.roles,
+    )) {
+      const location = httpTransactionToLabel(
+        transaction.request.data,
+        transaction.response.data,
+      );
+
+      const violation = validate(transaction, location);
+
+      if (violation) {
+        if (violation === true) {
+          results.push({
+            location,
+          });
+        } else {
+          results.push({
+            location,
+            ...violation,
+          });
+        }
+      }
+    }
+
+    return results.concat(this.violations);
+  }
+
+  validateCapturedHttpTraces(
+    validate: ValidationFn<[CapturedTrace, string]>,
+  ): RuleFnResult {
+    const results: RuleFnResult = [];
+
+    for (const trace of this.repository.readAllHttpTraces()) {
+      const location = capturedTraceToString(trace);
+
+      const violation = validate(trace, location);
+
+      if (violation) {
+        if (violation === true) {
+          results.push({
+            location,
+          });
+        } else {
+          results.push({
+            location,
+            ...violation,
+          });
+        }
+      }
+    }
+
+    return results.concat(this.violations);
   }
 }

--- a/packages/http-linter/src/api-context/api-context.ts
+++ b/packages/http-linter/src/api-context/api-context.ts
@@ -24,6 +24,7 @@ export type ValidationFn<
 
 export abstract class ApiContext {
   readonly format: ThymianFormat;
+  protected readonly violations: RuleViolation[] = [];
 
   constructor(
     format: ThymianFormat,
@@ -43,6 +44,10 @@ export abstract class ApiContext {
           ),
       );
     }
+  }
+
+  reportViolation(violation: RuleViolation): void {
+    this.violations.push(violation);
   }
 
   abstract validateCommonHttpTransactions(

--- a/packages/http-linter/src/api-context/http-test-api-context.ts
+++ b/packages/http-linter/src/api-context/http-test-api-context.ts
@@ -50,7 +50,6 @@ function hasSource(
 export class HttpTestApiContext<
   Locals extends HttpTestContextLocals = HttpTestContextLocals,
 > extends LiveApiContext {
-  private readonly violations: RuleViolation[] = [];
   private readonly ctx: HttpTestContext<Locals>;
 
   constructor(
@@ -64,10 +63,6 @@ export class HttpTestApiContext<
       ...ctx,
       format: this.format,
     };
-  }
-
-  reportViolation(violation: RuleViolation): void {
-    this.violations.push(violation);
   }
 
   async validateGroupedCommonHttpTransactions(

--- a/packages/http-linter/src/api-context/static-api-context.ts
+++ b/packages/http-linter/src/api-context/static-api-context.ts
@@ -86,7 +86,8 @@ export class StaticApiContext extends ApiContext {
         }
 
         return violations;
-      }, []);
+      }, [])
+      .concat(this.violations);
   }
 
   validateGroupedCommonHttpTransactions(
@@ -115,8 +116,8 @@ export class StaticApiContext extends ApiContext {
         {},
       );
 
-    return Object.entries(groups).reduce<RuleViolation[]>(
-      (violations, [key, group]) => {
+    return Object.entries(groups)
+      .reduce<RuleViolation[]>((violations, [key, group]) => {
         const validationResult = validationFn(
           key,
           group.map(
@@ -142,9 +143,8 @@ export class StaticApiContext extends ApiContext {
         }
 
         return violations;
-      },
-      [],
-    );
+      }, [])
+      .concat(this.violations);
   }
 
   validateHttpTransactions(
@@ -159,48 +159,50 @@ export class StaticApiContext extends ApiContext {
       responses: ThymianHttpResponse[],
     ) => PartialBy<RuleViolation, 'location'> | boolean = filterFn,
   ): RuleFnResult {
-    return this.format.graph.reduceNodes((violations, id, node) => {
-      if (!isNodeType(node, 'http-request')) {
-        return violations;
-      }
+    return this.format.graph
+      .reduceNodes((violations, id, node) => {
+        if (!isNodeType(node, 'http-request')) {
+          return violations;
+        }
 
-      const responsesWithIds = this.format.getHttpResponsesOf(id);
-      const responses = responsesWithIds.map(([, res]) => res);
+        const responsesWithIds = this.format.getHttpResponsesOf(id);
+        const responses = responsesWithIds.map(([, res]) => res);
 
-      for (const [resId, res] of responsesWithIds) {
-        if (filterFn(node, res, responses)) {
-          const result = validationFn(node, res, responses);
+        for (const [resId, res] of responsesWithIds) {
+          if (filterFn(node, res, responses)) {
+            const result = validationFn(node, res, responses);
 
-          const transactionId = this.format.graph.findEdge(
-            id,
-            resId,
-            (_, edge) => edge.type === 'http-transaction',
-          );
+            const transactionId = this.format.graph.findEdge(
+              id,
+              resId,
+              (_, edge) => edge.type === 'http-transaction',
+            );
 
-          if (!transactionId) {
-            throw new Error('Invalid HTTP transaction ID.');
-          }
+            if (!transactionId) {
+              throw new Error('Invalid HTTP transaction ID.');
+            }
 
-          if (typeof result === 'boolean' && result) {
-            violations.push({
-              location: {
-                elementType: 'edge',
-                elementId: transactionId,
-              },
-            });
-          } else if (result) {
-            violations.push({
-              location: {
-                elementType: 'edge',
-                elementId: transactionId,
-              },
-              ...result,
-            });
+            if (typeof result === 'boolean' && result) {
+              violations.push({
+                location: {
+                  elementType: 'edge',
+                  elementId: transactionId,
+                },
+              });
+            } else if (result) {
+              violations.push({
+                location: {
+                  elementType: 'edge',
+                  elementId: transactionId,
+                },
+                ...result,
+              });
+            }
           }
         }
-      }
 
-      return violations;
-    }, [] as RuleViolation[]);
+        return violations;
+      }, [] as RuleViolation[])
+      .concat(this.violations);
   }
 }

--- a/packages/http-linter/src/api-context/utils/trace-to-string.ts
+++ b/packages/http-linter/src/api-context/utils/trace-to-string.ts
@@ -7,22 +7,21 @@ import {
 import type { CapturedTrace, CapturedTransaction } from '../../types.js';
 
 export function capturedTraceToString(trace: CapturedTrace): string {
-  const firstTransactions = trace[0];
-  // the check prevents that lastTransaction is equal to firstTransaction
-  const lastTransactions =
+  const firstTransaction = trace[0];
+  // This check prevents lastTransaction from being equal to firstTransaction when the array has only one element.
+  const lastTransaction =
     trace[trace.length - 1] === trace[0] ? undefined : trace[trace.length - 1];
 
   // length === 1
-  if (!lastTransactions && !!firstTransactions) {
+  if (!lastTransaction && !!firstTransaction) {
     return httpTransactionToLabel(
-      firstTransactions.request.data,
-      firstTransactions.response.data,
+      firstTransaction.request.data,
+      firstTransaction.response.data,
     );
   }
 
-  // we changed this with the first checked so that we can be sure that firstTransactions and lastTransactions are not undefined, because if one of them is undefined, the other one is also undefined, so we can check only one of them
-  // length === 0
-  if (!firstTransactions || !lastTransactions) {
+  // Handle empty trace case.
+  if (!firstTransaction || !lastTransaction) {
     return '';
   }
 
@@ -37,9 +36,9 @@ export function capturedTraceToString(trace: CapturedTrace): string {
     return [...requests, ...responses].join(' -> ');
   }
 
-  const firstReq = formatReq(firstTransactions);
-  const lastReq = formatReq(lastTransactions);
-  const lastRes = formatRes(lastTransactions);
-  const firstRes = formatRes(firstTransactions);
-  return `${firstReq} -> ${lastReq} ->  ...${trace.length - 2}x more  -> ${lastRes} -> ${firstRes}`;
+  const firstReq = formatReq(firstTransaction);
+  const lastReq = formatReq(lastTransaction);
+  const lastRes = formatRes(lastTransaction);
+  const firstRes = formatRes(firstTransaction);
+  return `${firstReq} -> ${lastReq} -> ...${trace.length - 2}x more -> ${lastRes} -> ${firstRes}`;
 }

--- a/packages/http-linter/src/api-context/utils/trace-to-string.ts
+++ b/packages/http-linter/src/api-context/utils/trace-to-string.ts
@@ -1,0 +1,45 @@
+import {
+  httpRequestToLabel,
+  httpResponseToLabel,
+  httpTransactionToLabel,
+} from '@thymian/core';
+
+import type { CapturedTrace, CapturedTransaction } from '../../types.js';
+
+export function capturedTraceToString(trace: CapturedTrace): string {
+  const firstTransactions = trace[0];
+  // the check prevents that lastTransaction is equal to firstTransaction
+  const lastTransactions =
+    trace[trace.length - 1] === trace[0] ? undefined : trace[trace.length - 1];
+
+  // length === 1
+  if (!lastTransactions && !!firstTransactions) {
+    return httpTransactionToLabel(
+      firstTransactions.request.data,
+      firstTransactions.response.data,
+    );
+  }
+
+  // we changed this with the first checked so that we can be sure that firstTransactions and lastTransactions are not undefined, because if one of them is undefined, the other one is also undefined, so we can check only one of them
+  // length === 0
+  if (!firstTransactions || !lastTransactions) {
+    return '';
+  }
+
+  const formatReq = (t: CapturedTransaction) =>
+    httpRequestToLabel(t.request.data);
+  const formatRes = (t: CapturedTransaction) =>
+    httpResponseToLabel(t.response.data);
+
+  if (trace.length === 2) {
+    const requests = trace.map(formatReq);
+    const responses = trace.map(formatRes).reverse();
+    return [...requests, ...responses].join(' -> ');
+  }
+
+  const firstReq = formatReq(firstTransactions);
+  const lastReq = formatReq(lastTransactions);
+  const lastRes = formatRes(lastTransactions);
+  const firstRes = formatRes(firstTransactions);
+  return `${firstReq} -> ${lastReq} ->  ...${trace.length - 2}x more  -> ${lastRes} -> ${firstRes}`;
+}

--- a/packages/http-linter/src/db/http-transaction-repository.ts
+++ b/packages/http-linter/src/db/http-transaction-repository.ts
@@ -28,4 +28,6 @@ export interface HttpTransactionRepository {
     groupBy: HttpFilterExpression,
     role?: HttpParticipantRole[],
   ): IterableIterator<[string, CapturedTransaction[]], void, unknown>;
+
+  readAllHttpTraces(): IterableIterator<CapturedTrace, void, unknown>;
 }

--- a/packages/http-linter/src/db/sqlite/sqlite-http-transaction-repository.ts
+++ b/packages/http-linter/src/db/sqlite/sqlite-http-transaction-repository.ts
@@ -300,6 +300,23 @@ export class SqliteHttpTransactionRepository implements HttpTransactionRepositor
     return trace.length > 0 ? trace : undefined;
   }
 
+  // this could be implemented more efficiently by using a single query that joins the http_trace table with the http_transaction table
+  // but this would require a lot of refactoring of the code that reads traces and transactions
+  // so for now we just iterate over all traces and read all transactions for each trace
+  *readAllHttpTraces(): IterableIterator<CapturedTrace, void, unknown> {
+    const traceStmt = this.db.prepare(`
+      SELECT id FROM http_trace
+    `);
+    const traceRows = traceStmt.all() as Array<{ id: number }>;
+
+    for (const traceRow of traceRows) {
+      const trace = this.readTraceById(traceRow.id);
+      if (trace) {
+        yield trace;
+      }
+    }
+  }
+
   insertHttpTransaction(transaction: CapturedTransaction): number {
     const insertTransaction = this.db.transaction(() => {
       // Create a trace for this single transaction

--- a/packages/http-linter/src/types.ts
+++ b/packages/http-linter/src/types.ts
@@ -1,4 +1,10 @@
-import type { HttpRequest, HttpResponse } from '@thymian/core';
+import {
+  type HttpRequest,
+  httpRequestToLabel,
+  type HttpResponse,
+  httpResponseToLabel,
+  httpTransactionToLabel,
+} from '@thymian/core';
 
 import type { HttpParticipantRole } from './rule/rule-meta.js';
 

--- a/packages/http-linter/src/types.ts
+++ b/packages/http-linter/src/types.ts
@@ -1,10 +1,4 @@
-import {
-  type HttpRequest,
-  httpRequestToLabel,
-  type HttpResponse,
-  httpResponseToLabel,
-  httpTransactionToLabel,
-} from '@thymian/core';
+import { type HttpRequest, type HttpResponse } from '@thymian/core';
 
 import type { HttpParticipantRole } from './rule/rule-meta.js';
 

--- a/packages/http-linter/test/api-context/analytics-api-context.test.ts
+++ b/packages/http-linter/test/api-context/analytics-api-context.test.ts
@@ -499,6 +499,246 @@ describe('AnalyticsApiContext', () => {
 
       expect(result).toHaveLength(2);
     });
+
+    it('should apply intermediate role correctly', async () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'proxy',
+          },
+        },
+      });
+      insertTransaction({
+        request: {
+          data: {
+            method: 'post',
+            origin: 'https://api.example.de',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 201,
+            headers: {},
+            trailers: {},
+            duration: 150,
+          },
+          meta: {
+            role: 'origin server',
+          },
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+        () => undefined,
+        ['intermediary'],
+      );
+
+      const result = await context.validateCommonHttpTransactions(
+        path('/users'),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: expect.stringMatching('https://api.example.com/users'),
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('validateCapturedHttpTransactions', () => {
+    it('should validate captured transactions with filter', () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'post',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {},
+        },
+        response: {
+          data: {
+            statusCode: 201,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {},
+        },
+      });
+
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/products',
+            headers: {},
+          },
+          meta: {},
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 50,
+          },
+          meta: {},
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+      );
+
+      const result = context.validateCapturedHttpTransactions(
+        path('/users'),
+        (transaction, location) => {
+          if (transaction.request.data.method === 'post') {
+            return { message: 'POST method found', severity: 'error' };
+          }
+          return false;
+        },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'POST method found',
+            severity: 'error',
+            location: expect.stringContaining('/users'),
+          }),
+        ]),
+      );
+    });
+
+    it('should return true for boolean validation result', () => {
+      insertTransaction();
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+      );
+
+      const result = context.validateCapturedHttpTransactions(
+        path('/users'),
+        () => true,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: expect.stringContaining(''),
+          }),
+        ]),
+      );
+    });
+
+    it('should filter by role when provided', () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'proxy',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'proxy',
+          },
+        },
+      });
+
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'origin server',
+          },
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+        () => undefined,
+        ['intermediary'],
+      );
+
+      const result = context.validateCapturedHttpTransactions(
+        path('/users'),
+        () => true,
+      );
+
+      expect(result).toHaveLength(1);
+    });
   });
 
   describe('validateGroupedCommonHttpTransactions', () => {
@@ -987,6 +1227,195 @@ describe('AnalyticsApiContext', () => {
       );
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('validateCapturedHttpTraces', () => {
+    it('should validate traces with single transaction', () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {},
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {},
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+      );
+
+      const result = context.validateCapturedHttpTraces((trace) => {
+        if (trace.length === 1) {
+          return { message: 'Single transaction trace' };
+        }
+        return false;
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Single transaction trace',
+          }),
+        ]),
+      );
+    });
+
+    it('should validate traces with multiple transactions', () => {
+      repository.insertHttpTrace([
+        {
+          request: {
+            data: {
+              method: 'get',
+              origin: 'https://proxy.example.com',
+              path: '/users',
+              headers: {},
+            },
+            meta: { role: 'proxy' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 100,
+            },
+            meta: { role: 'proxy' },
+          },
+        },
+        {
+          request: {
+            data: {
+              method: 'get',
+              origin: 'https://api.example.com',
+              path: '/users',
+              headers: {},
+            },
+            meta: { role: 'origin server' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 50,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ]);
+
+      repository.insertHttpTrace([
+        {
+          request: {
+            data: {
+              method: 'get',
+              origin: 'https://cache.example.com',
+              path: '/users',
+              headers: {},
+            },
+            meta: { role: 'cache' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 100,
+            },
+            meta: { role: 'cache' },
+          },
+        },
+        {
+          request: {
+            data: {
+              method: 'get',
+              origin: 'https://cache.example.com',
+              path: '/users',
+              headers: {},
+            },
+            meta: { role: 'origin server' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 50,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ]);
+
+      repository.insertHttpTrace([
+        {
+          request: {
+            data: {
+              method: 'get',
+              origin: 'https://api.example.com',
+              path: '/users',
+              headers: {},
+            },
+            meta: { role: 'origin server' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 50,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ]);
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+      );
+
+      const result = context.validateCapturedHttpTraces((trace) => {
+        const [first, last] = trace;
+
+        if (!first || !last) {
+          return false;
+        }
+
+        return (
+          first.request.meta.role === 'proxy' &&
+          last.response.meta.role === 'origin server' &&
+          first.request.data.method === 'get'
+        );
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: expect.stringContaining('https://proxy.example.com'),
+          }),
+        ]),
+      );
     });
   });
 });

--- a/packages/http-linter/test/api-context/http-test-api-context.test.ts
+++ b/packages/http-linter/test/api-context/http-test-api-context.test.ts
@@ -471,4 +471,86 @@ describe('HttpTestApiContext', () => {
       expect(result).toHaveLength(0);
     });
   });
+
+  describe('reportViolation', () => {
+    it('should accumulate violations and include them in validation results', async () => {
+      const format = createThymianFormatWithTransaction(
+        createHttpRequest({ method: 'get', path: '/users' }),
+        createHttpResponse({ statusCode: 200, headers: {} }),
+      );
+
+      const mockContext = createMockHttpTestContext({ format });
+      vi.mocked(mockContext.runRequest).mockResolvedValue({
+        statusCode: 200,
+        headers: {},
+        duration: 0,
+        trailers: {},
+      });
+
+      const context = new HttpTestApiContext('test-rule', mockContext, vi.fn());
+
+      // Report some violations
+      context.reportViolation({
+        location: 'manual-location-1',
+        message: 'Manual violation 1',
+      });
+      context.reportViolation({
+        location: 'manual-location-2',
+        message: 'Manual violation 2',
+      });
+
+      // Run validation that also returns a violation
+      const result = await context.validateHttpTransactions(
+        method('get'),
+        () => ({ message: 'Validation violation', severity: 'error' }),
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: 'manual-location-1',
+            message: 'Manual violation 1',
+          }),
+          expect.objectContaining({
+            location: 'manual-location-2',
+            message: 'Manual violation 2',
+          }),
+          expect.objectContaining({
+            message: 'Validation violation',
+          }),
+        ]),
+      );
+    });
+
+    it('should include reported violations in validateCommonHttpTransactions', async () => {
+      const format = createThymianFormatWithTransaction(
+        createHttpRequest({ method: 'post', path: '/users' }),
+        createHttpResponse({ statusCode: 201, headers: {} }),
+      );
+
+      const mockContext = createMockHttpTestContext({ format });
+      const context = new HttpTestApiContext('test-rule', mockContext, vi.fn());
+
+      context.reportViolation({
+        location: 'reported-violation',
+        message: 'Custom reported violation',
+      });
+
+      const result = await context.validateCommonHttpTransactions(
+        method('post'),
+        () => false,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: 'reported-violation',
+            message: 'Custom reported violation',
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/packages/http-linter/test/api-context/utils/trace-to-string.test.ts
+++ b/packages/http-linter/test/api-context/utils/trace-to-string.test.ts
@@ -1,0 +1,160 @@
+import { httpTransactionToLabel } from '@thymian/core';
+import { describe, expect, it } from 'vitest';
+
+import { capturedTraceToString } from '../../../src/api-context/utils/trace-to-string.js';
+import type { CapturedTrace } from '../../../src/types.js';
+
+describe('capturedTraceToString', () => {
+  it('should return empty string for empty trace', () => {
+    const emptyTrace: CapturedTrace = [];
+    const result = capturedTraceToString(emptyTrace);
+    expect(result).toBe('');
+  });
+
+  it('should format single transaction trace', () => {
+    const trace: CapturedTrace = [
+      {
+        request: {
+          data: {
+            method: 'GET',
+            origin: 'https://api.example.com',
+            path: '/users',
+          },
+          meta: {},
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {},
+        },
+      },
+    ];
+
+    const result = capturedTraceToString(trace);
+    expect(result).toStrictEqual(
+      httpTransactionToLabel(trace[0]!.request.data, trace[0]!.response.data),
+    );
+  });
+
+  it('should format two-transaction trace with arrows', () => {
+    const trace: CapturedTrace = [
+      {
+        request: {
+          data: {
+            method: 'GET',
+            origin: 'https://proxy.example.com',
+            path: '/api',
+          },
+          meta: { role: 'proxy' },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 50,
+          },
+          meta: { role: 'proxy' },
+        },
+      },
+      {
+        request: {
+          data: {
+            method: 'GET',
+            origin: 'https://api.example.com',
+            path: '/api',
+          },
+          meta: { role: 'origin server' },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 50,
+          },
+          meta: { role: 'origin server' },
+        },
+      },
+    ];
+
+    const result = capturedTraceToString(trace);
+    expect(result).toContain('->');
+    expect(result).toContain('proxy.example.com');
+    expect(result).toContain('api.example.com');
+  });
+
+  it('should format multi-transaction trace (length > 2)', () => {
+    const trace: CapturedTrace = [
+      {
+        request: {
+          data: {
+            method: 'POST',
+            origin: 'https://client.example.com',
+            path: '/start',
+          },
+          meta: { role: 'user-agent' },
+        },
+        response: {
+          data: {
+            statusCode: 201,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: { role: 'user-agent' },
+        },
+      },
+      {
+        request: {
+          data: {
+            method: 'POST',
+            origin: 'https://proxy.example.com',
+            path: '/middle',
+          },
+          meta: { role: 'proxy' },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 80,
+          },
+          meta: { role: 'proxy' },
+        },
+      },
+      {
+        request: {
+          data: {
+            method: 'POST',
+            origin: 'https://api.example.com',
+            path: '/end',
+          },
+          meta: { role: 'origin server' },
+        },
+        response: {
+          data: {
+            statusCode: 201,
+            headers: {},
+            trailers: {},
+            duration: 60,
+          },
+          meta: { role: 'origin server' },
+        },
+      },
+    ];
+
+    const result = capturedTraceToString(trace);
+    expect(result).toContain('POST');
+    expect(result).toContain('->');
+    expect(result).toContain('client.example.com');
+    expect(result).toContain('api.example.com');
+    expect(result).toContain('201');
+    expect(result).toContain('1x more');
+  });
+});

--- a/packages/http-linter/test/db/sqlite-http-transaction-repository.test.ts
+++ b/packages/http-linter/test/db/sqlite-http-transaction-repository.test.ts
@@ -1299,4 +1299,144 @@ describe('HttpTransactionRepository', () => {
       expect(retrieved2).toHaveLength(1);
     });
   });
+
+  describe('readAllHttpTraces', () => {
+    it('should return empty iterator when no traces exist', () => {
+      const traces = Array.from(repo.readAllHttpTraces());
+      expect(traces).toHaveLength(0);
+    });
+
+    it('should return all traces from the database', async () => {
+      const trace1: CapturedTrace = [
+        {
+          request: {
+            data: {
+              method: 'GET',
+              origin: 'https://api.example.com',
+              path: '/users',
+            },
+            meta: { role: 'user-agent' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 100,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ];
+
+      const trace2: CapturedTrace = [
+        {
+          request: {
+            data: {
+              method: 'POST',
+              origin: 'https://api.example.com',
+              path: '/users',
+            },
+            meta: { role: 'user-agent' },
+          },
+          response: {
+            data: {
+              statusCode: 201,
+              headers: {},
+              trailers: {},
+              duration: 150,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ];
+
+      const trace3: CapturedTrace = [
+        {
+          request: {
+            data: {
+              method: 'GET',
+              origin: 'https://proxy.example.com',
+              path: '/api',
+            },
+            meta: { role: 'proxy' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 50,
+            },
+            meta: { role: 'proxy' },
+          },
+        },
+        {
+          request: {
+            data: {
+              method: 'GET',
+              origin: 'https://api.example.com',
+              path: '/api',
+            },
+            meta: { role: 'origin server' },
+          },
+          response: {
+            data: {
+              statusCode: 200,
+              headers: {},
+              trailers: {},
+              duration: 50,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ];
+
+      await repo.insertHttpTrace(trace1);
+      await repo.insertHttpTrace(trace2);
+      await repo.insertHttpTrace(trace3);
+
+      const allTraces = Array.from(repo.readAllHttpTraces());
+
+      expect(allTraces).toHaveLength(3);
+      expect(allTraces[0]).toHaveLength(1);
+      expect(allTraces[1]).toHaveLength(1);
+      expect(allTraces[2]).toHaveLength(2);
+    });
+
+    it('should correctly iterate through traces with iterator protocol', async () => {
+      const trace: CapturedTrace = [
+        {
+          request: {
+            data: {
+              method: 'DELETE',
+              origin: 'https://api.example.com',
+              path: '/users/123',
+            },
+            meta: { role: 'user-agent' },
+          },
+          response: {
+            data: {
+              statusCode: 204,
+              headers: {},
+              trailers: {},
+              duration: 75,
+            },
+            meta: { role: 'origin server' },
+          },
+        },
+      ];
+
+      await repo.insertHttpTrace(trace);
+
+      const iterator = repo.readAllHttpTraces();
+      const firstTrace = iterator.next();
+
+      expect(firstTrace.done).toBe(false);
+      expect(firstTrace.value).toHaveLength(1);
+
+      const secondTrace = iterator.next();
+      expect(secondTrace.done).toBe(true);
+    });
+  });
 });

--- a/packages/rfc-9110-rules/src/rules/routing/client-must-not-use-special-request-target-forms-with-other-methods.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/client-must-not-use-special-request-target-forms-with-other-methods.rule.ts
@@ -1,0 +1,18 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/client-must-not-use-special-request-target-forms-with-other-methods',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-determining-the-target-reso',
+  )
+  .description(
+    'The special request target forms (host:port for CONNECT, single asterisk for OPTIONS) MUST NOT be used with other methods. For CONNECT, the request target is the host name and port number of the tunnel destination, separated by a colon. For OPTIONS, the request target can be a single asterisk ("*"). These forms MUST NOT be used with other methods.',
+  )
+  .summary(
+    'Special request target forms MUST NOT be used with methods other than CONNECT or OPTIONS.',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/client-should-continue-sending-request-when-response-arrives.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/client-should-continue-sending-request-when-response-arrives.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/client-should-continue-sending-request-when-response-arrives',
+)
+  .severity('warn')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-response-correlation')
+  .description(
+    'A client that receives a response while it is still sending the associated request SHOULD continue sending that request unless it receives an explicit indication to the contrary. All responses can be sent at any time after a request is received, even if the request is not yet complete.',
+  )
+  .summary(
+    'Client SHOULD continue sending request even if response arrives early.',
+  )
+  .appliesTo('client')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/intermediary-must-parse-and-remove-connection-fields.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/intermediary-must-parse-and-remove-connection-fields.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-parse-and-remove-connection-fields',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connection')
+  .description(
+    "Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).",
+  )
+  .summary(
+    'Intermediary MUST parse and remove Connection fields before forwarding.',
+  )
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/intermediary-should-remove-known-hop-by-hop-fields.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/intermediary-should-remove-known-hop-by-hop-fields.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-should-remove-known-hop-by-hop-fields',
+)
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connection')
+  .description(
+    "Intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics. This includes but is not limited to: Proxy-Connection, Keep-Alive, TE, Transfer-Encoding, and Upgrade.",
+  )
+  .summary('Intermediary SHOULD remove known hop-by-hop fields.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/sender-must-list-connection-specific-field-in-connection-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/sender-must-list-connection-specific-field-in-connection-header.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-must-list-connection-specific-field-in-connection-header',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connection')
+  .description(
+    'When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field. This enables proper hop-by-hop vs end-to-end field distinction.',
+  )
+  .summary('Sender MUST list connection-specific fields in Connection header.')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-must-not-send-end-to-end-fields-as-connection-options',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connection')
+  .description(
+    'A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content. For example, Cache-Control is never appropriate as a connection option. This ensures end-to-end fields are not incorrectly marked as hop-by-hop.',
+  )
+  .summary('Sender MUST NOT use end-to-end fields as connection options.')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/intermediary-must-implement-connection-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/intermediary-must-implement-connection-header.rule.ts
@@ -1,0 +1,12 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/intermediary-must-implement-connection-header')
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-message-forwarding')
+  .description(
+    'An intermediary not acting as a tunnel MUST implement the Connection header field, as specified in Section 7.6.1, and exclude fields from being forwarded that are only intended for the incoming connection. This ensures proper hop-by-hop header handling.',
+  )
+  .summary('Intermediary MUST implement Connection header field.')
+  .appliesTo('proxy', 'gateway')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/intermediary-must-not-forward-message-to-itself.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/intermediary-must-not-forward-message-to-itself.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-not-forward-message-to-itself',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-message-forwarding')
+  .description(
+    'An intermediary MUST NOT forward a message to itself unless it is protected from an infinite request loop. In general, an intermediary ought to recognize its own server names, including any aliases, local variations, or literal IP addresses, and respond to such requests directly.',
+  )
+  .summary(
+    'Intermediary MUST NOT forward message to itself without loop protection.',
+  )
+  .appliesTo('proxy', 'gateway')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-check-and-update-max-forwards.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-check-and-update-max-forwards.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-check-and-update-max-forwards',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-max-forwards')
+  .description(
+    'Each intermediary that receives a TRACE or OPTIONS request containing a Max-Forwards header field MUST check and update its value prior to forwarding the request. The Max-Forwards mechanism limits the number of times a request can be forwarded.',
+  )
+  .summary('Intermediary MUST check and update Max-Forwards value.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-generate-updated-max-forwards-when-forwarding.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-generate-updated-max-forwards-when-forwarding.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-generate-updated-max-forwards-when-forwarding',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-max-forwards')
+  .description(
+    "If the received Max-Forwards value is greater than zero, the intermediary MUST generate an updated Max-Forwards field in the forwarded message with a field value that is the lesser of a) the received value decremented by one (1) or b) the recipient's maximum supported value for Max-Forwards.",
+  )
+  .summary('Intermediary MUST generate updated Max-Forwards when forwarding.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-not-forward-when-max-forwards-is-zero.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-not-forward-when-max-forwards-is-zero.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-not-forward-when-max-forwards-is-zero',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-max-forwards')
+  .description(
+    'If the received Max-Forwards value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient. This prevents infinite forwarding loops in TRACE and OPTIONS requests.',
+  )
+  .summary('Intermediary MUST NOT forward request when Max-Forwards is zero.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-respond-as-final-recipient-when-max-forward-is-zero.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/intermediary-must-respond-as-final-recipient-when-max-forward-is-zero.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-must-respond-as-final-recipient-when-max-forward-is-zero',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-max-forwards')
+  .description(
+    'If the received Max-Forwards value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient. This prevents infinite forwarding loops in TRACE and OPTIONS requests.',
+  )
+  .summary(
+    'Intermediary MUST respond as final recipient when Max-Forwards is zero.',
+  )
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/recipient-may-ignore-max-forwards-for-other-methods.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/max-forwards/recipient-may-ignore-max-forwards-for-other-methods.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/recipient-may-ignore-max-forwards-for-other-methods',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-max-forwards')
+  .description(
+    'A recipient MAY ignore a Max-Forwards header field received with any other request methods. The Max-Forwards mechanism is specifically designed for TRACE and OPTIONS methods to limit forwarding.',
+  )
+  .summary(
+    'Recipient MAY ignore Max-Forwards for methods other than TRACE/OPTIONS.',
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/firewall-intermediary-should-not-forward-internal-hosts.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/firewall-intermediary-should-not-forward-internal-hosts.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/firewall-intermediary-should-not-forward-internal-hosts',
+)
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'An intermediary used as a portal through a network firewall SHOULD NOT forward the names and ports of hosts within the firewall region unless it is explicitly enabled to do so. This protects internal network topology from exposure.',
+  )
+  .summary('Firewall intermediary SHOULD NOT forward internal host names.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/firewall-intermediary-should-replace-internal-hosts-with-pseudonyms.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/firewall-intermediary-should-replace-internal-hosts-with-pseudonyms.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/firewall-intermediary-should-replace-internal-hosts-with-pseudonyms',
+)
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'If not explicitly enabled to forward internal host names, an intermediary used as a portal through a network firewall SHOULD replace each received-by host of any host behind the firewall by an appropriate pseudonym for that host. This protects internal network information.',
+  )
+  .summary(
+    'Firewall intermediary SHOULD replace internal hosts with pseudonyms.',
+  )
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
@@ -1,4 +1,4 @@
-import { not, requestHeader } from '@thymian/core';
+import { not, responseHeader } from '@thymian/core';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule('rfc9110/gateway-may-send-via-header-in-responses')
@@ -12,7 +12,7 @@ export default httpRule('rfc9110/gateway-may-send-via-header-in-responses')
   .appliesTo('gateway')
   .rule((ctx) =>
     ctx.validateCapturedHttpTransactions(
-      not(requestHeader('via')),
+      not(responseHeader('via')),
       ({ response }) => response.meta.role === 'gateway',
     ),
   )

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
@@ -1,0 +1,19 @@
+import { not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/gateway-may-send-via-header-in-responses')
+  .severity('hint')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'An HTTP-to-HTTP gateway MAY send a Via header field in forwarded response messages. This is optional for responses, unlike requests where it is required.',
+  )
+  .summary('Gateway MAY send Via header in forwarded responses.')
+  .appliesTo('gateway')
+  .rule((ctx) =>
+    ctx.validateCapturedHttpTransactions(
+      not(requestHeader('via')),
+      ({ response }) => response.meta.role === 'gateway',
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-must-send-via-header-in-inbound-requests.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/gateway-must-send-via-header-in-inbound-requests.rule.ts
@@ -1,0 +1,21 @@
+import { not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/gateway-must-send-via-header-in-inbound-requests',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message. This enables tracking of the message path and protocol capabilities along the request/response chain.',
+  )
+  .summary('Gateway MUST send Via header in inbound requests.')
+  .appliesTo('gateway')
+  .rule((ctx) =>
+    ctx.validateCapturedHttpTransactions(
+      not(requestHeader('via')),
+      ({ request }) => request.meta.role === 'gateway',
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/intermediary-may-combine-via-entries-with-identical-protocols.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/intermediary-may-combine-via-entries-with-identical-protocols.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/intermediary-may-combine-via-entries-with-identical-protocols',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'An intermediary MAY combine an ordered subsequence of Via header field list members into a single member if the entries have identical received-protocol values. This can reduce header size while maintaining the essential routing information.',
+  )
+  .summary('Intermediary MAY combine Via entries with identical protocols.')
+  .appliesTo('intermediary')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
@@ -1,0 +1,19 @@
+import { constant, not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/proxy-must-send-via-header')
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'A proxy MUST send an appropriate Via header field in each message that it forwards. The Via header field indicates the presence of intermediate protocols and recipients between the user agent and the server, and is used for tracking message forwards, avoiding request loops, and identifying protocol capabilities.',
+  )
+  .summary('Proxy MUST send Via header in forwarded messages.')
+  .appliesTo('proxy')
+  .rule((ctx) =>
+    ctx.validateCapturedHttpTransactions(
+      not(requestHeader('via')),
+      ({ request }) => request.meta.role === 'proxy',
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
@@ -1,4 +1,4 @@
-import { constant, not, requestHeader } from '@thymian/core';
+import { not, requestHeader } from '@thymian/core';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule('rfc9110/proxy-must-send-via-header')

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/recipient-may-interpret-missing-port-as-default.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/recipient-may-interpret-missing-port-as-default.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/recipient-may-interpret-missing-port-as-default',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'If a port is not provided in the Via header field, a recipient MAY interpret that as meaning it was received on the default port, if any, for the received-protocol.',
+  )
+  .summary(
+    'Recipient MAY interpret missing port as default port in Via header.',
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/recipient-may-remove-comments-before-forwarding.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/recipient-may-remove-comments-before-forwarding.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/recipient-may-remove-comments-before-forwarding',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'Comments in Via are optional, and a recipient MAY remove them prior to forwarding the message. This allows intermediaries to strip potentially sensitive or unnecessary information.',
+  )
+  .summary('Recipient MAY remove comments from Via header before forwarding.')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-generate-comments-to-identify-software.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-generate-comments-to-identify-software.rule.ts
@@ -1,0 +1,13 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-may-generate-comments-to-identify-software',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'A sender MAY generate comments to identify the software of each recipient, analogous to the User-Agent and Server header fields. However, comments in Via are optional.',
+  )
+  .summary('Sender MAY generate comments in Via header to identify software.')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-replace-host-with-pseudonym.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-replace-host-with-pseudonym.rule.ts
@@ -1,0 +1,17 @@
+import { or, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/sender-may-replace-host-with-pseudonym')
+  .severity('hint')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'The received-by portion of the Via header is normally the host and optional port number of a recipient server or client that subsequently forwarded the message. However, if the real host is considered to be sensitive information, a sender MAY replace it with a pseudonym.',
+  )
+  .summary('Sender MAY replace host with pseudonym in Via header.')
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      or(requestHeader('host'), requestHeader(':authority')),
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-replace-host-with-pseudonym.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-may-replace-host-with-pseudonym.rule.ts
@@ -1,4 +1,4 @@
-import { or, requestHeader } from '@thymian/core';
+import { and, or, requestHeader } from '@thymian/core';
 import { httpRule } from '@thymian/http-linter';
 
 export default httpRule('rfc9110/sender-may-replace-host-with-pseudonym')
@@ -11,7 +11,10 @@ export default httpRule('rfc9110/sender-may-replace-host-with-pseudonym')
   .summary('Sender MAY replace host with pseudonym in Via header.')
   .rule((ctx) =>
     ctx.validateHttpTransactions(
-      or(requestHeader('host'), requestHeader(':authority')),
+      and(
+        or(requestHeader('host'), requestHeader(':authority')),
+        requestHeader('via'),
+      ),
     ),
   )
   .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-must-not-combine-via-entries-with-different-protocols.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-must-not-combine-via-entries-with-different-protocols.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-must-not-combine-via-entries-with-different-protocols',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'A sender MUST NOT combine members that have different received-protocol values. Combining Via entries is only permitted when the protocol versions are identical, as different protocols need to be separately tracked.',
+  )
+  .summary('Sender MUST NOT combine Via entries with different protocols.')
+  .appliesTo('proxy')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-should-not-combine-via-entries-unless-same-organization.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-forwarding/via/sender-should-not-combine-via-entries-unless-same-organization.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/sender-should-not-combine-via-entries-unless-same-organization',
+)
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-via')
+  .description(
+    'A sender SHOULD NOT combine multiple list members unless they are all under the same organizational control and the hosts have already been replaced by pseudonyms. This ensures transparency about the intermediaries involved in the request/response chain.',
+  )
+  .summary(
+    'Sender SHOULD NOT combine Via entries unless under same organizational control.',
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-may-add-domain-to-non-fqdn-hostname.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-may-add-domain-to-non-fqdn-hostname.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/proxy-may-add-domain-to-non-fqdn-hostname')
+  .severity('hint')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    'If a proxy receives a target URI with a host name that is not a fully qualified domain name, it MAY add its own domain to the host name it received when forwarding the request. This can help resolve ambiguous host names.',
+  )
+  .summary('Proxy MAY add domain to non-FQDN host name.')
+  .appliesTo('proxy')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-may-transform-content-without-no-transform-directive.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-may-transform-content-without-no-transform-directive.rule.ts
@@ -1,0 +1,46 @@
+import { getHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/proxy-may-transform-content-without-no-transform-directive',
+)
+  .severity('hint')
+  .type('analytics')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    'A proxy MAY transform the content of a message that does not contain a no-transform cache directive. A proxy that transforms the content of a 200 (OK) response can inform downstream recipients that a transformation has been applied by changing the response status code to 203 (Non-Authoritative Information).',
+  )
+  .summary('Proxy MAY transform content without no-transform directive.')
+  .appliesTo('proxy')
+  .rule((ctx) =>
+    ctx.validateCapturedHttpTraces((trace, location) => {
+      for (let i = 1; i < trace.length; i++) {
+        const prev = trace[i - 1];
+        const curr = trace[i];
+
+        if (!prev || !curr) {
+          continue;
+        }
+
+        const cacheControlHeader = getHeader(
+          prev.request.data.headers,
+          'cache-control',
+        );
+
+        if (
+          cacheControlHeader &&
+          !cacheControlHeader.includes('no-transform') &&
+          prev.request.data === curr.request.data
+        ) {
+          ctx.reportViolation({
+            location,
+          });
+        }
+      }
+
+      return false;
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-change-fqdn-hostname.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-change-fqdn-hostname.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/proxy-must-not-change-fqdn-hostname')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    'A proxy MUST NOT change the host name if the target URI contains a fully qualified domain name. This prevents incorrect routing and ensures the request reaches the intended destination.',
+  )
+  .summary(
+    'Proxy MUST NOT change host name when it is a fully qualified domain name.',
+  )
+  .appliesTo('proxy')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-modify-absolute-path-and-query.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-modify-absolute-path-and-query.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/proxy-must-not-modify-absolute-path-and-query')
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    'A proxy MUST NOT modify the "absolute-path" and "query" parts of the received target URI when forwarding it to the next inbound server except as required by that forwarding protocol. For example, a proxy forwarding a request to an origin server via HTTP/1.1 will replace an empty path with "/" or "*", depending on the request method.',
+  )
+  .summary('Proxy MUST NOT modify absolute-path and query parts of target URI.')
+  .appliesTo('proxy')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
@@ -1,0 +1,48 @@
+import { getHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/proxy-must-not-transform-content-with-no-transform-directive',
+)
+  .severity('error')
+  .type('analytics')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    'A proxy MUST NOT transform the content of a response message that contains a no-transform cache directive. Note that this does not apply to message transformations that do not change the content, such as the addition or removal of transfer codings.',
+  )
+  .summary(
+    'Proxy MUST NOT transform content when no-transform directive is present.',
+  )
+  .appliesTo('proxy')
+  .rule((ctx) =>
+    ctx.validateCapturedHttpTraces((trace, location) => {
+      for (let i = 1; i < trace.length; i++) {
+        const prev = trace[i - 1];
+        const curr = trace[i];
+
+        if (!prev || !curr) {
+          continue;
+        }
+
+        const cacheControlHeader = getHeader(
+          prev.request.data.headers,
+          'cache-control',
+        );
+
+        if (
+          cacheControlHeader &&
+          cacheControlHeader.includes('no-transform') &&
+          prev.request.data !== curr.request.data
+        ) {
+          ctx.reportViolation({
+            location,
+          });
+        }
+      }
+
+      return false;
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
@@ -19,21 +19,32 @@ export default httpRule(
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {
       for (let i = 1; i < trace.length; i++) {
+        // contains response from proxy (if there is a proxy)
         const prev = trace[i - 1];
+        // contains response to proxy (if there is a proxy)
         const curr = trace[i];
 
-        if (!prev || !curr) {
+        if (!prev || !curr || prev.response.meta.role !== 'proxy') {
           continue;
         }
 
         const cacheControlHeader = getHeader(
-          prev.request.data.headers,
+          curr.response.data.headers,
           'cache-control',
         );
 
+        if (!cacheControlHeader) {
+          continue;
+        }
+
+        const cacheDirectives = Array.isArray(cacheControlHeader)
+          ? cacheControlHeader
+          : [cacheControlHeader];
+
         if (
-          cacheControlHeader &&
-          cacheControlHeader.includes('no-transform') &&
+          cacheDirectives.some(
+            (directive) => directive.toLowerCase().trim() === 'no-transform',
+          ) &&
           prev.request.data !== curr.request.data
         ) {
           ctx.reportViolation({

--- a/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-should-not-modify-endpoint-and-representation-headers.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/message-transformations/proxy-should-not-modify-endpoint-and-representation-headers.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/proxy-should-not-modify-endpoint-and-representation-headers',
+)
+  .severity('warn')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-message-transformations',
+  )
+  .description(
+    "A proxy SHOULD NOT modify header fields that provide information about the endpoints of the communication chain, the resource state, or the selected representation (other than the content) unless the field's definition specifically allows such modification or the modification is deemed necessary for privacy or security.",
+  )
+  .summary('Proxy SHOULD NOT modify endpoint and representation headers.')
+  .appliesTo('proxy')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/origin-server-must-reject-https-requests-without-valid-certificate.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/origin-server-must-reject-https-requests-without-valid-certificate.rule.ts
@@ -1,0 +1,18 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/origin-server-must-reject-https-requests-without-valid-certificate',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-rejecting-misdirected-reque',
+  )
+  .description(
+    'Unless the connection is from a trusted gateway, an origin server MUST reject a request for an "https" resource unless it has been received over a connection that has been secured via a certificate valid for that target URI\'s origin, as defined by Section 4.2.2.',
+  )
+  .summary(
+    'Origin server MUST reject HTTPS requests not received over properly secured connections.',
+  )
+  .appliesTo('origin server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/origin-server-must-reject-requests-not-meeting-scheme-requirements.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/origin-server-must-reject-requests-not-meeting-scheme-requirements.rule.ts
@@ -1,0 +1,18 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/origin-server-must-reject-requests-not-meeting-scheme-requirements',
+)
+  .severity('error')
+  .type('informational')
+  .url(
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-rejecting-misdirected-reque',
+  )
+  .description(
+    'Unless the connection is from a trusted gateway, an origin server MUST reject a request if any scheme-specific requirements for the target URI are not met. This is important for security to prevent misdirected requests, bypass attempts, or content delivery to unintended recipients.',
+  )
+  .summary(
+    'Origin server MUST reject requests that do not meet scheme-specific requirements.',
+  )
+  .appliesTo('origin server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/client-may-send-upgrade-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/client-may-send-upgrade-header.rule.ts
@@ -1,0 +1,14 @@
+import { not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/client-may-send-upgrade-header')
+  .severity('hint')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.',
+  )
+  .summary('Client MAY send Upgrade header to invite protocol switch.')
+  .appliesTo('client')
+  .rule((ctx) => ctx.validateHttpTransactions(not(requestHeader('upgrade'))))
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/recipient-should-use-case-insensitive-comparison-for-protocol-names.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/recipient-should-use-case-insensitive-comparison-for-protocol-names.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/recipient-should-use-case-insensitive-comparison-for-protocol-names',
+)
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols. This ensures compatibility despite variations in protocol name casing.',
+  )
+  .summary(
+    'Recipient SHOULD use case-insensitive comparison for protocol names.',
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
@@ -1,0 +1,29 @@
+import { and, getHeader, not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/sender-must-send-upgrade-connection-option')
+  .severity('error')
+  .type('analytics', 'static')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field to inform intermediaries not to forward this field. This ensures the Upgrade header is treated as a hop-by-hop header.',
+  )
+  .summary('Sender MUST include "Upgrade" in Connection header.')
+  .overrideAnalyticsRule((ctx) =>
+    ctx.validateHttpTransactions(requestHeader('upgrade'), (req) => {
+      const connectionHeader = getHeader(req.headers, 'connection');
+
+      if (!connectionHeader) {
+        return false;
+      }
+
+      const connectionHeaderValues = Array.isArray(connectionHeader)
+        ? connectionHeader
+        : [connectionHeader];
+
+      return !connectionHeaderValues.find(
+        (value) => value.toLowerCase().trim() === 'upgrade',
+      );
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
@@ -14,7 +14,7 @@ export default httpRule('rfc9110/sender-must-send-upgrade-connection-option')
       const connectionHeader = getHeader(req.headers, 'connection');
 
       if (!connectionHeader) {
-        return false;
+        return true;
       }
 
       const connectionHeaderValues = Array.isArray(connectionHeader)

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-ignore-client-protocol-preference-order.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-ignore-client-protocol-preference-order.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-may-ignore-client-protocol-preference-order',
+)
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server MAY choose to ignore the order of preference indicated by the client and select the new protocol(s) based on other factors, such as the nature of the request or the current load on the server.',
+  )
+  .summary('Server MAY ignore client protocol preference order.')
+  .appliesTo('server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-ignore-upgrade-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-ignore-upgrade-header.rule.ts
@@ -1,0 +1,12 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule('rfc9110/server-may-ignore-upgrade-header')
+  .severity('hint')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server MAY ignore a received Upgrade header field if it wishes to continue using the current protocol on that connection. Upgrade cannot be used to insist on a protocol change.',
+  )
+  .summary('Server MAY ignore Upgrade header.')
+  .appliesTo('server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-send-upgrade-header-in-other-responses.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-may-send-upgrade-header-in-other-responses.rule.ts
@@ -1,0 +1,18 @@
+import { not, responseHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-may-send-upgrade-header-in-other-responses',
+)
+  .severity('hint')
+  .type('analytics', 'static')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.',
+  )
+  .summary('Server MAY send Upgrade header in responses to advertise support.')
+  .appliesTo('server')
+  .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(not(responseHeader('upgrade'))),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-ignore-upgrade-in-http-1.0-request.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-ignore-upgrade-in-http-1.0-request.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-ignore-upgrade-in-http-1.0-request',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field. Protocol switching is only supported in HTTP/1.1 and later versions.',
+  )
+  .summary('Server MUST ignore Upgrade header in HTTP/1.0 requests.')
+  .appliesTo('server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-list-protocols-in-layer-ascending-order.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-list-protocols-in-layer-ascending-order.rule.ts
@@ -1,0 +1,15 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-list-protocols-in-layer-ascending-order',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'If multiple protocol layers are being switched in a 101 (Switching Protocols) response, the sender MUST list the protocols in layer-ascending order. This ensures proper protocol stacking and negotiation.',
+  )
+  .summary(
+    'Server MUST list protocols in layer-ascending order in Upgrade header.',
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-not-switch-to-non-indicated-protocol.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-not-switch-to-non-indicated-protocol.rule.ts
@@ -1,0 +1,44 @@
+import { getHeader, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-not-switch-to-non-indicated-protocol',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field. The server can only switch to protocols explicitly requested by the client.",
+  )
+  .summary('Server MUST NOT switch to protocol not indicated by client.')
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(requestHeader('upgrade'), (req, res) => {
+      const reqUpgradeHeader = getHeader(req.headers, 'upgrade');
+      const resUpgradeHeader = getHeader(res.headers, 'upgrade');
+
+      if (reqUpgradeHeader && resUpgradeHeader) {
+        const reqUpgradeHeaderArray = Array.isArray(reqUpgradeHeader)
+          ? reqUpgradeHeader
+          : [reqUpgradeHeader];
+        const resUpgradeHeaderArray = Array.isArray(resUpgradeHeader)
+          ? resUpgradeHeader
+          : [resUpgradeHeader];
+
+        const reqUpgradeProtocols = reqUpgradeHeaderArray
+          .join(', ')
+          .split(',')
+          .map((protocol) => protocol.trim().toLowerCase());
+        const resUpgradeProtocols = resUpgradeHeaderArray
+          .join(', ')
+          .split(',')
+          .map((protocol) => protocol.trim().toLowerCase());
+
+        return resUpgradeProtocols.some(
+          (protocol) => !reqUpgradeProtocols.includes(protocol),
+        );
+      }
+
+      return false;
+    }),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-not-switch-unless-semantics-can-be-honored.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-not-switch-unless-semantics-can-be-honored.rule.ts
@@ -1,0 +1,14 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-not-switch-unless-semantics-can-be-honored',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server MUST NOT switch protocols unless the received message semantics can be honored by the new protocol. An OPTIONS request can be honored by any protocol. This allows a connection to be upgraded to protocols with the same semantics as HTTP without the latency cost of an additional round trip.',
+  )
+  .summary('Server MUST NOT switch unless message semantics can be honored.')
+  .appliesTo('server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-100-before-101-with-expect-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-100-before-101-with-expect-header.rule.ts
@@ -1,0 +1,16 @@
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-send-100-before-101-with-expect-header',
+)
+  .severity('error')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'If a server receives both an Upgrade and an Expect header field with the "100-continue" expectation, the server MUST send a 100 (Continue) response before sending a 101 (Switching Protocols) response. This ensures proper handling of the expect-continue mechanism before protocol switching.',
+  )
+  .summary(
+    'Server MUST send 100 response before 101 when Expect: 100-continue is present.',
+  )
+  .appliesTo('server')
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-upgrade-header-in-101-response.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-upgrade-header-in-101-response.rule.ts
@@ -1,0 +1,20 @@
+import { and, not, responseHeader, statusCode } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-send-upgrade-header-in-101-response',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server that sends a 101 (Switching Protocols) response MUST send an Upgrade header field to indicate the new protocol(s) to which the connection is being switched. This informs the client which protocol is now in use.',
+  )
+  .summary('Server MUST send Upgrade header in 101 response.')
+  .appliesTo('server')
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      and(statusCode(101), not(responseHeader('upgrade'))),
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-upgrade-header-in-426-response.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/upgrade/server-must-send-upgrade-header-in-426-response.rule.ts
@@ -1,0 +1,20 @@
+import { and, not, responseHeader, statusCode } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/server-must-send-upgrade-header-in-426-response',
+)
+  .severity('error')
+  .type('static', 'analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-upgrade')
+  .description(
+    'A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference. This informs the client which protocols it should use.',
+  )
+  .summary('Server MUST send Upgrade header in 426 response.')
+  .appliesTo('server')
+  .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(
+      and(statusCode(426), not(responseHeader('upgrade'))),
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/user-agent-must-generate-host-or-authority-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/user-agent-must-generate-host-or-authority-header.rule.ts
@@ -1,0 +1,19 @@
+import { and, not, requestHeader } from '@thymian/core';
+import { httpRule } from '@thymian/http-linter';
+
+export default httpRule(
+  'rfc9110/user-agent-must-generate-host-or-authority-header',
+)
+  .severity('error')
+  .type('analytics')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-host-and-authority')
+  .description(
+    'A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field. The target URI\'s authority information is critical for handling a request.',
+  )
+  .appliesTo('user-agent')
+  .rule((ctx) =>
+    ctx.validateHttpTransactions(
+      and(not(requestHeader('host')), not(requestHeader(':authority'))),
+    ),
+  )
+  .done();

--- a/packages/rfc-9110-rules/src/rules/routing/user-agent-should-send-host-as-first-header.rule.ts
+++ b/packages/rfc-9110-rules/src/rules/routing/user-agent-should-send-host-as-first-header.rule.ts
@@ -1,0 +1,12 @@
+import { httpRule } from '@thymian/http-linter';
+
+// we could test this if we would have access to the raw request
+export default httpRule('rfc9110/user-agent-should-send-host-as-first-header')
+  .severity('warn')
+  .type('informational')
+  .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-host-and-authority')
+  .description(
+    'A user agent that sends Host SHOULD send it as the first field in the header section of a request.',
+  )
+  .appliesTo('user-agent')
+  .done();


### PR DESCRIPTION
This pull request enhances the HTTP linter's validation framework by introducing support for reporting and accumulating rule violations across different API context implementations, and by enabling validation over captured HTTP traces. It also adds utility functions and tests for formatting and handling traces, and improves code consistency for violation handling.

Key changes include:

### HTTP Rules for Chapter 7 of RFC 9110

### Violation Accumulation and Reporting

* Introduced a `violations` array and a `reportViolation` method in the base `ApiContext` class, allowing manual reporting and accumulation of rule violations that are included in validation results for all derived contexts. (`packages/http-linter/src/api-context/api-context.ts` [[1]](diffhunk://#diff-9783a22906ba8b21d258af8a497a269be5b2c44cec29be0ce0aa943452249a63R27) [[2]](diffhunk://#diff-9783a22906ba8b21d258af8a497a269be5b2c44cec29be0ce0aa943452249a63R49-R52)
* Updated `AnalyticsApiContext` and `StaticApiContext` to append accumulated violations to the results of all validation methods, ensuring consistent violation reporting. (`packages/http-linter/src/api-context/analytics-api-context.ts` [[1]](diffhunk://#diff-5fd404313f3d4b078f5f54eddc8c01b06a0b2dce43056c68b56e62b26f23f1f9L105-R117) [[2]](diffhunk://#diff-5fd404313f3d4b078f5f54eddc8c01b06a0b2dce43056c68b56e62b26f23f1f9L192-R267); `packages/http-linter/src/api-context/static-api-context.ts` [[3]](diffhunk://#diff-e8a70bf7440eac8437b6b8d4e4e5a752e5eaf472ad1ae740db10ff1900f04e66L89-R90) [[4]](diffhunk://#diff-e8a70bf7440eac8437b6b8d4e4e5a752e5eaf472ad1ae740db10ff1900f04e66L118-R120) [[5]](diffhunk://#diff-e8a70bf7440eac8437b6b8d4e4e5a752e5eaf472ad1ae740db10ff1900f04e66L145-R147) [[6]](diffhunk://#diff-e8a70bf7440eac8437b6b8d4e4e5a752e5eaf472ad1ae740db10ff1900f04e66L162-R163) [[7]](diffhunk://#diff-e8a70bf7440eac8437b6b8d4e4e5a752e5eaf472ad1ae740db10ff1900f04e66L204-R206)
* Removed redundant violation handling from `HttpTestApiContext` to rely on the new base class implementation. (`packages/http-linter/src/api-context/http-test-api-context.ts` [[1]](diffhunk://#diff-406032ea55c6d197df35ecef97b66f1183e4ac75bcc118a8a02d6c971672fa95L53) [[2]](diffhunk://#diff-406032ea55c6d197df35ecef97b66f1183e4ac75bcc118a8a02d6c971672fa95L69-L72)

### Validation over HTTP Traces

* Added `validateCapturedHttpTraces` and `validateCapturedHttpTransactions` methods to `AnalyticsApiContext`, enabling validation logic to be applied over entire captured traces and transactions. (`packages/http-linter/src/api-context/analytics-api-context.ts` [packages/http-linter/src/api-context/analytics-api-context.tsL192-R267](diffhunk://#diff-5fd404313f3d4b078f5f54eddc8c01b06a0b2dce43056c68b56e62b26f23f1f9L192-R267))
* Extended the `HttpTransactionRepository` interface and its SQLite implementation to support iteration over all HTTP traces via a new `readAllHttpTraces` method. (`packages/http-linter/src/db/http-transaction-repository.ts` [[1]](diffhunk://#diff-6ae5b83c5169078a12d2a3a24121296b5cf155ed967e4e18cec5db2a945040c4R31-R32) `packages/http-linter/src/db/sqlite/sqlite-http-transaction-repository.ts` [[2]](diffhunk://#diff-323d63a3dfe1c70ce0bab471f4832ecdfce167700a710770ec1a2d8d0cb3892cR303-R319)

### Utilities and Testing for Trace Formatting

* Added a utility function `capturedTraceToString` for formatting traces as human-readable strings, and corresponding unit tests to verify its behavior for various trace scenarios. (`packages/http-linter/src/api-context/utils/trace-to-string.ts` [[1]](diffhunk://#diff-f05c3ad2532af92f053c3d1be4ddf468bb4e1e417ee4a8a511124d3d4c4d6042R1-R45) `packages/http-linter/test/api-context/utils/trace-to-string.test.ts` [[2]](diffhunk://#diff-19154ef00315241bb4b97bf7e5206cec89b5b1d186e6f5faf12aeb576eb0620eR1-R160)
* Updated imports and types to support new trace formatting and validation features. (`packages/http-linter/src/types.ts` [packages/http-linter/src/types.tsL1-R7](diffhunk://#diff-5bcf89373034c770f5a9ec318cec7606393325aea25b7181ad3841031e2b0e05L1-R7))

### Test Coverage for Violation Reporting

* Added comprehensive tests to ensure that manually reported violations are correctly accumulated and included in validation results for `HttpTestApiContext`. (`packages/http-linter/test/api-context/http-test-api-context.test.ts` [packages/http-linter/test/api-context/http-test-api-context.test.tsR474-R555](diffhunk://#diff-52eb8b371306c78f087409ef3895291cee0fc2963e5677695efa5972b727ee2eR474-R555))

### Miscellaneous

* Improved role handling in `AnalyticsApiContext` constructor for better flexibility and consistency. (`packages/http-linter/src/api-context/analytics-api-context.ts` [packages/http-linter/src/api-context/analytics-api-context.tsR18-R47](diffhunk://#diff-5fd404313f3d4b078f5f54eddc8c01b06a0b2dce43056c68b56e62b26f23f1f9R18-R47))

These changes collectively improve the flexibility, consistency, and testability of the HTTP linter's validation and reporting mechanisms.

Closes https://github.com/thymianofficial/thymian-internal/issues/88