### PR TITLE
fix(common-cli): make feedback and error cache call conditional

### DIFF
--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -279,7 +279,7 @@ export abstract class BaseCliRunCommand<
       await this.registerPluginsFromConfig();
     }
 
-    await this.feedback.run();
+    await this.feedback?.run();
   }
 
   protected override async catch(err: CommandError): Promise<void> {

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -132,11 +132,15 @@ export abstract class BaseCliRunCommand<
   protected logger!: Logger;
   protected thymianConfig!: ThymianConfig;
   protected thymian!: Thymian;
-  protected feedback: Feedback | undefined;
-  protected errorCache: ErrorCache | undefined;
+  protected feedback?: Feedback;
+  protected errorCache?: ErrorCache;
 
   public override async init(): Promise<void> {
     await super.init();
+
+    this.feedback = Feedback.forCommand(this);
+    this.errorCache = ErrorCache.forCommand(this);
+
     const { args, flags } = await this.parse({
       flags: this.ctor.flags,
       baseFlags: (super.ctor as typeof BaseCliRunCommand).baseFlags,
@@ -147,9 +151,6 @@ export abstract class BaseCliRunCommand<
     this.flags = flags as CommandFlags<T>;
     this.args = args as CommandArgs<T>;
     this.flags.debug = settings.debug || this.flags.debug;
-
-    this.feedback = Feedback.forCommand(this);
-    this.errorCache = ErrorCache.forCommand(this);
 
     // --- Config Resolution Chain ---
     // Step A+B: Load config from --config flag, well-known file, or defaultConfig

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -132,8 +132,8 @@ export abstract class BaseCliRunCommand<
   protected logger!: Logger;
   protected thymianConfig!: ThymianConfig;
   protected thymian!: Thymian;
-  protected feedback!: Feedback;
-  protected errorCache!: ErrorCache;
+  protected feedback: Feedback | undefined;
+  protected errorCache: ErrorCache | undefined;
 
   public override async init(): Promise<void> {
     await super.init();
@@ -281,14 +281,14 @@ export abstract class BaseCliRunCommand<
   }
 
   protected override async catch(err: CommandError): Promise<void> {
-    await this.feedback.error();
+    await this.feedback?.error();
     const versionDetails = this.config.versionDetails;
 
     const pluginVersions = Object.entries(versionDetails.pluginVersions ?? {})
       .filter(([name]) => !name.startsWith('@oclif'))
       .map(([name, version]) => ({ name, version: version.version }));
 
-    await this.errorCache.write({
+    await this.errorCache?.write({
       name: err.name,
       message: err.message,
       commandName: this.id ?? 'unknown command',

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -138,7 +138,6 @@ export abstract class BaseCliRunCommand<
   public override async init(): Promise<void> {
     await super.init();
 
-    this.feedback = Feedback.forCommand(this);
     this.errorCache = ErrorCache.forCommand(this);
 
     const { args, flags } = await this.parse({
@@ -151,6 +150,8 @@ export abstract class BaseCliRunCommand<
     this.flags = flags as CommandFlags<T>;
     this.args = args as CommandArgs<T>;
     this.flags.debug = settings.debug || this.flags.debug;
+
+    this.feedback = Feedback.forCommand(this);
 
     // --- Config Resolution Chain ---
     // Step A+B: Load config from --config flag, well-known file, or defaultConfig

--- a/packages/common-cli/src/thymian-base-command.ts
+++ b/packages/common-cli/src/thymian-base-command.ts
@@ -30,7 +30,6 @@ export abstract class ThymianBaseCommand<
   public override async init(): Promise<void> {
     await super.init();
 
-    this.feedback = Feedback.forCommand(this);
     this.errorCache = ErrorCache.forCommand(this);
 
     const { args, flags } = await this.parse({
@@ -42,6 +41,8 @@ export abstract class ThymianBaseCommand<
     });
     this.flags = flags as Flags<T>;
     this.args = args as Args<T>;
+
+    this.feedback = Feedback.forCommand(this);
 
     await this.feedback.run();
   }

--- a/packages/common-cli/src/thymian-base-command.ts
+++ b/packages/common-cli/src/thymian-base-command.ts
@@ -24,11 +24,15 @@ export abstract class ThymianBaseCommand<
 
   protected flags!: Flags<T>;
   protected args!: Args<T>;
-  protected feedback!: Feedback;
-  protected errorCache!: ErrorCache;
+  protected feedback?: Feedback;
+  protected errorCache?: ErrorCache;
 
   public override async init(): Promise<void> {
     await super.init();
+
+    this.feedback = Feedback.forCommand(this);
+    this.errorCache = ErrorCache.forCommand(this);
+
     const { args, flags } = await this.parse({
       flags: this.ctor.flags,
       baseFlags: (super.ctor as typeof ThymianBaseCommand).baseFlags,
@@ -38,21 +42,19 @@ export abstract class ThymianBaseCommand<
     });
     this.flags = flags as Flags<T>;
     this.args = args as Args<T>;
-    this.feedback = Feedback.forCommand(this);
-    this.errorCache = ErrorCache.forCommand(this);
 
     await this.feedback.run();
   }
 
   protected override async catch(err: CommandError): Promise<void> {
-    await this.feedback.error();
+    await this.feedback?.error();
     const versionDetails = this.config.versionDetails;
 
     const pluginVersions = Object.entries(versionDetails.pluginVersions ?? {})
       .filter(([name]) => !name.startsWith('@oclif'))
       .map(([name, version]) => ({ name, version: version.version }));
 
-    await this.errorCache.write({
+    await this.errorCache?.write({
       name: err.name,
       message: err.message,
       commandName: this.id ?? 'unknown command',

--- a/packages/common-cli/src/thymian-base-command.ts
+++ b/packages/common-cli/src/thymian-base-command.ts
@@ -44,7 +44,7 @@ export abstract class ThymianBaseCommand<
 
     this.feedback = Feedback.forCommand(this);
 
-    await this.feedback.run();
+    await this.feedback?.run();
   }
 
   protected override async catch(err: CommandError): Promise<void> {

--- a/packages/thymian/src/commands/feedback.ts
+++ b/packages/thymian/src/commands/feedback.ts
@@ -17,7 +17,7 @@ export class Feedback extends ThymianBaseCommand<typeof Feedback> {
   }
 
   override async run(): Promise<void> {
-    const lastError = await this.errorCache.read();
+    const lastError = await this.errorCache?.read();
 
     this.log('✨ Thank you for your feedback! ✨');
     this.log();
@@ -33,7 +33,7 @@ export class Feedback extends ThymianBaseCommand<typeof Feedback> {
       });
 
       if (reportError) {
-        await this.errorCache.reset();
+        await this.errorCache?.reset();
 
         await this.reportError(lastError);
       } else {


### PR DESCRIPTION
This pull request makes the handling of `feedback` and `errorCache` in the `BaseCliRunCommand` class more robust by allowing them to be undefined and updating method calls to safely handle this case. This prevents potential runtime errors if these properties are not initialized.

**Error handling improvements:**

* Changed the types of the `feedback` and `errorCache` properties to `Feedback | undefined` and `ErrorCache | undefined`, respectively, in `BaseCliRunCommand`, to allow for safer initialization and usage.
* Updated the `catch` method to use optional chaining (`?.`) when calling methods on `feedback` and `errorCache`, preventing errors if these properties are undefined.