### PR TITLE
docs(repo): integrate link checker and fix broken links

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
 import mailObfuscation from 'astro-mail-obfuscation';
 import mermaid from 'astro-mermaid';
+import starlightLinksValidator from 'starlight-links-validator';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
 const UMAMI_URL = process.env.UMAMI_URL;
@@ -100,6 +101,7 @@ export default defineConfig({
         starlightLlmsTxt({
           projectName: 'Thymian',
         }),
+        starlightLinksValidator(),
       ],
     }),
     mailObfuscation({

--- a/astro-docs/package.json
+++ b/astro-docs/package.json
@@ -12,6 +12,7 @@
     "astro-og-canvas": "^0.7.2",
     "mermaid": "^11.10.1",
     "sharp": "^0.34.2",
+    "starlight-links-validator": "^0.19.2",
     "starlight-llms-txt": "^0.6.0",
     "starlight-versions": "^0.5.4",
     "tailwindcss": "^4.1.12"

--- a/astro-docs/src/content/docs/concepts/rule-types.md
+++ b/astro-docs/src/content/docs/concepts/rule-types.md
@@ -390,4 +390,3 @@ type('static', 'test', 'analytics')  // Validate everywhere
 
 - Learn about [combining rule types](/guides/http-rules/combining-types/) for hybrid validation
 - Explore [how to use rules](/guides/http-rules/how-to-use-rules/) in your projects
-- See the [CLI reference](/references/plugins/http-linter/cli/) for rule management commands

--- a/astro-docs/src/content/docs/concepts/what-is-an-http-rule.md
+++ b/astro-docs/src/content/docs/concepts/what-is-an-http-rule.md
@@ -245,5 +245,5 @@ If they diverge, violations are reported in one context or the other.
 Now that you understand what HTTP rules are and how they work:
 
 - Learn [how to create your own rules](/guides/http-rules/creating-new-rules/)
-- Explore [rule types in depth](/references/plugins/http-linter/rule-types/)
+- Explore [rule types in depth](/concepts/rule-types/)
 - Discover [hybrid rule patterns](/guides/http-rules/combining-types/)

--- a/astro-docs/src/content/docs/guides/HTTP rules/combining-types.md
+++ b/astro-docs/src/content/docs/guides/HTTP rules/combining-types.md
@@ -404,4 +404,4 @@ httpRule('request-requirements') // Too broad
 ## Next Steps
 
 - See [how to use rules](/guides/http-rules/how-to-use-rules/) in your projects
-- Explore the [CLI tools](/references/plugins/http-linter/cli/) for managing rules
+- Explore the [CLI tools](/references/cli/) for managing rules

--- a/astro-docs/src/content/docs/guides/HTTP rules/creating-new-rules.md
+++ b/astro-docs/src/content/docs/guides/HTTP rules/creating-new-rules.md
@@ -310,6 +310,6 @@ or(method('GET'), method('POST'));
 
 Now that you know how to create rules:
 
-- Explore [rule types in depth](/references/plugins/http-linter/rule-types/) to understand context-specific features
+- Explore [rule types in depth](/concepts/rule-types/) to understand context-specific features
 - Learn about [combining rule types](/guides/http-rules/combining-types/) for hybrid rules
 - See [how to use rules](/guides/http-rules/how-to-use-rules/) in your projects

--- a/astro-docs/src/content/docs/guides/HTTP rules/how-to-use-rules.md
+++ b/astro-docs/src/content/docs/guides/HTTP rules/how-to-use-rules.md
@@ -141,6 +141,6 @@ tsc --noEmit
 
 ## Next Steps
 
-- Explore the [CLI commands](/references/plugins/http-linter/cli/) for managing rules
+- Explore the [CLI commands](/references/cli/) for managing rules
 - Learn about [creating custom rules](/guides/http-rules/creating-new-rules/)
 - See [combining rule types](/guides/http-rules/combining-types/) for hybrid validation

--- a/astro-docs/src/content/docs/guides/HTTP rules/use-linting-to-validate-your-apis.md
+++ b/astro-docs/src/content/docs/guides/HTTP rules/use-linting-to-validate-your-apis.md
@@ -108,13 +108,13 @@ Rules can target one or more contexts, and the linter automatically adapts the v
 
 1. [What is an HTTP Rule?](/concepts/what-is-an-http-rule/) — Core concepts and rule anatomy
 2. [Creating New Rules](/guides/http-rules/creating-new-rules/) — Step-by-step guide to writing rules
-3. [Rule Types](/references/plugins/http-linter/rule-types/) — Understanding static, test, and analytics contexts
+3. [Rule Types](/concepts/rule-types/) — Understanding static, test, and analytics contexts
 4. [Combining Different Rule Types](/guides/http-rules/combining-types/) — Writing hybrid rules
 5. [How To Use Rules](/guides/http-rules/how-to-use-rules/) — Integration and configuration
-6. [CLI](/references/plugins/http-linter/cli/) — Command-line tools reference
+6. [CLI](/references/cli/) — Command-line tools reference
 
 ## Next Steps
 
 - Learn about [HTTP rule fundamentals](/concepts/what-is-an-http-rule/)
 - Follow the guide to [create your first rule](/guides/http-rules/creating-new-rules/)
-- Explore the [CLI tools](/references/plugins/http-linter/cli/) for rule generation and management
+- Explore the [CLI tools](/references/cli/) for rule generation and management

--- a/json2md-partials/element.md
+++ b/json2md-partials/element.md
@@ -1,7 +1,6 @@
 {{#if path~}}
-<a name="{{{tolink (or path 'root')}}}"></a>
-{{/if~}}
-{{#if path}}{{{mdlevel path}}} {{escape path}}: {{escape (or title (or type 'any'))}}{{/if}}
+<h{{mdlevelnumber path}} id="{{{tolink (or path 'root')}}}">{{escape path}}: {{escape (or title (or type 'any'))}}</h{{mdlevelnumber path}}>
+{{/if}}
 
 {{#if deprecated}}(DEPRECATED){{/if}}
 

--- a/json2md-partials/element.md
+++ b/json2md-partials/element.md
@@ -1,5 +1,5 @@
 {{#if path~}}
-<h{{mdlevelnumber path}} id="{{{tolink (or path 'root')}}}">{{escape path}}: {{escape (or title (or type 'any'))}}</h{{mdlevelnumber path}}>
+<h{{mdlevelnumber path}} id="{{{tolink (or path 'root')}}}">{{path}}: {{or title (or type 'any')}}</h{{mdlevelnumber path}}>
 {{/if}}
 
 {{#if deprecated}}(DEPRECATED){{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "astro-og-canvas": "^0.7.2",
         "mermaid": "^11.10.1",
         "sharp": "^0.34.2",
+        "starlight-links-validator": "^0.19.2",
         "starlight-llms-txt": "^0.6.0",
         "starlight-versions": "^0.5.4",
         "tailwindcss": "^4.1.12"
@@ -10052,6 +10053,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/picomatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==",
+      "license": "MIT"
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -16535,7 +16542,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19867,6 +19873,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -31198,6 +31216,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/starlight-links-validator": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.19.2.tgz",
+      "integrity": "sha512-IHeK3R78fsmv53VfRkGbXkwK1CQEUBHM9QPzBEyoAxjZ/ssi5gjV+F4oNNUppTR48iPp+lEY0MTAmvkX7yNnkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/picomatch": "^3.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-has-property": "^3.0.0",
+        "is-absolute-url": "^4.0.1",
+        "kleur": "^4.1.5",
+        "mdast-util-mdx-jsx": "^3.1.3",
+        "mdast-util-to-string": "^4.0.0",
+        "picomatch": "^4.0.2",
+        "terminal-link": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.17.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32.0",
+        "astro": ">=5.1.5"
+      }
+    },
+    "node_modules/starlight-links-validator/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/starlight-llms-txt": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.6.1.tgz",
@@ -31676,6 +31729,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -31831,6 +31924,37 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/terminal-link": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-5.0.0.tgz",
+      "integrity": "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "supports-hyperlinks": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",
@@ -34934,6 +35058,7 @@
         "@oclif/plugin-plugins": "^5.4.43",
         "@oclif/plugin-version": "^2.2.30",
         "@thymian/common-cli": "0.0.0-PLACEHOLDER",
+        "@thymian/core": "0.0.0-PLACEHOLDER",
         "@thymian/plugin-http-analyzer": "0.0.0-PLACEHOLDER",
         "@thymian/plugin-http-linter": "0.0.0-PLACEHOLDER",
         "@thymian/plugin-http-tester": "0.0.0-PLACEHOLDER",

--- a/packages/plugin-websocket-proxy/project.json
+++ b/packages/plugin-websocket-proxy/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "generate-schema-docs": {
       "dependsOn": ["build"],
-      "command": "node scripts/generate-schema-docs.js @thymian/plugin-websocket-proxy astro-docs/src/content/docs/references/Plugins/WebSocket\\ Proxy/options.md"
+      "command": "node scripts/generate-schema-docs.js @thymian/plugin-websocket-proxy astro-docs/src/content/docs/references/Plugins/Websocket\\ Proxy/options.md"
     }
   }
 }

--- a/scripts/jsonschema2mk/nobr-in-table.cjs
+++ b/scripts/jsonschema2mk/nobr-in-table.cjs
@@ -13,4 +13,17 @@ module.exports = function (data, jsonschema2mk) {
       .join(', ');
     return new jsonschema2mk.Handlebars.SafeString(result);
   });
+
+  // Returns the numeric heading level for a given path.
+  // Used to generate HTML heading tags with explicit id attributes
+  // instead of <a name="..."> anchors (which starlight-links-validator
+  // does not recognize).
+  jsonschema2mk.Handlebars.registerHelper('mdlevelnumber', function (path) {
+    const helper = require('jsonschema2mk/helper');
+    let level = 1;
+    if (path && path !== 'root') {
+      level = path.split(/\./).length + 1;
+    }
+    return level + helper.level_plus;
+  });
 };


### PR DESCRIPTION
This pull request introduces improvements to the Astro documentation site, focusing on internal link validation, documentation structure, and minor code enhancements. The most significant update is the addition of the `starlight-links-validator` plugin, which helps ensure that all internal links are valid. To support this, the documentation markdown generation was updated to use semantic HTML headings with IDs instead of legacy anchor tags, improving compatibility with the validator. Several documentation links were also updated for clarity and consistency.

**Internal link validation and compatibility:**

* Added the `starlight-links-validator` plugin to the Astro config and project dependencies to automatically check for broken internal links. (`astro-docs/astro.config.mjs`, `astro-docs/package.json`) [[1]](diffhunk://#diff-46cc48f1d0de65564b54fdac367935f49c6cb4b4c8755d9027438b4464ddad95R7) [[2]](diffhunk://#diff-46cc48f1d0de65564b54fdac367935f49c6cb4b4c8755d9027438b4464ddad95R104) [[3]](diffhunk://#diff-27b72e876aeb683f1d09e69f57873d35c9f1b56e782ba86c830ef4af8a5279a5R15)
* Updated the Handlebars template and helper in the markdown generator to replace `<a name="...">` anchors with semantic heading tags (`<hN id="...">`), ensuring compatibility with the link validator. (`json2md-partials/element.md`, `scripts/jsonschema2mk/nobr-in-table.cjs`) [[1]](diffhunk://#diff-60ac5ce6f35b42c78b63b00b005e8c377dbc130b07319da09715909b726ff4d1L2-R3) [[2]](diffhunk://#diff-21c4670c33d5a49bae97a4480f673ecb0f3cdcfab85ffd9c5adb52d0b4d2e4e0R16-R28)

**Documentation improvements:**

* Updated multiple documentation files to use the new `/concepts/rule-types/` and `/references/cli/` links instead of outdated plugin-specific references, ensuring consistency and reducing broken links. (`astro-docs/src/content/docs/concepts/what-is-an-http-rule.md`, `astro-docs/src/content/docs/guides/HTTP rules/combining-types.md`, `astro-docs/src/content/docs/guides/HTTP rules/creating-new-rules.md`, `astro-docs/src/content/docs/guides/HTTP rules/how-to-use-rules.md`, `astro-docs/src/content/docs/guides/HTTP rules/use-linting-to-validate-your-apis.md`) [[1]](diffhunk://#diff-6eb6006b0a6aa417df6c6978cf0d18bdb562c5e4cef7e39836d178caeedc1865L248-R248) [[2]](diffhunk://#diff-54c8114d224b3d30524d0e811f8ad3a3d718128678c2b15482af57ad8aaa6667L407-R407) [[3]](diffhunk://#diff-c1a5c48f286c5182f1e6f4316e5f77e8ac304c17ed1e9b3db8adbebc9db25294L313-R313) [[4]](diffhunk://#diff-dfc7fa31de583097525bb94bb5b537272dd5161287e90bd3b96a3c085fe21166L144-R144) [[5]](diffhunk://#diff-152eef0d07751660e1bba06d1f81707ff5b47c37a68bf70f8f6fb3568e8d9415L111-R120) [[6]](diffhunk://#diff-a3a239f3168a0aee17f4adc96f17a20e59e9a9c67d9eb98a815c7ee3b684b67fL393)

These changes collectively improve the documentation site's reliability, maintainability, and user experience.