### PR TITLE
fix(release): allow latest release creation outside CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Release script - requires review from core maintainers
-/scripts/release.ts @Markus-Ende @BaggersIO
+/scripts/release.ts @Markus-Ende @BaggersIO @matthyk
 
 # Workflow - requires review from core maintainers
-/.github/workflows/release.yaml @Markus-Ende @BaggersIO
+/.github/workflows/release.yaml @Markus-Ende @BaggersIO @matthyk

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -63,15 +63,9 @@ function validateAndDetermineMode(argv: {
     process.exit(1);
   }
 
-  // Reject: publishing to npm outside CI (except canary which runs in CI anyway)
-  if (!argv.local && !inCI && isLatest) {
-    console.error('❌ Error: Invalid argument combination');
-    console.error('   --dist-tag latest --no-local (outside CI)');
-    console.error(
-      '   Problem: This bypasses CI authorization. Use CI for npm publishes.\n',
-    );
-    process.exit(1);
-  }
+  // Note: --dist-tag latest --no-local outside CI is allowed.
+  // The 'latest' mode only creates a git tag + GitHub Release.
+  // Actual npm publishing is handled by CI when it picks up the GitHub Release event.
 
   // Determine mode
   let mode: ReleaseMode;


### PR DESCRIPTION
## Changes

- **release.ts**: Removed overly aggressive validation that blocked `--dist-tag latest --no-local` outside CI. The `latest` mode only creates a git tag + GitHub Release — it does NOT publish to npm directly. CI handles the actual npm publish when triggered by the GitHub Release event.

- **CODEOWNERS**: Added `@matthyk` (Matthias Keckl) to release script and workflow code ownership.

## Context

This fix was discovered during the 0.1.0 npm package surface transition. The release script incorrectly prevented creating GitHub Releases from a local machine, which is the intended workflow (local creates tag → CI publishes to npm).