### PR TITLE
fix(release): re-enable canary release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    # Canary release deactivated — change `if: false` back to the original condition to re-enable:
-    # if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
-    if: false
+    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The canary release job in `.github/workflows/release.yaml` had `if: false`, completely disabling automatic canary publishes on every push to `main`.

**Fix**: Restore the original condition:
```yaml
if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
```