### PR TITLE
feat(repo): harden e2e test infrastructure (isolation, ports, env)

### DIFF
--- a/e2e-tests/test/e2e-tests.test.ts
+++ b/e2e-tests/test/e2e-tests.test.ts
@@ -1,28 +1,45 @@
+import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { render, type RenderResult, waitFor } from 'cli-testing-library';
 import fastify from 'fastify';
-import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
-import { join } from 'path';
 import { filter, firstValueFrom, ReplaySubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 
-const dirname = import.meta.dirname;
-const fixturesDir = join(dirname, '..', 'fixtures');
-const e2eTempDir =
-  process.env.TARGET_FOLDER || join(process.cwd(), 'tmp-e2e-test');
+const fixturesDir = join(import.meta.dirname, '..', 'fixtures');
 
-const thymianConfigPath = join(e2eTempDir, 'thymian.config.yaml');
+type InstallationMode = 'npx' | 'global' | 'local';
+const installationMode: InstallationMode =
+  (process.env.THYMIAN_E2E_MODE as InstallationMode) || 'npx';
 
-const thymianBin = 'thymian';
+function renderThymian(args: string[], opts?: { cwd?: string }) {
+  const version = process.env.THYMIAN_E2E_VERSION ?? '';
+  switch (installationMode) {
+    case 'npx':
+      return render('npx', ['--yes', `@thymian/cli@${version}`, ...args], opts);
+    case 'global':
+      return render(
+        process.env.THYMIAN_E2E_GLOBAL_BIN ?? 'thymian',
+        args,
+        opts,
+      );
+    case 'local':
+      throw new Error('Local installation mode not yet implemented');
+  }
+}
 
 describe('E2E test Thymian', () => {
+  let e2eTempDir: string;
+
   beforeEach(() => {
-    console.log('Creating e2e test temp dir');
-    mkdirSync(e2eTempDir, { recursive: true });
+    e2eTempDir = mkdtempSync(join(tmpdir(), 'thymian-e2e-'));
+    console.log(`Created e2e test temp dir: ${e2eTempDir}`);
   });
 
   afterEach(() => {
-    console.log('Removing e2e test temp dir');
+    console.log(`Removing e2e test temp dir: ${e2eTempDir}`);
     rmSync(e2eTempDir, { recursive: true, force: true });
   });
 
@@ -31,7 +48,7 @@ describe('E2E test Thymian', () => {
       'should print the standard message',
       async () => {
         console.log('=> should print the standard message');
-        const { findByText } = await render(thymianBin, [], {
+        const { findByText } = await renderThymian([], {
           cwd: e2eTempDir,
         });
 
@@ -45,7 +62,7 @@ describe('E2E test Thymian', () => {
     it(
       'should initialize Thymian',
       async () => {
-        const { findByText } = await render(thymianBin, ['init', '--yes'], {
+        const { findByText } = await renderThymian(['init', '--yes'], {
           cwd: e2eTempDir,
         });
 
@@ -53,7 +70,7 @@ describe('E2E test Thymian', () => {
           findByText(/Initialized Thymian/, undefined, { timeout: 89000 }),
         ).resolves.toBeTruthy();
 
-        expect(existsSync(thymianConfigPath)).toBe(true);
+        expect(existsSync(join(e2eTempDir, 'thymian.config.yaml'))).toBe(true);
       },
       { timeout: 90000 },
     );
@@ -61,9 +78,9 @@ describe('E2E test Thymian', () => {
     it(
       'should run a static check',
       async () => {
-        copyFixturesToTempDir(join(fixturesDir, 'static-lint'));
+        copyFixturesToTempDir(join(fixturesDir, 'static-lint'), e2eTempDir);
 
-        const { findByText } = await render(thymianBin, ['run'], {
+        const { findByText } = await renderThymian(['run'], {
           cwd: e2eTempDir,
         });
 
@@ -77,10 +94,9 @@ describe('E2E test Thymian', () => {
     it(
       'should generate samples and run a dynamic check',
       async () => {
-        copyFixturesToTempDir(join(fixturesDir, 'samples/'));
+        copyFixturesToTempDir(join(fixturesDir, 'samples/'), e2eTempDir);
 
-        const { findByText } = await render(
-          thymianBin,
+        const { findByText } = await renderThymian(
           ['sampler:init', '--no-check'],
           {
             cwd: e2eTempDir,
@@ -104,7 +120,7 @@ describe('E2E test Thymian', () => {
         await server.listen({ port: 3000, host: '0.0.0.0' });
 
         try {
-          const { findByText } = await render(thymianBin, ['format:check'], {
+          const { findByText } = await renderThymian(['format:check'], {
             cwd: e2eTempDir,
           });
 
@@ -125,7 +141,7 @@ describe('E2E test Thymian', () => {
     let instance: RenderResult;
 
     beforeEach(async () => {
-      instance = await render(thymianBin, [
+      instance = await renderThymian([
         'serve',
         '-o',
         '@thymian/websocket-proxy.port=51234',
@@ -264,6 +280,6 @@ components:
   });
 });
 
-function copyFixturesToTempDir(fixturesDir: string) {
-  cpSync(fixturesDir, e2eTempDir, { recursive: true, force: true });
+function copyFixturesToTempDir(sourceDir: string, tempDir: string) {
+  cpSync(sourceDir, tempDir, { recursive: true, force: true });
 }

--- a/e2e-tests/test/e2e-tests.test.ts
+++ b/e2e-tests/test/e2e-tests.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import {
   cpSync,
   existsSync,
@@ -15,6 +16,7 @@ import { filter, firstValueFrom, ReplaySubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 
+import { getCleanEnv } from './env-utils.js';
 import { getAvailablePort } from './port-utils.js';
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures');
@@ -23,17 +25,56 @@ type InstallationMode = 'npx' | 'global' | 'local';
 const installationMode: InstallationMode =
   (process.env.THYMIAN_E2E_MODE as InstallationMode) || 'npx';
 
-function renderThymian(args: string[], opts?: { cwd?: string }) {
+function execThymian(args: string[], opts: { cwd?: string } = {}): string {
   const version = process.env.THYMIAN_E2E_VERSION ?? '';
+  const env = getCleanEnv();
+  let command: string;
   switch (installationMode) {
     case 'npx':
-      return render('npx', ['--yes', `@thymian/cli@${version}`, ...args], opts);
+      command = `npx --yes @thymian/cli@${version} ${args.join(' ')}`;
+      break;
+    case 'global': {
+      const bin = process.env.THYMIAN_E2E_GLOBAL_BIN ?? 'thymian';
+      command = `${bin} ${args.join(' ')}`;
+      break;
+    }
+    case 'local':
+      throw new Error('Local installation mode not yet implemented');
+  }
+  try {
+    return execSync(command, {
+      cwd: opts.cwd,
+      env,
+      encoding: 'utf-8',
+      timeout: 90_000,
+    });
+  } catch (error) {
+    const execError = error as {
+      stdout?: string;
+      stderr?: string;
+      status?: number;
+    };
+    console.warn(
+      `execThymian exited with status ${execError.status ?? 'unknown'}`,
+    );
+    return (execError.stdout ?? '') + (execError.stderr ?? '');
+  }
+}
+
+function renderThymian(args: string[], opts?: { cwd?: string }) {
+  const version = process.env.THYMIAN_E2E_VERSION ?? '';
+  const env = getCleanEnv();
+  switch (installationMode) {
+    case 'npx':
+      return render('npx', ['--yes', `@thymian/cli@${version}`, ...args], {
+        ...opts,
+        env,
+      });
     case 'global':
-      return render(
-        process.env.THYMIAN_E2E_GLOBAL_BIN ?? 'thymian',
-        args,
-        opts,
-      );
+      return render(process.env.THYMIAN_E2E_GLOBAL_BIN ?? 'thymian', args, {
+        ...opts,
+        env,
+      });
     case 'local':
       throw new Error('Local installation mode not yet implemented');
   }
@@ -55,30 +96,18 @@ describe('E2E test Thymian', () => {
   describe('using cli', () => {
     it(
       'should print the standard message',
-      async () => {
-        console.log('=> should print the standard message');
-        const { findByText } = await renderThymian([], {
-          cwd: e2eTempDir,
-        });
-
-        await expect(
-          findByText(/VERSION/, undefined, { timeout: 59000 }),
-        ).resolves.toBeTruthy();
+      () => {
+        const output = execThymian([], { cwd: e2eTempDir });
+        expect(output).toMatch(/VERSION/);
       },
-      { timeout: 60000 },
+      { timeout: 90000 },
     );
 
     it(
       'should initialize Thymian',
-      async () => {
-        const { findByText } = await renderThymian(['init', '--yes'], {
-          cwd: e2eTempDir,
-        });
-
-        await expect(
-          findByText(/Initialized Thymian/, undefined, { timeout: 89000 }),
-        ).resolves.toBeTruthy();
-
+      () => {
+        const output = execThymian(['init', '--yes'], { cwd: e2eTempDir });
+        expect(output).toMatch(/Initialized Thymian/);
         expect(existsSync(join(e2eTempDir, 'thymian.config.yaml'))).toBe(true);
       },
       { timeout: 90000 },
@@ -86,16 +115,10 @@ describe('E2E test Thymian', () => {
 
     it(
       'should run a static check',
-      async () => {
+      () => {
         copyFixturesToTempDir(join(fixturesDir, 'static-lint'), e2eTempDir);
-
-        const { findByText } = await renderThymian(['run'], {
-          cwd: e2eTempDir,
-        });
-
-        await expect(
-          findByText(/Static Checks/, undefined, { timeout: 89000 }),
-        ).resolves.toBeTruthy();
+        const output = execThymian(['run'], { cwd: e2eTempDir });
+        expect(output).toMatch(/Static Checks/);
       },
       { timeout: 90000 },
     );
@@ -105,17 +128,10 @@ describe('E2E test Thymian', () => {
       async () => {
         copyFixturesToTempDir(join(fixturesDir, 'samples/'), e2eTempDir);
 
-        const { findByText } = await renderThymian(
-          ['sampler:init', '--no-check'],
-          {
-            cwd: e2eTempDir,
-          },
-        );
-
-        await expect(
-          findByText(/Sampler initialized/, undefined, { timeout: 89000 }),
-        ).resolves.toBeTruthy();
-
+        const samplerOutput = execThymian(['sampler:init', '--no-check'], {
+          cwd: e2eTempDir,
+        });
+        expect(samplerOutput).toMatch(/Sampler initialized/);
         expect(existsSync(join(e2eTempDir, '.thymian'))).toBe(true);
 
         const port = await getAvailablePort();
@@ -141,15 +157,8 @@ describe('E2E test Thymian', () => {
         await server.listen({ port, host: '0.0.0.0' });
 
         try {
-          const { findByText } = await renderThymian(['format:check'], {
-            cwd: e2eTempDir,
-          });
-
-          await expect(
-            findByText(/GET \/api\/hello → 200 OK/, undefined, {
-              timeout: 89000,
-            }),
-          ).resolves.toBeTruthy();
+          const output = execThymian(['format:check'], { cwd: e2eTempDir });
+          expect(output).toMatch(/GET \/api\/hello → 200 OK/);
         } finally {
           await server.close();
         }

--- a/e2e-tests/test/e2e-tests.test.ts
+++ b/e2e-tests/test/e2e-tests.test.ts
@@ -1,4 +1,11 @@
-import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -7,6 +14,8 @@ import fastify from 'fastify';
 import { filter, firstValueFrom, ReplaySubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
+
+import { getAvailablePort } from './port-utils.js';
 
 const fixturesDir = join(import.meta.dirname, '..', 'fixtures');
 
@@ -109,6 +118,18 @@ describe('E2E test Thymian', () => {
 
         expect(existsSync(join(e2eTempDir, '.thymian'))).toBe(true);
 
+        const port = await getAvailablePort();
+
+        const openapiPath = join(e2eTempDir, 'test.openapi.yaml');
+        const openapiContent = readFileSync(openapiPath, 'utf-8');
+        writeFileSync(
+          openapiPath,
+          openapiContent.replace(
+            'http://localhost:3000',
+            `http://localhost:${port}`,
+          ),
+        );
+
         const server = fastify();
         server.get<{ Querystring: { name: string } }>(
           '/api/hello',
@@ -117,7 +138,7 @@ describe('E2E test Thymian', () => {
             return { content: `Hello ${name}` };
           },
         );
-        await server.listen({ port: 3000, host: '0.0.0.0' });
+        await server.listen({ port, host: '0.0.0.0' });
 
         try {
           const { findByText } = await renderThymian(['format:check'], {
@@ -139,12 +160,14 @@ describe('E2E test Thymian', () => {
 
   describe('using websocket', () => {
     let instance: RenderResult;
+    let wsPort: number;
 
     beforeEach(async () => {
+      wsPort = await getAvailablePort();
       instance = await renderThymian([
         'serve',
         '-o',
-        '@thymian/websocket-proxy.port=51234',
+        `@thymian/websocket-proxy.port=${wsPort}`,
       ]);
     });
 
@@ -167,7 +190,7 @@ describe('E2E test Thymian', () => {
           }),
         ).resolves.toBeTruthy();
 
-        const ws = new WebSocket('ws://localhost:51234');
+        const ws = new WebSocket(`ws://localhost:${wsPort}`);
         console.log('Created WebSocket instance');
 
         try {

--- a/e2e-tests/test/env-utils.ts
+++ b/e2e-tests/test/env-utils.ts
@@ -1,0 +1,20 @@
+export function getCleanEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (key.startsWith('NX_')) {
+      continue;
+    }
+    if (key === 'NODE_PATH') {
+      continue;
+    }
+    if (key === 'JEST_WORKER_ID') {
+      continue;
+    }
+    env[key] = value;
+  }
+  env['FORCE_COLOR'] = '0';
+  return env;
+}

--- a/e2e-tests/test/global.setup.ts
+++ b/e2e-tests/test/global.setup.ts
@@ -1,17 +1,23 @@
 import { type ChildProcess, exec, execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { waitFor } from 'cli-testing-library';
-import { join } from 'path';
 import type { TestProject } from 'vitest/node';
 
-const dirname = import.meta.dirname;
-const rootDir = join(dirname, '..', '..');
+const rootDir = join(import.meta.dirname, '..', '..');
 
-export const thymianVersion = '0.0.1-e2e';
+const thymianVersion = '0.0.1-e2e';
+const verdaccioUrl = 'http://localhost:4873';
 
 let verdaccioProcess: ChildProcess;
+let globalPrefix: string;
 
-export default async function setup(project: TestProject) {
+export default async function setup(_project: TestProject) {
+  // Registry isolation: all npm operations resolve packages from Verdaccio
+  process.env.npm_config_registry = verdaccioUrl;
+
   verdaccioProcess = exec(
     'npm run local-registry',
     {
@@ -29,7 +35,7 @@ export default async function setup(project: TestProject) {
 
   await waitFor(
     async () => {
-      const response = await fetch('http://localhost:4873');
+      const response = await fetch(verdaccioUrl);
       if (!response.ok) {
         throw new Error('Verdaccio is not ready yet');
       }
@@ -60,8 +66,14 @@ export default async function setup(project: TestProject) {
     throw error;
   }
 
-  console.log('Installing e2e test Thymian version');
-  output = execSync(`npm install -g @thymian/cli@${thymianVersion}`).toString();
+  // Global install isolation: redirect to temp dir via npm_config_prefix
+  globalPrefix = mkdtempSync(join(tmpdir(), 'thymian-e2e-global-'));
+  console.log(
+    `Installing e2e test Thymian version to isolated prefix: ${globalPrefix}`,
+  );
+  output = execSync(`npm install -g @thymian/cli@${thymianVersion}`, {
+    env: { ...process.env, npm_config_prefix: globalPrefix },
+  }).toString();
   console.log(output);
 
   try {
@@ -77,9 +89,26 @@ export default async function setup(project: TestProject) {
     verdaccioProcess.kill();
     throw error;
   }
+
+  // Expose environment for tests
+  process.env.THYMIAN_E2E_VERSION = thymianVersion;
+  process.env.THYMIAN_E2E_GLOBAL_BIN = join(globalPrefix, 'bin', 'thymian');
+  process.env.THYMIAN_E2E_GLOBAL_PREFIX = globalPrefix;
 }
 
 export function teardown() {
   console.log('Shutting down local registry');
   verdaccioProcess.kill();
+
+  // Clean up isolated global prefix
+  if (globalPrefix) {
+    console.log(`Cleaning up global prefix: ${globalPrefix}`);
+    rmSync(globalPrefix, { recursive: true, force: true });
+  }
+
+  // Clean up environment variables
+  delete process.env.npm_config_registry;
+  delete process.env.THYMIAN_E2E_VERSION;
+  delete process.env.THYMIAN_E2E_GLOBAL_BIN;
+  delete process.env.THYMIAN_E2E_GLOBAL_PREFIX;
 }

--- a/e2e-tests/test/global.setup.ts
+++ b/e2e-tests/test/global.setup.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path';
 import { waitFor } from 'cli-testing-library';
 import type { TestProject } from 'vitest/node';
 
+import { getCleanEnv } from './env-utils.js';
+
 const rootDir = join(import.meta.dirname, '..', '..');
 
 const thymianVersion = '0.0.1-e2e';
@@ -44,10 +46,12 @@ export default async function setup(_project: TestProject) {
   );
 
   console.log('Publishing e2e test Thymian version');
+  const cleanEnv = getCleanEnv();
   let output = execSync(
     `npm run local-publish -- --dist-tag latest --version ${thymianVersion}`,
     {
       cwd: rootDir,
+      env: { ...cleanEnv, npm_config_registry: verdaccioUrl },
     },
   ).toString();
 
@@ -71,9 +75,16 @@ export default async function setup(_project: TestProject) {
   console.log(
     `Installing e2e test Thymian version to isolated prefix: ${globalPrefix}`,
   );
-  output = execSync(`npm install -g @thymian/cli@${thymianVersion}`, {
-    env: { ...process.env, npm_config_prefix: globalPrefix },
-  }).toString();
+  output = execSync(
+    `npm install -g @thymian/cli@${thymianVersion} --registry ${verdaccioUrl}`,
+    {
+      env: {
+        ...cleanEnv,
+        npm_config_prefix: globalPrefix,
+        npm_config_registry: verdaccioUrl,
+      },
+    },
+  ).toString();
   console.log(output);
 
   try {

--- a/e2e-tests/test/port-utils.ts
+++ b/e2e-tests/test/port-utils.ts
@@ -1,0 +1,12 @@
+import { createServer } from 'node:net';
+
+export function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number };
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}


### PR DESCRIPTION
## E2E Test Infrastructure Hardening

This PR combines three stacked stories that harden the e2e test infrastructure:

### Story #198 — Isolate e2e tests from host system
- Replace `npm install -g` with `npm_config_prefix` redirection to temp dir
- Use `mkdtempSync` in `$TMPDIR` for test temp dirs instead of workspace-relative paths
- Set `npm_config_registry` env var for explicit Verdaccio scoping
- Add cleanup in teardown for isolated global prefix
- Add `renderThymian()` helper supporting npx/global/local installation modes

### Story #253 — Enable parallel-safe e2e tests with dynamic port allocation
- Add `port-utils.ts` with `getAvailablePort()` using OS-assigned port 0
- Replace hardcoded port 3000 in Fastify test with dynamic allocation
- Replace hardcoded port 51234 in WebSocket proxy test with dynamic port
- Update OpenAPI fixture URL to use dynamic port for format:check test

### Story #254 — Harden e2e command execution with env stripping and tiered invocation
- Add `env-utils.ts` with `getCleanEnv()` stripping `NX_*`, `NODE_PATH`, `JEST_WORKER_ID`; sets `FORCE_COLOR=0`
- Add `execThymian()` sync wrapper for one-shot CLI commands (`init`, `run`, `sampler:init`, `format:check`)
- Convert 4 one-shot tests from async `render()` to sync `execSync`
- Keep `render()` for streaming serve/WebSocket test
- Apply `getCleanEnv()` to `global.setup.ts` publish and install commands

### Files changed
- `e2e-tests/test/global.setup.ts` — isolation + clean env
- `e2e-tests/test/e2e-tests.test.ts` — all three stories
- `e2e-tests/test/port-utils.ts` — new: dynamic port allocation
- `e2e-tests/test/env-utils.ts` — new: environment stripping

### References
- Research: thymianofficial/thymian-internal/discussions/252
- Change Proposal: thymianofficial/thymian-internal/discussions/255
- Closes thymianofficial/thymian-internal#198
- Closes thymianofficial/thymian-internal#253
- Closes thymianofficial/thymian-internal#254