### PR TITLE
feat(openapi): include file path in all OpenAPI error messages

### DIFF
--- a/astro-docs/src/content/docs/references/Errors/openapi-dereference-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-dereference-error.md
@@ -67,11 +67,11 @@ components:
 5. **Validate your document** - Use an OpenAPI validator to catch reference errors early:
 
    ```bash
-   thymian lint openapi.yaml
+   thymian openapi validate openapi.yaml
    ```
 
 If you continue to see this error, enable debug output to see which specific references are failing:
 
 ```bash
-DEBUG=thymian:* thymian lint openapi.yaml
+DEBUG=thymian:* thymian openapi validate openapi.yaml
 ```

--- a/astro-docs/src/content/docs/references/Errors/openapi-dereference-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-dereference-error.md
@@ -1,0 +1,77 @@
+---
+title: 'OpenAPIDereferenceError'
+---
+
+## The Cause
+
+Thymian failed to dereference all internal `$ref` references in your OpenAPI document. This occurs when:
+
+- A `$ref` points to a location that doesn't exist in the document
+- A `$ref` uses an invalid path or pointer format (e.g., malformed JSON Pointer)
+- A `$ref` is circular or contains unresolvable nested references
+- The referenced schema or object is missing required fields
+
+For example:
+
+```yaml
+# ❌ Invalid: $ref points to non-existent path
+components:
+  schemas:
+    User:
+      properties:
+        role:
+          $ref: '#/components/schemas/InvalidRole' # InvalidRole doesn't exist
+```
+
+## The Solution
+
+1. **Verify all `$ref` paths exist** - Check that each reference points to an actual component or schema in your document.
+
+   ```yaml
+   # ✅ Correct: $ref points to existing schema
+   components:
+     schemas:
+       User:
+         properties:
+           role:
+             $ref: '#/components/schemas/Role' # Role is defined
+       Role:
+         type: string
+         enum: [admin, user, guest]
+   ```
+
+2. **Check JSON Pointer syntax** - Ensure `$ref` paths follow the JSON Pointer format:
+
+   ```yaml
+   # ✅ Correct patterns:
+   $ref: '#/components/schemas/User'
+   $ref: '#/components/responses/NotFound'
+   $ref: '#/paths/~1users/get'  # Use ~1 for / in path segments
+   ```
+
+3. **Avoid circular references** - If references form a cycle, use `allOf`, `oneOf`, or `anyOf` to break the cycle:
+
+   ```yaml
+   # ❌ Circular (User -> Address -> User)
+   # ✅ Better: Break cycle with explicit schema composition
+   User:
+     type: object
+     properties:
+       address:
+         allOf:
+           - $ref: '#/components/schemas/Address'
+   ```
+
+4. **Use external references sparingly** - This error only concerns internal references. External references (URLs) are handled differently and cannot be dereferenced locally.
+
+5. **Validate your document** - Use an OpenAPI validator to catch reference errors early:
+
+   ```bash
+   thymian lint openapi.yaml
+   ```
+
+If you continue to see this error, enable debug output to see which specific references are failing:
+
+```bash
+DEBUG=thymian:* thymian lint openapi.yaml
+```

--- a/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
@@ -11,8 +11,6 @@ Common causes include:
 - **File does not exist** - The path you provided doesn't point to an actual file
 - **Incorrect path** - The file path is relative but the current working directory is different than expected
 - **File permissions** - The file exists but cannot be read due to permission restrictions
-- **Invalid file format** - The file is not a valid YAML or JSON file
-- **Network issues** - For remote URLs, the file could not be fetched
 
 ## The Solution
 
@@ -33,5 +31,5 @@ pwd
 If you're having issues with relative paths, try using an absolute path:
 
 ```bash
-thymian openapi:validate /absolute/path/to/openapi.yaml
+thymian openapi validate /absolute/path/to/openapi.yaml
 ```

--- a/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
@@ -1,0 +1,37 @@
+---
+title: 'OpenAPIFileNotFoundError'
+---
+
+## The Cause
+
+The OpenAPI file could not be found or read. This error occurs during the file resolution phase when Thymian attempts to locate and load the specified OpenAPI document.
+
+Common causes include:
+
+- **File does not exist** - The path you provided doesn't point to an actual file
+- **Incorrect path** - The file path is relative but the current working directory is different than expected
+- **File permissions** - The file exists but cannot be read due to permission restrictions
+- **Invalid file format** - The file is not a valid YAML or JSON file
+- **Network issues** - For remote URLs, the file could not be fetched
+
+## The Solution
+
+### Verify the file path
+
+Ensure the file path is correct and the file exists:
+
+```bash
+# Check if the file exists
+ls -la path/to/your/openapi.yaml
+
+# If using a relative path, verify your working directory
+pwd
+```
+
+### Use absolute paths
+
+If you're having issues with relative paths, try using an absolute path:
+
+```bash
+thymian validate /absolute/path/to/openapi.yaml
+```

--- a/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-file-not-found-error.md
@@ -33,5 +33,5 @@ pwd
 If you're having issues with relative paths, try using an absolute path:
 
 ```bash
-thymian validate /absolute/path/to/openapi.yaml
+thymian openapi:validate /absolute/path/to/openapi.yaml
 ```

--- a/astro-docs/src/content/docs/references/Errors/openapi-validation-error.md
+++ b/astro-docs/src/content/docs/references/Errors/openapi-validation-error.md
@@ -1,0 +1,57 @@
+---
+title: 'OpenAPIValidationError'
+---
+
+## The Cause
+
+The OpenAPI document failed validation against the OpenAPI 3.x specification. This means the document structure or content does not conform to the OpenAPI standard and cannot be processed.
+
+Common validation issues include:
+
+- **Missing required fields** - Fields like `openapi`, `info`, or `paths` are missing
+- **Invalid schema definitions** - Schema objects don't follow the JSON Schema specification
+- **Incorrect data types** - Properties have values that don't match their expected types
+- **Malformed references** - `$ref` pointers are invalid or point to non-existent definitions
+- **Invalid server definitions** - Server objects are missing required properties
+- **Incorrect HTTP methods** - Unsupported or misspelled HTTP methods in path definitions
+
+Example of invalid OpenAPI:
+
+```yaml
+# ❌ Invalid - missing required 'info' field
+openapi: 3.1.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: Success
+
+# ✅ Valid - includes all required fields
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: Success
+```
+
+## The Solution
+
+### Use the validation command
+
+Thymian provides a validation command that shows detailed error messages:
+
+```bash
+thymian openapi:validate path/to/your/openapi.yaml
+```
+
+This will output the specific validation errors with line numbers and descriptions.
+
+### Review the OpenAPI specification
+
+Consult the OpenAPI specification to understand the required structure.

--- a/packages/plugin-openapi/src/cli/commands/openapi/info.ts
+++ b/packages/plugin-openapi/src/cli/commands/openapi/info.ts
@@ -20,7 +20,7 @@ export default class Info extends BaseCliRunCommand<typeof Info> {
   ];
 
   override async run(): Promise<void> {
-    const [document] = await loadOpenApi(this.args.content, this.flags.cwd);
+    const { document } = await loadOpenApi(this.args.content, this.flags.cwd);
 
     const { valid, version, specification } = await validate(document);
 

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -1,3 +1,4 @@
+import { access } from 'node:fs/promises';
 import { isAbsolute, join, relative } from 'node:path';
 
 import { bundle } from '@scalar/json-magic/bundle';
@@ -35,6 +36,15 @@ function formatSourceLabel(relativePath: string | undefined): string {
   return relativePath ? `'${relativePath}'` : 'the OpenAPI document';
 }
 
+async function fileExists(path: string) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export type LoadResult = {
   document: OpenAPIV3_1.Document;
   original: OpenAPI.Document;
@@ -68,12 +78,7 @@ export async function loadOpenApi(
       filePath: isFileValue ? finalValue : undefined,
     };
   } catch (e) {
-    const isENOENT =
-      e instanceof Error &&
-      'code' in e &&
-      (e as NodeJS.ErrnoException).code === 'ENOENT';
-
-    if (isFileValue && isENOENT) {
+    if (isFileValue && !(await fileExists(finalValue))) {
       throw new ThymianBaseError(
         `OpenAPI file not found: ${relativePath ?? value}`,
         {
@@ -121,6 +126,26 @@ export async function loadAndUpgrade(
   const validationResult = await validate(document, { throwOnError: false });
 
   if (!validationResult.valid && validationResult.errors) {
+    const refErrors = validationResult.errors.filter(
+      (err) => err.code === 'INVALID_REFERENCE',
+    );
+
+    if (refErrors.length > 0) {
+      throw new ThymianBaseError(
+        `Invalid $ref${refErrors.length > 1 ? 's' : ''} found: ${refErrors.map((err) => err.message).join(', ')}`,
+        {
+          name: 'OpenAPIDereferenceError',
+          ref: 'https://thymian.dev/references/errors/openapi-dereference-error/',
+          cause: new Error(
+            validationResult?.errors?.map((e) => e.message).join('; ') ?? '',
+          ),
+          suggestions: [
+            'Ensure all $refs are valid and resolve to a valid non-external location.',
+          ],
+        },
+      );
+    }
+
     throw new ThymianBaseError(`Schema validation for ${sourceLabel} failed.`, {
       name: 'OpenAPIValidationError',
       ref: 'https://thymian.dev/references/errors/openapi-validation-error/',

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -202,10 +202,13 @@ export async function openapiToThymianFormat(
     filePath?: string;
     format?: ThymianFormat;
     sourceName?: string;
+    cwd?: string;
   },
 ): Promise<ThymianFormat> {
   const sourceLabel = options.filePath
-    ? formatSourceLabel(getRelativePath(options.filePath, process.cwd()))
+    ? formatSourceLabel(
+        getRelativePath(options.filePath, options.cwd ?? process.cwd()),
+      )
     : formatSourceLabel(undefined);
 
   if (
@@ -253,6 +256,7 @@ export async function loadAndTransform(
     ...options,
     filePath: loadResult.filePath,
     filter: options.filter,
+    cwd: options.cwd,
   });
 
   options.logger.debug(

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -61,7 +61,7 @@ export async function loadOpenApi(
         plugins,
         treeShake: false,
       }),
-      filePath: finalValue,
+      filePath: isFileValue ? finalValue : undefined,
     };
   } catch (e) {
     const suggestions = ['Ensure the content is valid YAML or JSON'];
@@ -69,7 +69,7 @@ export async function loadOpenApi(
     if (isFileValue) {
       suggestions.push(
         ...[
-          `Verify the file path is correct: ${relativePath}`,
+          `Verify the file path is correct: ${relativePath ?? ''}`,
           'Check file permissions and ensure the file is readable',
         ],
       );
@@ -116,11 +116,11 @@ export async function loadAndUpgrade(
     );
   }
 
-  logger.debug(`Successfully validated OpenAPI file '${relativePath}'.`);
+  logger.debug(`Successfully validated OpenAPI file '${relativePath ?? ''}'.`);
 
   const upgradedObject = upgrade(structuredClone(document), '3.1');
 
-  logger.debug(`Upgraded OpenAPI file '${relativePath}' to version 3.1.`);
+  logger.debug(`Upgraded OpenAPI file '${relativePath ?? ''}' to version 3.1.`);
 
   const dereferencedResult = dereference(upgradedObject, {
     throwOnError: false,
@@ -132,6 +132,7 @@ export async function loadAndUpgrade(
       `Error in OpenAPI file '${relativePath}': Dereferencing all internal references failed.`,
       {
         name: 'OpenAPIDereferenceError',
+        ref: 'https://thymian.dev/references/errors/openapi-dereference-error/',
         cause: new Error(
           dereferencedResult?.errors?.map((e) => e.message).join('; ') ?? '',
         ),
@@ -160,17 +161,12 @@ export async function openapiToThymianFormat(
     sourceName?: string;
   },
 ): Promise<ThymianFormat> {
-  const cwd = process.cwd();
-  const relativePath = options.filePath
-    ? getRelativePath(options.filePath, cwd)
-    : 'unknown file';
-
   if (
     typeof document.openapi !== 'string' ||
     !document.openapi.startsWith('3.1')
   ) {
     throw new ThymianBaseError(
-      `Error in OpenAPI file ${relativePath ?? ''}: Only OpenAPI 3.1.x documents are supported.`,
+      `Error in OpenAPI file ${options.filePath ?? ''}: Only OpenAPI 3.1.x documents are supported.`,
       {
         name: 'OpenAPIDocumentVersionError',
       },

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -31,6 +31,10 @@ function getRelativePath(filePath: string, cwd: string): string {
   }
 }
 
+function formatSourceLabel(relativePath: string | undefined): string {
+  return relativePath ? `'${relativePath}'` : 'the OpenAPI document';
+}
+
 export type LoadResult = {
   document: OpenAPIV3_1.Document;
   original: OpenAPI.Document;
@@ -64,26 +68,41 @@ export async function loadOpenApi(
       filePath: isFileValue ? finalValue : undefined,
     };
   } catch (e) {
-    const suggestions = ['Ensure the content is valid YAML or JSON'];
+    const isENOENT =
+      e instanceof Error &&
+      'code' in e &&
+      (e as NodeJS.ErrnoException).code === 'ENOENT';
 
-    if (isFileValue) {
-      suggestions.push(
-        ...[
-          `Verify the file path is correct: ${relativePath ?? ''}`,
-          'Check file permissions and ensure the file is readable',
-        ],
+    if (isFileValue && isENOENT) {
+      throw new ThymianBaseError(
+        `OpenAPI file not found: ${relativePath ?? value}`,
+        {
+          name: 'OpenAPIFileNotFoundError',
+          ref: 'https://thymian.dev/references/errors/openapi-file-not-found-error/',
+          cause: e,
+          suggestions: [
+            `Verify the file path is correct: ${relativePath ?? value}`,
+            'Check file permissions and ensure the file is readable',
+          ],
+        },
       );
     }
 
-    throw new ThymianBaseError(
-      `Error in OpenAPI file ${relativePath ?? ''}: Failed to read or parse the document.`,
-      {
-        name: 'OpenAPIFileNotFoundError',
-        ref: 'https://thymian.dev/references/errors/openapi-file-not-found-error/',
-        cause: e,
-        suggestions,
-      },
-    );
+    const sourceLabel = relativePath ? `'${relativePath}'` : 'the document';
+
+    throw new ThymianBaseError(`Failed to read or parse ${sourceLabel}.`, {
+      name: 'OpenAPILoadError',
+      cause: e,
+      suggestions: [
+        'Ensure the content is valid YAML or JSON',
+        ...(isFileValue
+          ? [
+              `Verify the file path is correct: ${relativePath ?? value}`,
+              'Check file permissions and ensure the file is readable',
+            ]
+          : []),
+      ],
+    });
   }
 }
 
@@ -95,41 +114,40 @@ export async function loadAndUpgrade(
   const { document, filePath } = await loadOpenApi(value, cwd);
   const relativePath = filePath ? getRelativePath(filePath, cwd) : undefined;
 
-  logger.info(`Loading OpenAPI file ${relativePath ?? ''}.`);
+  const sourceLabel = formatSourceLabel(relativePath);
+
+  logger.info(`Loading ${sourceLabel}.`);
 
   const validationResult = await validate(document, { throwOnError: false });
 
   if (!validationResult.valid && validationResult.errors) {
-    throw new ThymianBaseError(
-      `Schema validation for OpenAPI file ${relativePath ?? ''} failed.`,
-      {
-        name: 'OpenAPIValidationError',
-        ref: 'https://thymian.dev/references/errors/openapi-validation-error/',
-        cause: new Error(
-          validationResult.errors.map((e) => e.message).join('; '),
-        ),
-        suggestions: [
-          'This indicates that your OpenAPI document does not match the OpenAPI specification. Use `thymian openapi:validate` to get detailed validation errors',
-          'Ensure all required fields are present (openapi, info, paths)',
-        ],
-      },
-    );
+    throw new ThymianBaseError(`Schema validation for ${sourceLabel} failed.`, {
+      name: 'OpenAPIValidationError',
+      ref: 'https://thymian.dev/references/errors/openapi-validation-error/',
+      cause: new Error(
+        validationResult.errors.map((e) => e.message).join('; '),
+      ),
+      suggestions: [
+        'This indicates that your OpenAPI document does not match the OpenAPI specification. Use `thymian openapi:validate` to get detailed validation errors',
+        'Ensure all required fields are present (openapi, info, paths)',
+      ],
+    });
   }
 
-  logger.debug(`Successfully validated OpenAPI file '${relativePath ?? ''}'.`);
+  logger.debug(`Successfully validated ${sourceLabel}.`);
 
   const upgradedObject = upgrade(structuredClone(document), '3.1');
 
-  logger.debug(`Upgraded OpenAPI file '${relativePath ?? ''}' to version 3.1.`);
+  logger.debug(`Upgraded ${sourceLabel} to version 3.1.`);
 
   const dereferencedResult = dereference(upgradedObject, {
     throwOnError: false,
   });
 
   if (dereferencedResult?.errors?.length || !dereferencedResult.schema) {
-    logger.debug(`Cannot dereferenced OpenAPI file '${relativePath}'.`);
+    logger.debug(`Cannot dereference ${sourceLabel}.`);
     throw new ThymianBaseError(
-      `Error in OpenAPI file '${relativePath}': Dereferencing all internal references failed.`,
+      `Dereferencing all internal references in ${sourceLabel} failed.`,
       {
         name: 'OpenAPIDereferenceError',
         ref: 'https://thymian.dev/references/errors/openapi-dereference-error/',
@@ -161,12 +179,16 @@ export async function openapiToThymianFormat(
     sourceName?: string;
   },
 ): Promise<ThymianFormat> {
+  const sourceLabel = options.filePath
+    ? formatSourceLabel(getRelativePath(options.filePath, process.cwd()))
+    : formatSourceLabel(undefined);
+
   if (
     typeof document.openapi !== 'string' ||
     !document.openapi.startsWith('3.1')
   ) {
     throw new ThymianBaseError(
-      `Error in OpenAPI file ${options.filePath ?? ''}: Only OpenAPI 3.1.x documents are supported.`,
+      `Only OpenAPI 3.1.x documents are supported (found in ${sourceLabel}).`,
       {
         name: 'OpenAPIDocumentVersionError',
       },
@@ -198,10 +220,9 @@ export async function loadAndTransform(
   },
 ): Promise<[OpenAPI.Document, ThymianFormat, string | undefined]> {
   const loadResult = await loadAndUpgrade(value, options.cwd, options.logger);
-  const relativePath = getRelativePath(
-    loadResult.filePath || value,
-    options.cwd,
-  );
+  const relativePath = loadResult.filePath
+    ? getRelativePath(loadResult.filePath, options.cwd)
+    : undefined;
 
   const result = await openapiToThymianFormat(loadResult.document, {
     ...options,
@@ -210,7 +231,7 @@ export async function loadAndTransform(
   });
 
   options.logger.debug(
-    `Transformed OpenAPI file '${relativePath}' into Thymian format.`,
+    `Transformed ${formatSourceLabel(relativePath)} into Thymian format.`,
   );
 
   return [loadResult.original, result, loadResult.filePath];

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute, join, relative } from 'node:path';
 
 import { bundle } from '@scalar/json-magic/bundle';
 import {
@@ -23,6 +23,14 @@ import { NoopLocMapper } from './loc-mapper/noop-loc-mapper.js';
 import type { ServerInfo } from './processors/extract-server-info.js';
 import { OpenapiProcessor } from './processors/openapi.processor.js';
 
+function getRelativePath(filePath: string, cwd: string): string {
+  try {
+    return relative(cwd, filePath);
+  } catch {
+    return filePath;
+  }
+}
+
 export type LoadResult = {
   document: OpenAPIV3_1.Document;
   original: OpenAPI.Document;
@@ -32,7 +40,7 @@ export type LoadResult = {
 export async function loadOpenApi(
   value: string,
   cwd: string = process.cwd(),
-): Promise<[object, string | undefined]> {
+): Promise<{ document: object; filePath: string | undefined }> {
   const readFilesPlugin = readFiles();
   // the validate function of the readFiles plugin returns undefined if the value is not a local file
   const isFileValue = readFilesPlugin.validate(value);
@@ -41,15 +49,42 @@ export async function loadOpenApi(
       ? value
       : join(cwd, value);
 
+  const relativePath = isFileValue
+    ? getRelativePath(finalValue, cwd)
+    : undefined;
+
   const plugins = [parseJson(), parseYaml(), readFilesPlugin, fetchUrls()];
 
-  return [
-    await bundle(finalValue, {
-      plugins,
-      treeShake: false,
-    }),
-    isFileValue ? finalValue : undefined,
-  ];
+  try {
+    return {
+      document: await bundle(finalValue, {
+        plugins,
+        treeShake: false,
+      }),
+      filePath: finalValue,
+    };
+  } catch (e) {
+    const suggestions = ['Ensure the content is valid YAML or JSON'];
+
+    if (isFileValue) {
+      suggestions.push(
+        ...[
+          `Verify the file path is correct: ${relativePath}`,
+          'Check file permissions and ensure the file is readable',
+        ],
+      );
+    }
+
+    throw new ThymianBaseError(
+      `Error in OpenAPI file ${relativePath ?? ''}: Failed to read or parse the document.`,
+      {
+        name: 'OpenAPIFileNotFoundError',
+        ref: 'https://thymian.dev/references/errors/openapi-file-not-found-error/',
+        cause: e,
+        suggestions,
+      },
+    );
+  }
 }
 
 export async function loadAndUpgrade(
@@ -57,41 +92,62 @@ export async function loadAndUpgrade(
   cwd: string = process.cwd(),
   logger: Logger,
 ): Promise<LoadResult> {
-  try {
-    const [result, filePath] = await loadOpenApi(value, cwd);
+  const { document, filePath } = await loadOpenApi(value, cwd);
+  const relativePath = filePath ? getRelativePath(filePath, cwd) : undefined;
 
-    logger.debug(`Loaded OpenAPI document.`);
+  logger.info(`Loading OpenAPI file ${relativePath ?? ''}.`);
 
-    await validate(result, { throwOnError: true });
+  const validationResult = await validate(document, { throwOnError: false });
 
-    logger.debug(`Successfully validated OpenAPI document.`);
-
-    const upgradedObject = upgrade(structuredClone(result), '3.1');
-
-    logger.debug(`Upgraded OpenAPI document.`);
-
-    const dereferenced = dereference(upgradedObject, {
-      throwOnError: true,
-    }).schema as OpenAPIV3_1.Document;
-
-    logger.debug(`Dereferenced OpenAPI document.`);
-
-    return {
-      document: dereferenced,
-      original: result as OpenAPI.Document,
-      filePath: filePath,
-    };
-  } catch (e) {
-    throw new ThymianBaseError(`Error while loading OpenAPI document.`, {
-      name: 'OpenAPILoadError',
-      ref: 'https://thymian.dev/references/errors/openapi-load-error/',
-      cause: e,
-      suggestions: [
-        'Currently, only files without external references are supported. Do your OpenAPI documents contain any external references?',
-        'You can validate your OpenAPI document using the `thymian openapi:validate` command.',
-      ],
-    });
+  if (!validationResult.valid && validationResult.errors) {
+    throw new ThymianBaseError(
+      `Schema validation for OpenAPI file ${relativePath ?? ''} failed.`,
+      {
+        name: 'OpenAPIValidationError',
+        ref: 'https://thymian.dev/references/errors/openapi-validation-error/',
+        cause: new Error(
+          validationResult.errors.map((e) => e.message).join('; '),
+        ),
+        suggestions: [
+          'This indicates that your OpenAPI document does not match the OpenAPI specification. Use `thymian openapi:validate` to get detailed validation errors',
+          'Ensure all required fields are present (openapi, info, paths)',
+        ],
+      },
+    );
   }
+
+  logger.debug(`Successfully validated OpenAPI file '${relativePath}'.`);
+
+  const upgradedObject = upgrade(structuredClone(document), '3.1');
+
+  logger.debug(`Upgraded OpenAPI file '${relativePath}' to version 3.1.`);
+
+  const dereferencedResult = dereference(upgradedObject, {
+    throwOnError: false,
+  });
+
+  if (dereferencedResult?.errors?.length || !dereferencedResult.schema) {
+    logger.debug(`Cannot dereferenced OpenAPI file '${relativePath}'.`);
+    throw new ThymianBaseError(
+      `Error in OpenAPI file '${relativePath}': Dereferencing all internal references failed.`,
+      {
+        name: 'OpenAPIDereferenceError',
+        ref: 'https://thymian.dev/references/errors/openapi-dereference-error/',
+        cause: new Error(
+          dereferencedResult?.errors?.map((e) => e.message).join('; ') ?? '',
+        ),
+        suggestions: [
+          'Ensure all $refs are valid and resolve to a valid non-external location.',
+        ],
+      },
+    );
+  }
+
+  return {
+    document: dereferencedResult.schema as OpenAPIV3_1.Document,
+    original: document as OpenAPI.Document,
+    filePath: filePath ? filePath : undefined,
+  };
 }
 
 export async function openapiToThymianFormat(
@@ -105,12 +161,23 @@ export async function openapiToThymianFormat(
     sourceName?: string;
   },
 ): Promise<ThymianFormat> {
+  const cwd = process.cwd();
+  const relativePath = options.filePath
+    ? getRelativePath(options.filePath, cwd)
+    : 'unknown file';
+
   if (
     typeof document.openapi !== 'string' ||
     !document.openapi.startsWith('3.1')
   ) {
-    throw new ThymianBaseError('Only OpenAPI 3.1.x documents are supported.');
+    throw new ThymianBaseError(
+      `Error in OpenAPI file ${relativePath ?? ''}: Only OpenAPI 3.1.x documents are supported.`,
+      {
+        name: 'OpenAPIDocumentVersionError',
+      },
+    );
   }
+
   const locMapper =
     typeof options.filePath === 'string'
       ? await locMapperForFile(options.filePath)
@@ -136,6 +203,10 @@ export async function loadAndTransform(
   },
 ): Promise<[OpenAPI.Document, ThymianFormat, string | undefined]> {
   const loadResult = await loadAndUpgrade(value, options.cwd, options.logger);
+  const relativePath = getRelativePath(
+    loadResult.filePath || value,
+    options.cwd,
+  );
 
   const result = await openapiToThymianFormat(loadResult.document, {
     ...options,
@@ -143,7 +214,9 @@ export async function loadAndTransform(
     filter: options.filter,
   });
 
-  options.logger.debug('Transformed OpenAPI document into Thymian format.');
+  options.logger.debug(
+    `Transformed OpenAPI file '${relativePath}' into Thymian format.`,
+  );
 
   return [loadResult.original, result, loadResult.filePath];
 }

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -132,7 +132,6 @@ export async function loadAndUpgrade(
       `Error in OpenAPI file '${relativePath}': Dereferencing all internal references failed.`,
       {
         name: 'OpenAPIDereferenceError',
-        ref: 'https://thymian.dev/references/errors/openapi-dereference-error/',
         cause: new Error(
           dereferencedResult?.errors?.map((e) => e.message).join('; ') ?? '',
         ),

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -1,7 +1,7 @@
 import * as http from 'node:http';
 import { join } from 'node:path';
 
-import { constant, NoopLogger } from '@thymian/core';
+import { constant, NoopLogger, ThymianBaseError } from '@thymian/core';
 import type { OpenAPIV3_1 } from 'openapi-types';
 import { describe, expect, it } from 'vitest';
 import yaml from 'yaml';
@@ -91,6 +91,55 @@ describe('load-openapi', () => {
       server.closeAllConnections();
 
       await new Promise((resolve) => server.close(resolve));
+    });
+
+    it('throws OpenAPIFileNotFoundError when file does not exist', async () => {
+      try {
+        await loadAndUpgrade(
+          'nonexistent-file.yaml',
+          process.cwd(),
+          new NoopLogger(),
+        );
+        expect.fail('Error should have been thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ThymianBaseError);
+        expect((error as ThymianBaseError).options.name).toBe(
+          'OpenAPIFileNotFoundError',
+        );
+        expect((error as ThymianBaseError).options.ref).toBe(
+          'https://thymian.dev/references/errors/openapi-file-not-found-error/',
+        );
+        expect(String(error)).toContain('nonexistent-file.yaml');
+      }
+    });
+
+    it('throws OpenAPIValidationError when validation fails', async () => {
+      const invalidDocument = {
+        swagger: '2.0',
+        info: {
+          // Missing required 'title' field
+          version: '1.0.0',
+        },
+        paths: {},
+      };
+
+      try {
+        await loadAndUpgrade(
+          JSON.stringify(invalidDocument),
+          process.cwd(),
+          new NoopLogger(),
+        );
+        expect.fail('Error should have been thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ThymianBaseError);
+        expect((error as ThymianBaseError).options.name).toBe(
+          'OpenAPIValidationError',
+        );
+        expect((error as ThymianBaseError).options.ref).toBe(
+          'https://thymian.dev/references/errors/openapi-validation-error/',
+        );
+        expect(String(error)).toContain('validation');
+      }
     });
   });
 

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -141,6 +141,51 @@ describe('load-openapi', () => {
         expect(String(error)).toContain('validation');
       }
     });
+
+    it('throws OpenAPIDereferenceError when $ref cannot be resolved', async () => {
+      const documentWithBadRef = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: '#/components/schemas/NonExistent',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      try {
+        await loadAndUpgrade(
+          JSON.stringify(documentWithBadRef),
+          process.cwd(),
+          new NoopLogger(),
+        );
+        expect.fail('Error should have been thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ThymianBaseError);
+        expect((error as ThymianBaseError).options.name).toBe(
+          'OpenAPIDereferenceError',
+        );
+        expect((error as ThymianBaseError).options.ref).toBe(
+          'https://thymian.dev/references/errors/openapi-dereference-error/',
+        );
+      }
+    });
   });
 
   describe('openapiToThymianFormat', () => {


### PR DESCRIPTION
This pull request improves error handling and user feedback when loading and validating OpenAPI documents in the `@thymian/openapi` package. It introduces more specific error types with actionable suggestions, enhances logging with file context, and adds documentation for new error types. The changes also include new tests to ensure the correct errors are thrown and referenced documentation is provided.

**Error handling and user feedback improvements:**

* Refactored `loadOpenApi`, `loadAndUpgrade`, and related functions to throw specific error types (`OpenAPIFileNotFoundError`, `OpenAPIValidationError`, `OpenAPIDereferenceError`, `OpenAPIDocumentVersionError`) with clear messages, documentation references, and suggestions for resolution. Errors now include the relevant file path for easier debugging. [[1]](diffhunk://#diff-70a533d2c5f03290350a5c30080cecbf2aed01375325d66c5caa88ce8477b9deR26-R33) [[2]](diffhunk://#diff-70a533d2c5f03290350a5c30080cecbf2aed01375325d66c5caa88ce8477b9deR52-L94) [[3]](diffhunk://#diff-70a533d2c5f03290350a5c30080cecbf2aed01375325d66c5caa88ce8477b9deR164-R178)
* Improved logging to include the file name or relative path throughout the loading, validation, upgrading, and transformation process, giving users better context in logs.

**Documentation updates:**

* Added new documentation pages describing the causes and solutions for `OpenAPIFileNotFoundError` and `OpenAPIValidationError`, with examples and troubleshooting steps. [[1]](diffhunk://#diff-2d1bfb517ff7bc960a466eaf977aac3cfe1383178d3fce55aa318e203307e87bR1-R37) [[2]](diffhunk://#diff-185c293628179c975288a5c71d4b474098535fba617bf652bd495638ed7d4f26R1-R57)

**Testing enhancements:**

* Added tests to ensure that the correct error types are thrown and that error messages include the correct file name and documentation reference when a file is missing or validation fails.

**Internal code improvements:**

* Changed the return type of `loadOpenApi` from a tuple to an object for better clarity and maintainability.
* Added a utility function `getRelativePath` to consistently generate user-friendly file paths in error messages and logs.

These changes collectively make error handling more robust and user-friendly, while also improving maintainability and test coverage.

Closes https://github.com/thymianofficial/thymian-internal/issues/159