### PR TITLE
fix(http-linter): rules with severity off are not loaded

### DIFF
--- a/packages/http-linter/src/load-rules.ts
+++ b/packages/http-linter/src/load-rules.ts
@@ -120,19 +120,25 @@ export async function loadRules(
   const ruleOrRuleSet = module.default;
 
   if (isRule(ruleOrRuleSet)) {
-    const { name } = ruleOrRuleSet.meta;
+    // Create a shallow copy of the rule to avoid mutating the cached module
+    const rule = {
+      ...ruleOrRuleSet,
+      meta: {
+        ...ruleOrRuleSet.meta,
+      },
+    };
 
+    const { name } = rule.meta;
     const ruleOptions = options[name];
 
     if (isRecord(ruleOptions)) {
-      ruleOrRuleSet.meta.severity =
-        ruleOptions.severity ?? ruleOrRuleSet.meta.severity;
-      ruleOrRuleSet.meta.type = ruleOptions.type ?? ruleOrRuleSet.meta.type;
+      rule.meta.severity = ruleOptions.severity ?? rule.meta.severity;
+      rule.meta.type = ruleOptions.type ?? rule.meta.type;
 
-      if (ruleOptions.options && ruleOrRuleSet.meta.options) {
-        if (!validate(ruleOrRuleSet.meta.options, ruleOptions.options)) {
+      if (ruleOptions.options && rule.meta.options) {
+        if (!validate(rule.meta.options, ruleOptions.options)) {
           throw new ThymianBaseError(
-            `Options for rule "${ruleOrRuleSet.meta.name}" does not match the schema of the rule.`,
+            `Options for rule "${rule.meta.name}" does not match the schema of the rule.`,
             {
               suggestions: [
                 'Check the options for the rule in your Thymian config file.',
@@ -144,11 +150,11 @@ export async function loadRules(
         }
       }
     } else if (isRuleSeverityLevel(ruleOptions)) {
-      ruleOrRuleSet.meta.severity = ruleOptions;
+      rule.meta.severity = ruleOptions;
     }
 
-    if (ruleFilter(ruleOrRuleSet)) {
-      return [ruleOrRuleSet];
+    if (ruleFilter(rule)) {
+      return [rule];
     }
   }
 

--- a/packages/http-linter/src/rule-filter.ts
+++ b/packages/http-linter/src/rule-filter.ts
@@ -14,7 +14,7 @@ export function createRuleFilter({
   severity: RuleSeverity;
   type: RuleType[];
 }): RuleFilter {
-  // we need this so we don't load any rules of the severity of the linter is set to off
+  // we need this so we don't load any rules if the linter severity is set to 'off'
   if (severity === 'off') {
     return () => false;
   }

--- a/packages/http-linter/src/rule-filter.ts
+++ b/packages/http-linter/src/rule-filter.ts
@@ -14,6 +14,11 @@ export function createRuleFilter({
   severity: RuleSeverity;
   type: RuleType[];
 }): RuleFilter {
+  // we need this so we don't load any rules of the severity of the linter is set to off
+  if (severity === 'off') {
+    return () => false;
+  }
+
   const ruleFilters: RuleFilter[] = [];
 
   ruleFilters.push(

--- a/packages/http-linter/src/rule/rule-severity.ts
+++ b/packages/http-linter/src/rule/rule-severity.ts
@@ -1,10 +1,10 @@
 export type RuleSeverity = (typeof severityLevels)[number];
 
 export const severityLevelValues = {
-  off: 0,
   error: 1,
   warn: 2,
   hint: 3,
+  off: 4,
 } as const;
 
 export const severityLevels = ['off', 'error', 'warn', 'hint'] as const;

--- a/packages/http-linter/test/plugin-integration.test.ts
+++ b/packages/http-linter/test/plugin-integration.test.ts
@@ -71,7 +71,7 @@ describe('http-linter integration tests', () => {
     expect(result.valid).toBeFalsy();
   });
 
-  it('rule should be able to disable rules', async () => {
+  it('should be able to disable a rule', async () => {
     await thymian
       .register(httpLinterPlugin, {
         ruleSets: [

--- a/packages/http-linter/test/plugin-integration.test.ts
+++ b/packages/http-linter/test/plugin-integration.test.ts
@@ -71,6 +71,49 @@ describe('http-linter integration tests', () => {
     expect(result.valid).toBeFalsy();
   });
 
+  it('rule should be able to disable rules', async () => {
+    await thymian
+      .register(httpLinterPlugin, {
+        ruleSets: [
+          join(
+            import.meta.dirname,
+            'fixtures/rules/should-send-validator-fields.rule.mjs',
+          ),
+        ],
+        type: ['test'],
+        rules: {
+          'rfc9110/server-should-send-validator-fields': 'off',
+        },
+      })
+      .ready();
+
+    const format = createThymianFormatWithTransaction(
+      createHttpRequest({
+        method: 'get',
+      }),
+      createHttpResponse({
+        statusCode: 200,
+      }),
+    );
+
+    const rules = await thymian.emitter.emitAction(
+      'http-linter.rules',
+      undefined,
+      {
+        strategy: 'first',
+      },
+    );
+
+    const result = await thymian.emitter.emitAction(
+      'http-linter.lint-static',
+      { format: format.export() },
+      { strategy: 'first' },
+    );
+
+    expect(result.valid).toBeTruthy();
+    expect(rules).toHaveLength(0);
+  });
+
   it.each([
     ['off', 0],
     ['warn', 2],


### PR DESCRIPTION
This pull request introduces improvements to how rules are disabled in the HTTP linter, ensuring that rules set to `'off'` are properly filtered out and not loaded or executed. The changes also clarify the handling of severity levels and add a test to verify the new behavior.

Rule disabling and filtering improvements:

* Updated `createRuleFilter` in `rule-filter.ts` to immediately return a filter that disables all rules if the severity is set to `'off'`, preventing any rules from being loaded or executed.
* Modified `loadRules` in `load-rules.ts` to use a shallow copy of rule objects and consistently apply severity and type options, ensuring that rules set to `'off'` are not mutated or loaded. [[1]](diffhunk://#diff-07055436708d58a0d68e2126a450563adf2c1ba71f269c8a627686681ad4ba7eL123-R141) [[2]](diffhunk://#diff-07055436708d58a0d68e2126a450563adf2c1ba71f269c8a627686681ad4ba7eL147-R157)

Severity level handling:

* Changed the value of `'off'` in `severityLevelValues` in `rule-severity.ts` to be distinct from other severities, improving clarity and preventing ambiguity in severity comparisons.

Testing:

* Added a new integration test in `plugin-integration.test.ts` to verify that rules can be disabled and are not loaded when their severity is set to `'off'`.

closes https://github.com/thymianofficial/thymian-internal/issues/155