### PR TITLE
fix(plugin-openapi): fix openapi files search regexp

### DIFF
--- a/packages/plugin-openapi/src/search-for-openapi-files.ts
+++ b/packages/plugin-openapi/src/search-for-openapi-files.ts
@@ -32,8 +32,8 @@ export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
 
       for await (const line of rl) {
         if (
-          /^\s*"?swagger"?\s*:\s*("?2\.0"?)/i.test(line) ||
-          /^\s*"?openapi"?\s*:\s*("?3\.([01])\.\d+"?)/i.test(line)
+          /^\s*"?swagger"?\s*:\s*"?2\.0(?:\.0)?"?\s*$/i.test(line) ||
+          /^\s*"?openapi"?\s*:\s*"?3\.[01]\.\d+"?\s*$/i.test(line)
         ) {
           found.push(match);
           break;

--- a/packages/plugin-openapi/src/search-for-openapi-files.ts
+++ b/packages/plugin-openapi/src/search-for-openapi-files.ts
@@ -32,8 +32,8 @@ export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
 
       for await (const line of rl) {
         if (
-          /^\s*"?swagger"?\s*:\s*"?2\.0(?:\.0)?"?\s*$/i.test(line) ||
-          /^\s*"?openapi"?\s*:\s*"?3\.[01]\.\d+"?\s*$/i.test(line)
+          /^\s*"?swagger"?\s*:\s*"?2\.0(?:\.0)?"?\s*,?\s*$/i.test(line) ||
+          /^\s*"?openapi"?\s*:\s*"?3\.[01]\.\d+"?\s*,?\s*$/i.test(line)
         ) {
           found.push(match);
           break;

--- a/packages/plugin-openapi/src/search-for-openapi-files.ts
+++ b/packages/plugin-openapi/src/search-for-openapi-files.ts
@@ -32,8 +32,8 @@ export async function searchForOpenApiFiles(cwd: string): Promise<string[]> {
 
       for await (const line of rl) {
         if (
-          /^\s*"?swagger"?\s*:\s*("?2\.0\.0"?)/i.test(line) ||
-          /^\s*"?openapi"?\s*:\s*("?3\.(0|1)\.\d+"?)/i.test(line)
+          /^\s*"?swagger"?\s*:\s*("?2\.0"?)/i.test(line) ||
+          /^\s*"?openapi"?\s*:\s*("?3\.([01])\.\d+"?)/i.test(line)
         ) {
           found.push(match);
           break;


### PR DESCRIPTION
This pull request updates the logic for detecting OpenAPI and Swagger specification files in the `searchForOpenApiFiles` function. The main change is to make the version matching more flexible and accurate, allowing for detection of any `2.0` Swagger version (not just `2.0.0`) and any `3.0.x` or `3.1.x` OpenAPI version.

**Improvements to OpenAPI/Swagger version detection:**

* The regular expression for matching Swagger files now accepts any `2.0` version, not just `2.0.0`, making it more robust to different file formats. (`packages/plugin-openapi/src/search-for-openapi-files.ts`, [packages/plugin-openapi/src/search-for-openapi-files.tsL35-R36](diffhunk://#diff-509fa3411875aee9eb523f4eac2bc81946076728cf1ebf287ff1a1b2b0cafaf7L35-R36))
* The regular expression for matching OpenAPI files now correctly matches both `3.0.x` and `3.1.x` versions. (`packages/plugin-openapi/src/search-for-openapi-files.ts`, [packages/plugin-openapi/src/search-for-openapi-files.tsL35-R36](diffhunk://#diff-509fa3411875aee9eb523f4eac2bc81946076728cf1ebf287ff1a1b2b0cafaf7L35-R36))