### PR TITLE
feat(cli): improve init command with early validation and config over…

### DIFF
--- a/packages/cli-common/src/base-cli-run-command.ts
+++ b/packages/cli-common/src/base-cli-run-command.ts
@@ -20,6 +20,7 @@ import { Feedback } from './feedback.js';
 import { filterFlag } from './flags/filter-flag.js';
 import { optionFlag, optionRegexp } from './flags/option-flag.js';
 import { getConfig } from './get-config.js';
+import { printStackTraces } from './print-stack-traces.js';
 import { safeParse } from './safe-parse.js';
 import type { ThymianConfig } from './thymian-config.js';
 
@@ -180,24 +181,15 @@ export abstract class BaseCliRunCommand<
       Object.defineProperty(cliError, 'ref', { value: err.options.ref });
 
       if (settings.debug) {
-        this.printStackTraces(err);
+        printStackTraces(err, this.jsonEnabled(), (data) =>
+          this.logJson(this.toErrorJson(data as Error)),
+        );
       }
 
       return super.catch(cliError);
     }
 
     return super.catch(err);
-  }
-
-  protected printStackTraces(err: unknown): void {
-    if (err instanceof Error) {
-      if (this.jsonEnabled() && err.cause) {
-        this.logJson(this.toErrorJson(err.cause));
-      } else if (err.cause) {
-        console.log(err.cause);
-      }
-      this.printStackTraces(err.cause);
-    }
   }
 
   protected shouldAutoload(): boolean {

--- a/packages/cli-common/src/base-cli-run-command.ts
+++ b/packages/cli-common/src/base-cli-run-command.ts
@@ -49,7 +49,7 @@ export abstract class BaseCliRunCommand<
       aliases: ['c'],
       charAliases: ['c'],
       description: 'Path to thymian configuration file.',
-      default: 'thymian.config.yaml',
+      default: 'thymian.config.json',
       helpGroup: 'BASE',
     }),
     autoload: Flags.boolean({

--- a/packages/cli-common/src/print-stack-traces.ts
+++ b/packages/cli-common/src/print-stack-traces.ts
@@ -1,0 +1,14 @@
+export function printStackTraces(
+  err: unknown,
+  jsonEnabled: boolean,
+  logJsonFn: (data: unknown) => void,
+): void {
+  if (err instanceof Error) {
+    if (jsonEnabled && err.cause) {
+      logJsonFn(err.cause);
+    } else if (err.cause) {
+      console.log(err.cause);
+    }
+    printStackTraces(err.cause, jsonEnabled, logJsonFn);
+  }
+}

--- a/packages/cli-common/src/thymian-base-command.ts
+++ b/packages/cli-common/src/thymian-base-command.ts
@@ -1,5 +1,7 @@
-import { Command, Flags, Interfaces } from '@oclif/core';
+import { Command, Flags, Interfaces, settings } from '@oclif/core';
+import { CLIError } from '@oclif/core/errors';
 import type { CommandError } from '@oclif/core/interfaces';
+import { ThymianBaseError } from '@thymian/core';
 
 import { ErrorCache } from './error-cache.js';
 import { Feedback } from './feedback.js';
@@ -68,7 +70,36 @@ export abstract class ThymianBaseCommand<
       },
       pluginVersions,
     });
+
+    if (err instanceof ThymianBaseError) {
+      const cliError = new CLIError(err.message, {
+        suggestions: err.options.suggestions,
+        exit: err.options.exitCode,
+        code: err.options.code,
+      });
+
+      cliError.name = err.name;
+      Object.defineProperty(cliError, 'ref', { value: err.options.ref });
+
+      if (settings.debug) {
+        this.printStackTraces(err);
+      }
+
+      return super.catch(cliError);
+    }
+
     return super.catch(err);
+  }
+
+  protected printStackTraces(err: unknown): void {
+    if (err instanceof Error) {
+      if (this.jsonEnabled() && err.cause) {
+        this.logJson(this.toErrorJson(err.cause));
+      } else if (err.cause) {
+        console.log(err.cause);
+      }
+      this.printStackTraces(err.cause);
+    }
   }
 
   public shouldSuppressFeedback(): boolean {

--- a/packages/cli-common/src/thymian-base-command.ts
+++ b/packages/cli-common/src/thymian-base-command.ts
@@ -5,6 +5,7 @@ import { ThymianBaseError } from '@thymian/core';
 
 import { ErrorCache } from './error-cache.js';
 import { Feedback } from './feedback.js';
+import { printStackTraces } from './print-stack-traces.js';
 
 type Flags<T extends typeof Command> = Interfaces.InferredFlags<
   (typeof ThymianBaseCommand)['baseFlags'] & T['flags']
@@ -82,24 +83,15 @@ export abstract class ThymianBaseCommand<
       Object.defineProperty(cliError, 'ref', { value: err.options.ref });
 
       if (settings.debug) {
-        this.printStackTraces(err);
+        printStackTraces(err, this.jsonEnabled(), (data) =>
+          this.logJson(this.toErrorJson(data as Error)),
+        );
       }
 
       return super.catch(cliError);
     }
 
     return super.catch(err);
-  }
-
-  protected printStackTraces(err: unknown): void {
-    if (err instanceof Error) {
-      if (this.jsonEnabled() && err.cause) {
-        this.logJson(this.toErrorJson(err.cause));
-      } else if (err.cause) {
-        console.log(err.cause);
-      }
-      this.printStackTraces(err.cause);
-    }
   }
 
   public shouldSuppressFeedback(): boolean {

--- a/packages/thymian/src/commands/init.ts
+++ b/packages/thymian/src/commands/init.ts
@@ -1,22 +1,28 @@
+import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { extname, format, join, parse } from 'node:path';
 
 import {
   defaultConfig,
   ThymianBaseCommand,
   type ThymianConfig,
 } from '@thymian/cli-common';
-import { Flags } from '@thymian/cli-common/oclif';
+import { Flags, ux } from '@thymian/cli-common/oclif';
 import { stringify } from '@thymian/cli-common/yaml';
-import { type Logger, TextLogger } from '@thymian/core';
+import { type Logger, TextLogger, ThymianBaseError } from '@thymian/core';
 
 export default class Init extends ThymianBaseCommand<typeof Init> {
   static override description = 'Initialize Thymian in your project.';
-  static override examples = ['<%= config.bin %> <%= command.id %>'];
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --yes',
+    '<%= config.bin %> <%= command.id %> --yes --force',
+    '<%= config.bin %> <%= command.id %> --config-file custom-config.yaml',
+  ];
 
   static override flags = {
-    yaml: Flags.boolean({
-      default: true,
+    ['yaml-format']: Flags.boolean({
+      default: false,
       allowNo: true,
       description: 'Output configuration file in YAML format.',
     }),
@@ -25,7 +31,11 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
       description: 'Set current working directory.',
     }),
     'config-file': Flags.string({
-      default: 'thymian.config',
+      default: 'thymian.config.json',
+    }),
+    force: Flags.boolean({
+      default: false,
+      description: 'Overwrite existing configuration file.',
     }),
     yes: Flags.boolean({
       default: false,
@@ -36,6 +46,45 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
   private readonly thymianConfig: ThymianConfig = defaultConfig;
 
   public async run(): Promise<void> {
+    const configFilePath = join(this.flags.cwd, this.flags['config-file']);
+
+    const parsedPath = parse(configFilePath);
+
+    const shouldBeYamlFormat =
+      this.flags['yaml-format'] ||
+      extname(configFilePath) === '.yaml' ||
+      extname(configFilePath) === '.yml';
+
+    if (parsedPath.ext === '.json' && shouldBeYamlFormat) {
+      parsedPath.ext = '.yaml';
+    } else if (
+      (parsedPath.ext === '.yaml' || parsedPath.ext === '.yml') &&
+      !shouldBeYamlFormat
+    ) {
+      parsedPath.ext = '.json';
+    }
+
+    const finalConfigFilePath = format({
+      dir: parsedPath.dir,
+      name: parsedPath.name,
+      ext: parsedPath.ext,
+      root: parsedPath.root,
+    });
+
+    if (existsSync(finalConfigFilePath) && !this.flags.force) {
+      // Pre-flight check: verify config file doesn't already exist
+      throw new ThymianBaseError(
+        `Configuration file "${configFilePath}" already exists.`,
+        {
+          suggestions: [
+            '`thymian init --force` to overwrite current configuration',
+            '`thymian init --config-file <path>` to specify a different file path',
+          ],
+          name: 'ThymianConfigAlreadyExists',
+        },
+      );
+    }
+
     const hookResults = await this.config.runHook('thymian-plugin.init', {
       cwd: this.flags.cwd,
       interactive: !this.flags.yes,
@@ -62,31 +111,25 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
       }
     }
 
-    const configFilePath = join(
-      this.flags.cwd,
-      `${this.flags['config-file']}${this.flags.yaml ? '.yaml' : '.json'}`,
-    );
+    for (const pluginName of Object.keys(this.thymianConfig.plugins)) {
+      this.log(`${ux.colorize('cyan', 'ADDED')} plugin ${pluginName}`);
+    }
 
     try {
-      await writeFile(configFilePath, this.getConfig(this.flags.yaml), {
+      await writeFile(finalConfigFilePath, this.getConfig(shouldBeYamlFormat), {
         encoding: 'utf-8',
-        flag: 'wx',
+        flag: this.flags.force ? 'w' : 'wx',
       });
     } catch (e) {
       this.debug('Error writing configuration file: ' + e);
-      this.error(
-        `Configuration file "${configFilePath}" already exists. Please remove it before initializing Thymian.`,
-        { exit: 1 },
-      );
+      this.error(`Failed to write configuration file to "${configFilePath}".`, {
+        exit: 1,
+      });
     }
 
-    this.debug('Created configuration file at: ' + configFilePath);
-
+    this.log(`${ux.colorize('green', 'CREATED')} ${configFilePath}`);
+    this.log();
     this.log(`Initialized Thymian.`);
-  }
-
-  private printConfig(yaml: boolean): void {
-    this.log(this.getConfig(yaml));
   }
 
   private getConfig(yaml: boolean): string {

--- a/packages/thymian/src/commands/init.ts
+++ b/packages/thymian/src/commands/init.ts
@@ -62,6 +62,8 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
       !shouldBeYamlFormat
     ) {
       parsedPath.ext = '.json';
+    } else if (parsedPath.ext === '') {
+      parsedPath.ext = shouldBeYamlFormat ? '.yaml' : '.json';
     }
 
     const finalConfigFilePath = format({
@@ -74,7 +76,7 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
     if (existsSync(finalConfigFilePath) && !this.flags.force) {
       // Pre-flight check: verify config file doesn't already exist
       throw new ThymianBaseError(
-        `Configuration file "${configFilePath}" already exists.`,
+        `Configuration file "${finalConfigFilePath}" already exists.`,
         {
           suggestions: [
             '`thymian init --force` to overwrite current configuration',
@@ -122,12 +124,15 @@ export default class Init extends ThymianBaseCommand<typeof Init> {
       });
     } catch (e) {
       this.debug('Error writing configuration file: ' + e);
-      this.error(`Failed to write configuration file to "${configFilePath}".`, {
-        exit: 1,
-      });
+      this.error(
+        `Failed to write configuration file to "${finalConfigFilePath}".`,
+        {
+          exit: 1,
+        },
+      );
     }
 
-    this.log(`${ux.colorize('green', 'CREATED')} ${configFilePath}`);
+    this.log(`${ux.colorize('green', 'CREATED')} ${finalConfigFilePath}`);
     this.log();
     this.log(`Initialized Thymian.`);
   }

--- a/packages/thymian/test/commands/init.test.ts
+++ b/packages/thymian/test/commands/init.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { captureOutput, runCommand } from '@oclif/test';
+import { runCommand } from '@oclif/test';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 process.env.OCLIF_TEST_ROOT = join(import.meta.url, '../../..');
@@ -81,17 +81,29 @@ describe('init command', () => {
   });
 
   it('should create yaml config file when --yaml-format flag is used', async () => {
-    const r = await runCommand(`init --cwd ${testDir} --yaml-format --yes`);
+    await runCommand(`init --cwd ${testDir} --yaml-format --yes`);
 
     expect(existsSync(join(testDir, 'thymian.config.yaml'))).toBe(true);
   });
 
+  it('should append .json extension when --config-file is given without an extension', async () => {
+    await runCommand(`init --cwd ${testDir} --config-file custom-config --yes`);
+
+    expect(existsSync(join(testDir, 'custom-config.json'))).toBe(true);
+  });
+
+  it('should append .yaml extension when --config-file without extension is combined with --yaml-format', async () => {
+    await runCommand(
+      `init --cwd ${testDir} --config-file custom-config --yaml-format --yes`,
+    );
+
+    expect(existsSync(join(testDir, 'custom-config.yaml'))).toBe(true);
+  });
+
   it('should create yaml config file with custom name when both --yaml-format and --config-file are used', async () => {
-    const result = await captureOutput(async () => {
-      await runCommand(
-        `init --cwd ${testDir} --config-file my-thymian.yaml --yaml-format --yes`,
-      );
-    });
+    await runCommand(
+      `init --cwd ${testDir} --config-file my-thymian.yaml --yaml-format --yes`,
+    );
 
     expect(existsSync(join(testDir, 'my-thymian.yaml'))).toBe(true);
   });

--- a/packages/thymian/test/commands/init.test.ts
+++ b/packages/thymian/test/commands/init.test.ts
@@ -1,12 +1,98 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { captureOutput, runCommand } from '@oclif/test';
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 process.env.OCLIF_TEST_ROOT = join(import.meta.url, '../../..');
 
 describe('init command', () => {
-  it('should run init command', async () => {
-    await captureOutput(async () => await runCommand('init --no-input'));
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'thymian-init-test-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should run init command in a clean directory', async () => {
+    const result = await runCommand(`init --cwd ${testDir} --yes`);
+
+    expect(result.stdout).toContain('CREATED');
+    expect(result.stdout).toContain('ADDED');
+    expect(result.stdout).toContain('Initialized Thymian');
+    expect(existsSync(join(testDir, 'thymian.config.json'))).toBe(true);
+  });
+
+  it('should fail when config file already exists without --force flag', async () => {
+    // Create an existing config file
+    const configPath = join(testDir, 'thymian.config.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    const result = await runCommand(`init --cwd ${testDir} --yes`);
+
+    expect(result.error).toBeDefined();
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('already exists'),
+      }),
+    );
+  });
+
+  it('should overwrite existing config file when --force flag is used', async () => {
+    // Create an existing config file with different content
+    const configPath = join(testDir, 'thymian.config.json');
+    const oldContent = {
+      plugins: {
+        testPluginName: {},
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(oldContent));
+
+    await runCommand(`init --cwd ${testDir} --yes --force`);
+
+    const configResult = await runCommand(
+      `config:show --cwd ${testDir} --no-autoload`,
+    );
+
+    expect(configResult.stdout).not.toContain('testPluginName');
+  });
+
+  it('should handle custom config-file name with .json extension', async () => {
+    await runCommand(
+      `init --cwd ${testDir} --config-file custom-config.json --yes`,
+    );
+
+    expect(existsSync(join(testDir, 'custom-config.json'))).toBe(true);
+  });
+
+  it('should handle custom config-file name with .yaml extension', async () => {
+    await runCommand(
+      `init --cwd ${testDir} --config-file custom-config.yaml --yes`,
+    );
+
+    expect(existsSync(join(testDir, 'custom-config.yaml'))).toBe(true);
+  });
+
+  it('should create yaml config file when --yaml-format flag is used', async () => {
+    const r = await runCommand(`init --cwd ${testDir} --yaml-format --yes`);
+
+    expect(existsSync(join(testDir, 'thymian.config.yaml'))).toBe(true);
+  });
+
+  it('should create yaml config file with custom name when both --yaml-format and --config-file are used', async () => {
+    const result = await captureOutput(async () => {
+      await runCommand(
+        `init --cwd ${testDir} --config-file my-thymian.yaml --yaml-format --yes`,
+      );
+    });
+
+    expect(existsSync(join(testDir, 'my-thymian.yaml'))).toBe(true);
   });
 });


### PR DESCRIPTION
This pull request introduces several improvements to the Thymian CLI initialization command, focusing on enhanced configuration file handling, error reporting, and test coverage. The most significant updates are the switch to `.json` as the default config file format, robust support for YAML and custom file names, improved error handling when overwriting config files, and comprehensive tests for these scenarios.

Configuration file handling improvements:

* Changed the default configuration file extension from `.yaml` to `.json` in both the CLI base command and the `init` command, and added support for custom file names and formats via flags (`--config-file`, `--yaml-format`). [[1]](diffhunk://#diff-6622b52056bb921b019ef99c102b003b8f1d95209999a3f23608a7223c839832L52-R52) [[2]](diffhunk://#diff-68821933aedac5f03b642a7039811d57b07339658117b5163ea5116b05a0661cL28-R38)
* Enhanced logic in `init` to automatically adjust file extension based on user flags and handle overwriting existing files with the `--force` flag. [[1]](diffhunk://#diff-68821933aedac5f03b642a7039811d57b07339658117b5163ea5116b05a0661cR49-R87) [[2]](diffhunk://#diff-68821933aedac5f03b642a7039811d57b07339658117b5163ea5116b05a0661cL65-L91)

Error handling and reporting:

* Improved error handling in the base command: 
* `init` now provides clear feedback when a config file already exists and suggests actions to resolve the conflict before the interactive selection of plugins begins

Testing enhancements:

* Added comprehensive tests for the `init` command, covering scenarios such as file creation, overwriting, custom file names, and format selection

Closes https://github.com/thymianofficial/thymian-internal/issues/158