### PR TITLE
fix(plugin-sampler): rewrite check command to use httpTest pipeline

### DIFF
--- a/astro-docs/src/content/docs/concepts/types-file.md
+++ b/astro-docs/src/content/docs/concepts/types-file.md
@@ -11,7 +11,7 @@ The `types.d.ts` file provides TypeScript type definitions for making HTTP reque
 
 ## How It Works
 
-When you run `thymian sampler:init`, the sampler plugin analyzes your OpenAPI specification(s) and generates TypeScript types for every endpoint.
+When you run `thymian sampler init`, the sampler plugin analyzes your OpenAPI specification(s) and generates TypeScript types for every endpoint.
 
 ### Example
 
@@ -41,7 +41,7 @@ The `types.d.ts` file generates:
 ```typescript
 declare module '@thymian/hooks' {
   interface Endpoints {
-    'POST http://localhost:3000/api/v1/launches': {
+    'POST http://localhost:3000/launches': {
       req: {
         body: {
           missionName: string;
@@ -72,7 +72,7 @@ import { BeforeEachRequestHook } from '@thymian/hooks';
 
 const hook: BeforeEachRequestHook = async (request, context, utils) => {
   // TypeScript knows the structure of this request
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: {
       missionName: 'Apollo 11', // ✓ Type-checked
       launchDate: '2026-01-01T00:00:00Z', // ✓ Type-checked
@@ -100,7 +100,7 @@ export default hook;
 
 ### Reasons
 
-1. **Auto-generated**: The file is regenerated every time you run `thymian sampler:init`
+1. **Auto-generated**: The file is regenerated every time you run `thymian sampler init`
 2. **Derived from spec**: Types are calculated from your OpenAPI specification
 3. **Overwritten**: Manual changes will be lost on the next regeneration
 
@@ -109,13 +109,13 @@ export default hook;
 The `types.d.ts` file is regenerated when you run:
 
 ```bash
-thymian sampler:init
+thymian sampler init
 ```
 
 Or:
 
 ```bash
-thymian sampler:init --overwrite
+thymian sampler init --overwrite
 ```
 
 ## Working Without Types
@@ -125,7 +125,7 @@ If your project doesn't use TypeScript, you can ignore `types.d.ts`. Write hooks
 ```javascript
 // hook.beforeEach.js
 const hook = async (request, context, utils) => {
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: {
       missionName: 'Apollo 11',
       launchDate: '2026-01-01T00:00:00Z',

--- a/astro-docs/src/content/docs/guides/Hooks/make-requests-in-hooks.mdx
+++ b/astro-docs/src/content/docs/guides/Hooks/make-requests-in-hooks.mdx
@@ -29,7 +29,7 @@ import { BeforeEachRequestHook } from '@thymian/hooks';
 
 const hook: BeforeEachRequestHook = async (request, context, utils) => {
   const response = await utils.request(
-    'POST http://localhost:3000/api/v1/launches',
+    'POST http://localhost:3000/launches',
     {
       body: {
         missionName: 'Apollo 11',
@@ -63,9 +63,9 @@ Your IDE suggests available endpoints:
 
 ```typescript
 // Type "utils.request('" and get autocomplete:
-utils.request('POST http://localhost:3000/api/v1/launches', ...)
-utils.request('GET http://localhost:3000/api/v1/launches', ...)
-utils.request('GET http://localhost:3000/api/v1/astronauts', ...)
+utils.request('POST http://localhost:3000/launches', ...)
+utils.request('GET http://localhost:3000/launches', ...)
+utils.request('GET http://localhost:3000/astronauts', ...)
 ```
 
 ### Type-Checked Request Bodies
@@ -73,7 +73,7 @@ utils.request('GET http://localhost:3000/api/v1/astronauts', ...)
 Request bodies are validated against your API schema:
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: {
     missionName: 'Apollo 11',     // ✓ Valid
     launchDate: '2026-12-31T00:00:00Z',  // ✓ Valid
@@ -91,7 +91,7 @@ const response = await utils.request('POST http://localhost:3000/api/v1/launches
 Response bodies are typed based on your OpenAPI responses:
 
 ```typescript
-const response = await utils.request('GET http://localhost:3000/api/v1/launches', {});
+const response = await utils.request('GET http://localhost:3000/launches', {});
 
 // TypeScript knows the response structure
 if (response.statusCode === 200) {
@@ -109,7 +109,7 @@ if (response.statusCode === 200) {
 By default, `utils.request()` runs all hooks (beforeEach, authorize, afterEach) for the target endpoint. Disable this to prevent infinite loops:
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/astronauts', {
+const response = await utils.request('POST http://localhost:3000/astronauts', {
   body: { name: 'Buzz Aldrin', password: 'secret', role: 'Pilot' },
   headers: { 'content-type': 'application/json' }
 }, {
@@ -124,7 +124,7 @@ const response = await utils.request('POST http://localhost:3000/api/v1/astronau
 Skip only the authorize hook while keeping other hooks:
 
 ```typescript
-const response = await utils.request('GET http://localhost:3000/api/v1/launches', {}, {
+const response = await utils.request('GET http://localhost:3000/launches', {}, {
   authorize: false  // Skip authorize, but run beforeEach/afterEach
 });
 ```
@@ -137,7 +137,7 @@ If an endpoint has multiple response samples (e.g., 200, 404), specify which one
 
 ```typescript
 // Request the 404 response sample
-const response = await utils.request('GET http://localhost:3000/api/v1/launches/123', {}, {
+const response = await utils.request('GET http://localhost:3000/launches/123', {}, {
   forStatusCode: 404
 });
 ```
@@ -153,7 +153,7 @@ const response = await utils.request('GET http://localhost:3000/api/v1/launches/
 Always verify responses succeeded:
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: { /* ... */ },
   headers: { 'content-type': 'application/json' }
 });
@@ -166,7 +166,7 @@ if (response.statusCode !== 201) {
 ### Handle Missing Resources
 
 ```typescript
-const response = await utils.request('GET http://localhost:3000/api/v1/launches/123', {});
+const response = await utils.request('GET http://localhost:3000/launches/123', {});
 
 if (response.statusCode === 404) {
   utils.skip('Launch not found, skipping test');
@@ -177,7 +177,7 @@ if (response.statusCode === 404) {
 
 ```typescript
 try {
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: { /* ... */ },
     headers: { 'content-type': 'application/json' }
   });
@@ -205,12 +205,12 @@ The URL must exactly match the format: `METHOD http://host:port/path`
 
 ```typescript
 // ✓ Correct
-utils.request('POST http://localhost:3000/api/v1/launches', ...)
+utils.request('POST http://localhost:3000/launches', ...)
 
 // ✗ Incorrect - Missing method
-utils.request('http://localhost:3000/api/v1/launches', ...)
+utils.request('http://localhost:3000/launches', ...)
 
 // ✗ Incorrect - Wrong format
-utils.request('localhost:3000/api/v1/launches', ...)
+utils.request('localhost:3000/launches', ...)
 ```
 

--- a/astro-docs/src/content/docs/guides/Hooks/skip-and-fail-tests.mdx
+++ b/astro-docs/src/content/docs/guides/Hooks/skip-and-fail-tests.mdx
@@ -31,7 +31,7 @@ Use `utils.skip()` when a test cannot run due to missing preconditions.
 import { BeforeEachRequestHook } from '@thymian/hooks';
 
 const hook: BeforeEachRequestHook = async (request, context, utils) => {
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: {
       missionName: utils.randomString(10),
       launchDate: '2026-12-31T00:00:00Z',
@@ -81,7 +81,7 @@ Use `utils.fail()` when a test should explicitly fail due to invalid conditions.
 import { BeforeEachRequestHook } from '@thymian/hooks';
 
 const hook: BeforeEachRequestHook = async (request, context, utils) => {
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: {
       missionName: utils.randomString(10),
       launchDate: '2026-12-31T00:00:00Z',
@@ -125,7 +125,7 @@ utils.skip('Resource unavailable');
 
 **Output:**
 ```
-GET /api/v1/launches/123
+GET /launches/123
   ⊘ Skipped: Resource unavailable
 ```
 
@@ -143,7 +143,7 @@ utils.fail('Invalid response structure');
 
 **Output:**
 ```
-GET /api/v1/launches/123
+GET /launches/123
   ✗ Failed: Invalid response structure
 ```
 

--- a/astro-docs/src/content/docs/guides/Hooks/write-hooks.mdx
+++ b/astro-docs/src/content/docs/guides/Hooks/write-hooks.mdx
@@ -25,7 +25,7 @@ BeforeEach hooks modify request data before sending HTTP requests.
 Use the CLI to generate a hook template:
 
 ```bash
-thymian sampler:hooks:generate
+thymian sampler generate hook
 ```
 
 This command lets you choose for which transactions you want to create a hook file interactively. It also generates
@@ -75,7 +75,7 @@ for which the `authorize` property in the corresponding `request.json` file is s
 ### Generate the Hook File
 
 ```bash
-thymian sampler:hooks:generate
+thymian sampler generate hook
 ```
 
 Choose "authorize" when prompted.
@@ -91,7 +91,7 @@ const hook: AuthorizeHook = async (request, context, utils) => {
   const password = utils.randomString(12);
 
   // Create user account
-  const response = await utils.request('POST http://localhost:3000/api/v1/astronauts', {
+  const response = await utils.request('POST http://localhost:3000/astronauts', {
     body: { name: username, password, role: 'Commander' },
     headers: { 'content-type': 'application/json' }
   }, {
@@ -115,7 +115,7 @@ AfterEach hooks validate responses and perform cleanup.
 ### Generate the Hook File
 
 ```bash
-thymian sampler:hooks:generate
+thymian sampler generate hook
 ```
 
 Choose "afterEach" when prompted.

--- a/astro-docs/src/content/docs/guides/Samples/update-samples.mdx
+++ b/astro-docs/src/content/docs/guides/Samples/update-samples.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 Error Message:
 
 ```
-Cannot sample for transaction "GET /api/v1/launches -> 200",
+Cannot sample for transaction "GET /launches -> 200",
 because it based on version "abc123" but the loaded samples
 are based on version "def456".
 ```

--- a/astro-docs/src/content/docs/references/Errors/invalid-sample-json-error.md
+++ b/astro-docs/src/content/docs/references/Errors/invalid-sample-json-error.md
@@ -45,5 +45,5 @@ To fix this:
 3. Or regenerate the samples:
 
 ```bash
-thymian sampler:init --overwrite
+thymian sampler init --overwrite
 ```

--- a/astro-docs/src/content/docs/references/Errors/invalid-sample-timestamp-error.md
+++ b/astro-docs/src/content/docs/references/Errors/invalid-sample-timestamp-error.md
@@ -13,7 +13,7 @@ The samples metadata includes a timestamp that tracks when the samples were gene
 To fix this, regenerate your samples:
 
 ```bash
-thymian sampler:init --overwrite
+thymian sampler init --overwrite
 ```
 
 This will create fresh samples with a valid timestamp.

--- a/astro-docs/src/content/docs/references/Errors/path-already-exists-error.md
+++ b/astro-docs/src/content/docs/references/Errors/path-already-exists-error.md
@@ -19,7 +19,7 @@ rm -rf path/to/samples
 2. **Use overwrite mode** when initializing:
 
 ```bash
-thymian sampler:init --overwrite
+thymian sampler init --overwrite
 ```
 
 The `--overwrite` flag tells Thymian to replace existing files instead of failing when they already exist. Use this when you want to regenerate samples and replace the old ones.

--- a/astro-docs/src/content/docs/references/Errors/samples-not-loaded-error.md
+++ b/astro-docs/src/content/docs/references/Errors/samples-not-loaded-error.md
@@ -19,7 +19,7 @@ To resolve this:
 1. Generate samples if you haven't already:
 
 ```bash
-thymian sampler:init
+thymian sampler init
 ```
 
 2. Ensure the samples directory exists and contains the generated sample files

--- a/astro-docs/src/content/docs/references/Errors/transaction-sample-not-found-error.md
+++ b/astro-docs/src/content/docs/references/Errors/transaction-sample-not-found-error.md
@@ -17,7 +17,7 @@ This can happen when:
 To resolve this, regenerate your samples:
 
 ```bash
-thymian sampler:init
+thymian sampler init
 ```
 
 This will create new samples for all transactions in your format, including the one that's currently missing.

--- a/astro-docs/src/content/docs/references/Errors/unknown-content-source-type-error.md
+++ b/astro-docs/src/content/docs/references/Errors/unknown-content-source-type-error.md
@@ -13,7 +13,7 @@ This error typically indicates internal data corruption or a bug in how samples 
 If you encounter this error, try regenerating your samples:
 
 ```bash
-thymian sampler:init
+thymian sampler init
 ```
 
 If the error persists, it may indicate a bug that should be reported.

--- a/astro-docs/src/content/docs/references/Plugins/Sampler/hooks-api.md
+++ b/astro-docs/src/content/docs/references/Plugins/Sampler/hooks-api.md
@@ -127,7 +127,7 @@ Promise resolving to response object:
 Basic request:
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: {
     missionName: 'Apollo 11',
     launchDate: '2026-12-31T00:00:00Z',
@@ -143,7 +143,7 @@ Request without hooks:
 
 ```typescript
 const response = await utils.request(
-  'POST http://localhost:3000/api/v1/astronauts',
+  'POST http://localhost:3000/astronauts',
   {
     body: { name: 'Buzz', password: 'secret', role: 'Pilot' },
     headers: { 'content-type': 'application/json' },
@@ -158,7 +158,7 @@ Request specific status code:
 
 ```typescript
 const response = await utils.request(
-  'GET http://localhost:3000/api/v1/launches/123',
+  'GET http://localhost:3000/launches/123',
   {},
   {
     forStatusCode: 404, // Use 404 response sample
@@ -181,7 +181,7 @@ skip(message: string): never
 #### Example
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: {
     /* ... */
   },
@@ -208,7 +208,7 @@ fail(message: string): never
 #### Example
 
 ```typescript
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: {
     /* ... */
   },
@@ -240,7 +240,7 @@ info(message: string): void
 
 ```typescript
 utils.info('Creating test user');
-const response = await utils.request('POST http://localhost:3000/api/v1/astronauts', {
+const response = await utils.request('POST http://localhost:3000/astronauts', {
   body: {
     /* ... */
   },
@@ -252,7 +252,7 @@ utils.info(`User created with ID: ${response.body.id}`);
 **Output:**
 
 ```
-POST /api/v1/launches
+POST /launches
   ℹ Creating test user
   ℹ User created with ID: abc123
   ✓ 201 Created (15ms)
@@ -282,7 +282,7 @@ if (response.headers['x-rate-limit-remaining'] === '1') {
 **Output:**
 
 ```
-POST /api/v1/launches
+POST /launches
   ⚠ Rate limit almost exhausted (Only 1 request remaining)
   ✓ 201 Created (15ms)
 ```
@@ -303,7 +303,7 @@ assertionSuccess(message: string, assertion?: string): void
 #### Example
 
 ```typescript
-const response = await utils.request('GET http://localhost:3000/api/v1/launches', {});
+const response = await utils.request('GET http://localhost:3000/launches', {});
 
 if (response.body.length > 0) {
   utils.assertionSuccess('Response contains launches', 'has launches');
@@ -313,7 +313,7 @@ if (response.body.length > 0) {
 **Output:**
 
 ```
-GET /api/v1/launches
+GET /launches
   ✓ has launches
   ✓ 200 OK (8ms)
 ```
@@ -366,7 +366,7 @@ if (!body.missionName) {
 **Output:**
 
 ```
-POST /api/v1/launches
+POST /launches
   ✗ has id (expected: "id field present", actual: "id field missing")
   ✗ has missionName (expected: "missionName field present", actual: "missionName field missing")
   ✓ 201 Created (12ms)
@@ -389,7 +389,7 @@ timeout(message: string, durationMs: number): void
 
 ```typescript
 const start = Date.now();
-const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+const response = await utils.request('POST http://localhost:3000/launches', {
   body: {
     /* ... */
   },

--- a/astro-docs/src/content/docs/references/Plugins/Sampler/request-format.mdx
+++ b/astro-docs/src/content/docs/references/Plugins/Sampler/request-format.mdx
@@ -16,7 +16,7 @@ Each endpoint has a `request.json` file that defines the HTTP request to send:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "POST",
   "authorize": false,
   "headers": {
@@ -60,9 +60,9 @@ The endpoint path, including path parameters.
 **Examples:**
 
 ```json
-"path": "/api/v1/launches"
-"path": "/api/v1/launches/123"
-"path": "/api/v1/users/abc/posts/xyz"
+"path": "/launches"
+"path": "/launches/123"
+"path": "/users/abc/posts/xyz"
 ```
 
 <Aside type="note">
@@ -167,19 +167,19 @@ Values for path parameters defined in the endpoint.
 
 **Examples:**
 
-For path `/api/v1/launches/{id}`:
+For path `/launches/{id}`:
 
 ```jsonc
-"path": "/api/v1/launches/{id}",
+"path": "/launches/{id}",
 "pathParameters": {
   "id": "abc123"
 }
 ```
 
-For path `/api/v1/users/{userId}/posts/{postId}`:
+For path `/users/{userId}/posts/{postId}`:
 
 ```jsonc
-"path": "/api/v1/users/{userId}/posts/{postId}",
+"path": "/users/{userId}/posts/{postId}",
 "pathParameters": {
   "userId": "user-123",
   "postId": "post-456"
@@ -218,7 +218,7 @@ Query parameters to include in the request URL.
 }
 ```
 
-**Result:** `GET /api/v1/launches?limit=10&offset=0&sort=createdAt`
+**Result:** `GET /launches?limit=10&offset=0&sort=createdAt`
 
 ### `body`
 
@@ -354,7 +354,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "POST",
   "authorize": false,
   "headers": {
@@ -383,7 +383,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "GET",
   "authorize": true,
   "headers": {
@@ -404,7 +404,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "POST",
   "authorize": true,
   "headers": {
@@ -426,7 +426,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches/{id}",
+  "path": "/launches/{id}",
   "method": "PUT",
   "authorize": true,
   "headers": {
@@ -449,7 +449,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches/{id}",
+  "path": "/launches/{id}",
   "method": "DELETE",
   "authorize": true,
   "headers": {},
@@ -466,7 +466,7 @@ Create a file in the same directory as `request.json`:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "GET",
   "authorize": true,
   "headers": {

--- a/astro-docs/src/content/docs/tutorials/sampler-getting-started.mdx
+++ b/astro-docs/src/content/docs/tutorials/sampler-getting-started.mdx
@@ -128,7 +128,7 @@ You'll see auto-generated sample data:
 ```json
 {
   "origin": "http://localhost:3000",
-  "path": "/api/v1/launches",
+  "path": "/launches",
   "method": "post",
   "authorize": true,
   "headers": {
@@ -179,20 +179,20 @@ npx thymian sampler check --spec openapi:openapi.yaml
 **Expected result:** Most tests will fail because of a `401 Unauthorized` response because the API requires authentication.
 
 ```
-✖ GET /api/v1/launches → 200 OK - application/json
-✖ POST /api/v1/launches - application/json → 201 CREATED - application/json
-✖ GET /api/v1/launches/{id} → 200 OK - application/json
-✖ GET /api/v1/launches/{id} → 404 NOT FOUND
-✖ PUT /api/v1/launches/{id} - application/json → 200 OK - application/json
-✖ DELETE /api/v1/launches/{id} → 204 NO CONTENT
-✖ DELETE /api/v1/launches/{id} → 404 NOT FOUND
-✖ GET /api/v1/astronauts → 200 OK - application/json
-✔ POST /api/v1/astronauts - application/json → 201 CREATED - application/json
-✖ GET /api/v1/astronauts/{id} → 200 OK - application/json
-✖ GET /api/v1/astronauts/{id} → 404 NOT FOUND
-✖ PUT /api/v1/astronauts/{id} - application/json → 200 OK - application/json
-✖ DELETE /api/v1/astronauts/{id} → 204 NO CONTENT
-✖ DELETE /api/v1/astronauts/{id} → 404 NOT FOUND
+✖ GET /launches → 200 OK - application/json
+✖ POST /launches - application/json → 201 CREATED - application/json
+✖ GET /launches/{id} → 200 OK - application/json
+✖ GET /launches/{id} → 404 NOT FOUND
+✖ PUT /launches/{id} - application/json → 200 OK - application/json
+✖ DELETE /launches/{id} → 204 NO CONTENT
+✖ DELETE /launches/{id} → 404 NOT FOUND
+✖ GET /astronauts → 200 OK - application/json
+✔ POST /astronauts - application/json → 201 CREATED - application/json
+✖ GET /astronauts/{id} → 200 OK - application/json
+✖ GET /astronauts/{id} → 404 NOT FOUND
+✖ PUT /astronauts/{id} - application/json → 200 OK - application/json
+✖ DELETE /astronauts/{id} → 204 NO CONTENT
+✖ DELETE /astronauts/{id} → 404 NOT FOUND
 
 Checked 14 transactions. 13 failed.
 ```
@@ -213,8 +213,8 @@ Then we implement the hook:
 import { AuthorizeHook } from '@thymian/hooks';
 
 const hook: AuthorizeHook = async (request, context, utils) => {
-  // if a new austronaut is being created, skip authentication
-  if (context.thymianReq.path === '/api/v1/austronauts' && context.thymianReq.method === 'POST') {
+  // if a new astronaut is being created, skip authentication
+  if (context.thymianReq.path === '/astronauts' && context.thymianReq.method === 'POST') {
     return request;
   }
 
@@ -223,7 +223,7 @@ const hook: AuthorizeHook = async (request, context, utils) => {
   const password = utils.randomString(12);
 
   // Create a test user
-  const response = await utils.request('POST http://localhost:3000/api/v1/astronauts', {
+  const response = await utils.request('POST http://localhost:3000/astronauts', {
     body: {
       name: username,
       password: password,
@@ -267,20 +267,20 @@ We should now see that most requests can be run. The only ones that fail request
 `id` for a resource.
 
 ```
-✔ GET /api/v1/launches → 200 OK - application/json
-✔ POST /api/v1/launches - application/json → 201 CREATED - application/json
-✖ GET /api/v1/launches/{id} → 200 OK - application/json                      <-- Missing ID
-✔ GET /api/v1/launches/{id} → 404 NOT FOUND
-✔ PUT /api/v1/launches/{id} - application/json → 200 OK - application/json
-✖ DELETE /api/v1/launches/{id} → 204 NO CONTENT                              <-- Missing ID
-✔ DELETE /api/v1/launches/{id} → 404 NOT FOUND
-✔ GET /api/v1/astronauts → 200 OK - application/json
-✔ POST /api/v1/astronauts - application/json → 201 CREATED - application/json
-✖ GET /api/v1/astronauts/{id} → 200 OK - application/json                    <-- Missing ID
-✔ GET /api/v1/astronauts/{id} → 404 NOT FOUND
-✔ PUT /api/v1/astronauts/{id} - application/json → 200 OK - application/json
-✖ DELETE /api/v1/astronauts/{id} → 204 NO CONTENT                            <-- Missing ID
-✔ DELETE /api/v1/astronauts/{id} → 404 NOT FOUND
+✔ GET /launches → 200 OK - application/json
+✔ POST /launches - application/json → 201 CREATED - application/json
+✖ GET /launches/{id} → 200 OK - application/json                      <-- Missing ID
+✔ GET /launches/{id} → 404 NOT FOUND
+✔ PUT /launches/{id} - application/json → 200 OK - application/json
+✖ DELETE /launches/{id} → 204 NO CONTENT                              <-- Missing ID
+✔ DELETE /launches/{id} → 404 NOT FOUND
+✔ GET /astronauts → 200 OK - application/json
+✔ POST /astronauts - application/json → 201 CREATED - application/json
+✖ GET /astronauts/{id} → 200 OK - application/json                    <-- Missing ID
+✔ GET /astronauts/{id} → 404 NOT FOUND
+✔ PUT /astronauts/{id} - application/json → 200 OK - application/json
+✖ DELETE /astronauts/{id} → 204 NO CONTENT                            <-- Missing ID
+✔ DELETE /astronauts/{id} → 404 NOT FOUND
 
 Checked 14 transactions. 4 failed.
 ```
@@ -309,7 +309,7 @@ const hook: BeforeEachRequestHook = async (request, context, utils) => {
   }
 
   // Create a launch
-  const response = await utils.request('POST http://localhost:3000/api/v1/launches', {
+  const response = await utils.request('POST http://localhost:3000/launches', {
     body: {
       missionName: utils.randomString(10),
       launchDate: '2026-12-31T00:00:00Z',
@@ -349,20 +349,20 @@ npx thymian sampler check --spec openapi:openapi.yaml
 **Expected result:**
 
 ```
-✔ GET /api/v1/launches → 200 OK - application/json
-✔ POST /api/v1/launches - application/json → 201 CREATED - application/json
-✔ GET /api/v1/launches/{id} → 200 OK - application/json
-✔ GET /api/v1/launches/{id} → 404 NOT FOUND
-✔ PUT /api/v1/launches/{id} - application/json → 200 OK - application/json
-✔ DELETE /api/v1/launches/{id} → 204 NO CONTENT
-✔ DELETE /api/v1/launches/{id} → 404 NOT FOUND
-✔ GET /api/v1/astronauts → 200 OK - application/json
-✔ POST /api/v1/astronauts - application/json → 201 CREATED - application/json
-✖ GET /api/v1/astronauts/{id} → 200 OK - application/json
-✔ GET /api/v1/astronauts/{id} → 404 NOT FOUND
-✔ PUT /api/v1/astronauts/{id} - application/json → 200 OK - application/json
-✖ DELETE /api/v1/astronauts/{id} → 204 NO CONTENT
-✔ DELETE /api/v1/astronauts/{id} → 404 NOT FOUND
+✔ GET /launches → 200 OK - application/json
+✔ POST /launches - application/json → 201 CREATED - application/json
+✔ GET /launches/{id} → 200 OK - application/json
+✔ GET /launches/{id} → 404 NOT FOUND
+✔ PUT /launches/{id} - application/json → 200 OK - application/json
+✔ DELETE /launches/{id} → 204 NO CONTENT
+✔ DELETE /launches/{id} → 404 NOT FOUND
+✔ GET /astronauts → 200 OK - application/json
+✔ POST /astronauts - application/json → 201 CREATED - application/json
+✖ GET /astronauts/{id} → 200 OK - application/json
+✔ GET /astronauts/{id} → 404 NOT FOUND
+✔ PUT /astronauts/{id} - application/json → 200 OK - application/json
+✖ DELETE /astronauts/{id} → 204 NO CONTENT
+✔ DELETE /astronauts/{id} → 404 NOT FOUND
 
 Checked 14 transactions. 2 failed.
 ```
@@ -391,7 +391,7 @@ const hook: BeforeEachRequestHook = async (request, context, utils) => {
   }
 
   // Create a launch
-  const response = await utils.request('POST http://localhost:3000/api/v1/astronauts', {
+  const response = await utils.request('POST http://localhost:3000/astronauts', {
     body: {
       name: utils.randomString(10),
       password: utils.randomString(12),
@@ -432,20 +432,20 @@ npx thymian sampler check --spec openapi:openapi.yaml
 Now you should see that all transactions can be run:
 
 ```
-✔ GET /api/v1/launches → 200 OK - application/json
-✔ POST /api/v1/launches - application/json → 201 CREATED - application/json
-✔ GET /api/v1/launches/{id} → 200 OK - application/json
-✔ GET /api/v1/launches/{id} → 404 NOT FOUND
-✔ PUT /api/v1/launches/{id} - application/json → 200 OK - application/json
-✔ DELETE /api/v1/launches/{id} → 204 NO CONTENT
-✔ DELETE /api/v1/launches/{id} → 404 NOT FOUND
-✔ GET /api/v1/astronauts → 200 OK - application/json
-✔ POST /api/v1/astronauts - application/json → 201 CREATED - application/json
-✔ GET /api/v1/astronauts/{id} → 200 OK - application/json
-✔ GET /api/v1/astronauts/{id} → 404 NOT FOUND
-✔ PUT /api/v1/astronauts/{id} - application/json → 200 OK - application/json
-✔ DELETE /api/v1/astronauts/{id} → 204 NO CONTENT
-✔ DELETE /api/v1/astronauts/{id} → 404 NOT FOUND
+✔ GET /launches → 200 OK - application/json
+✔ POST /launches - application/json → 201 CREATED - application/json
+✔ GET /launches/{id} → 200 OK - application/json
+✔ GET /launches/{id} → 404 NOT FOUND
+✔ PUT /launches/{id} - application/json → 200 OK - application/json
+✔ DELETE /launches/{id} → 204 NO CONTENT
+✔ DELETE /launches/{id} → 404 NOT FOUND
+✔ GET /astronauts → 200 OK - application/json
+✔ POST /astronauts - application/json → 201 CREATED - application/json
+✔ GET /astronauts/{id} → 200 OK - application/json
+✔ GET /astronauts/{id} → 404 NOT FOUND
+✔ PUT /astronauts/{id} - application/json → 200 OK - application/json
+✔ DELETE /astronauts/{id} → 204 NO CONTENT
+✔ DELETE /astronauts/{id} → 404 NOT FOUND
 
 Checked 14 transactions. 0 failed.
 ```

--- a/e2e-tests/src/cli-test.test.ts
+++ b/e2e-tests/src/cli-test.test.ts
@@ -15,7 +15,7 @@ import {
 import { getAvailablePort } from './port-utils.js';
 
 /**
- * Helper: copy a fixture to temp dir, run `sampler:init`, and start a test server.
+ * Helper: copy a fixture to temp dir, run `sampler init`, and start a test server.
  * Returns the server and its port so tests can use `--target-url`.
  */
 async function setupTestEnvironment(

--- a/packages/core/src/http-testing/operators/run-requests.operator.ts
+++ b/packages/core/src/http-testing/operators/run-requests.operator.ts
@@ -24,6 +24,8 @@ export type RunRequestsOptions = {
   checkBody: boolean;
   expectStatusCode?: number;
   authorize: boolean;
+  /** Override the origin of all request templates. When set, every request is sent to this origin instead of the one defined in the specification. */
+  origin?: string;
 };
 
 export function runRequests<
@@ -57,6 +59,13 @@ export function runRequests<
       }
 
       for (const transaction of step.transactions) {
+        if (options.origin) {
+          transaction.requestTemplate = {
+            ...transaction.requestTemplate,
+            origin: options.origin,
+          };
+        }
+
         const transactionName = transaction.source
           ? thymianHttpTransactionToString(
               transaction.source.thymianReq,

--- a/packages/plugin-sampler/src/cli/commands/sampler/check.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/check.ts
@@ -1,22 +1,21 @@
 import { BaseCliRunCommand, oclif, prompts } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
 import {
-  getHeader,
-  type HttpResponse,
-  httpStatusCodeToPhrase,
+  filterHttpTransactions,
+  generateRequests,
+  httpTest,
+  type HttpTestCase,
   isValidClientErrorStatusCode,
-  isValidHttpStatusCode,
   isValidSuccessfulStatusCode,
-  serializeRequest,
+  mapToTestCase,
+  type RequestFilterFn,
+  type ResponseFilterFn,
+  runRequests,
   type ThymianHttpTransaction,
   thymianHttpTransactionToString,
 } from '@thymian/core';
 
-type CheckResult =
-  | { passed: true }
-  | { passed: false; reason: string; response?: HttpResponse };
-
-const MAX_BODY_PREVIEW_LENGTH = 500;
+import { createContext } from '../../create-context.js';
 
 export default class Check extends BaseCliRunCommand<typeof Check> {
   static override description =
@@ -42,7 +41,7 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
   };
 
   override async run(): Promise<void> {
-    await this.thymian.run(async () => {
+    await this.thymian.run(async (emitter) => {
       const specifications = this.thymianConfig.specifications ?? [];
 
       const format = await this.thymian.loadFormat({
@@ -53,16 +52,27 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
       const targetUrl =
         this.flags['target-url'] ?? this.thymianConfig.targetUrl;
 
+      const context = createContext(
+        format,
+        this.logger.child('sampler-check'),
+        emitter,
+      );
+
       if (this.flags.incremental) {
-        await this.checkTransactionsIncremental(transactions, targetUrl);
+        await this.checkTransactionsIncremental(
+          transactions,
+          context,
+          targetUrl,
+        );
       } else {
-        await this.checkAllTransactions(transactions, targetUrl);
+        await this.checkAllTransactions(transactions, context, targetUrl);
       }
     });
   }
 
   private async checkAllTransactions(
     transactions: ThymianHttpTransaction[],
+    context: ReturnType<typeof createContext>,
     targetUrl?: string,
   ): Promise<void> {
     let successful = 0;
@@ -80,14 +90,20 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
 
       this.logger.debug('Checking transaction: ' + transactionName);
 
-      const result = await this.checkTransaction(transaction, targetUrl);
+      const testResult = await this.runTransaction(
+        transaction,
+        context,
+        targetUrl,
+      );
 
-      if (result.passed) {
+      const testCase = testResult.cases[0];
+
+      if (testCase && testCase.status === 'passed') {
         this.log(oclif.ux.colorize('green', `✔ ${transactionName}`));
         successful++;
       } else {
         this.log(oclif.ux.colorize('red', `✖ ${transactionName}`));
-        this.logFailureDetails(result);
+        this.logFailureDetails(testCase);
         this.log();
         failed++;
       }
@@ -112,6 +128,7 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
 
   private async checkTransactionsIncremental(
     transactions: ThymianHttpTransaction[],
+    context: ReturnType<typeof createContext>,
     targetUrl?: string,
   ): Promise<void> {
     for (const transaction of transactions) {
@@ -126,15 +143,21 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
 
       this.logger.debug('Checking transaction: ' + transactionName);
 
-      const result = await this.checkTransaction(transaction, targetUrl);
+      const testResult = await this.runTransaction(
+        transaction,
+        context,
+        targetUrl,
+      );
 
-      if (result.passed) {
+      const testCase = testResult.cases[0];
+
+      if (testCase && testCase.status === 'passed') {
         this.log(oclif.ux.colorize('green', `✔ ${transactionName}`));
         continue;
       }
 
       this.log(oclif.ux.colorize('red', `✖ ${transactionName}`));
-      this.logFailureDetails(result);
+      this.logFailureDetails(testCase);
 
       this.log();
       this.log('You can generate a hook for this transaction with:');
@@ -174,73 +197,50 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
     );
   }
 
-  private async checkTransaction(
+  private async runTransaction(
     transaction: ThymianHttpTransaction,
+    context: ReturnType<typeof createContext>,
     targetUrl?: string,
-  ): Promise<CheckResult> {
-    try {
-      const template = await this.thymian.sample({ transaction });
+  ) {
+    const transactionName = thymianHttpTransactionToString(
+      transaction.thymianReq,
+      transaction.thymianRes,
+    );
 
-      const request = serializeRequest({
-        requestTemplate: template,
-        source: transaction,
-      });
+    const reqFilter: RequestFilterFn = (_req, reqId) =>
+      reqId === transaction.thymianReqId;
+    const resFilter: ResponseFilterFn = (_res, resId) =>
+      resId === transaction.thymianResId;
 
-      if (targetUrl) {
-        request.origin = targetUrl;
-      }
-
-      const response = await this.thymian.dispatch({ request });
-
-      if (response.statusCode !== transaction.thymianRes.statusCode) {
-        return {
-          passed: false,
-          reason: `Expected status ${transaction.thymianRes.statusCode}, got ${response.statusCode}.`,
-          response,
-        };
-      }
-
-      return { passed: true };
-    } catch (error) {
-      return {
-        passed: false,
-        reason: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  private logFailureDetails(
-    result: Extract<CheckResult, { passed: false }>,
-  ): void {
-    this.log(oclif.ux.colorize('dim', `    Reason: ${result.reason}`));
-
-    if (!result.response) {
-      return;
-    }
-
-    const { statusCode, headers, body } = result.response;
-    const phrase = isValidHttpStatusCode(statusCode)
-      ? httpStatusCodeToPhrase[statusCode]
-      : '';
-    const contentType = getHeader(headers, 'content-type');
-    const contentTypeStr = Array.isArray(contentType)
-      ? contentType[0]
-      : contentType;
-
-    this.log(
-      oclif.ux.colorize(
-        'dim',
-        `    Received: ${statusCode} ${phrase}${contentTypeStr ? ` (${contentTypeStr})` : ''}`,
+    const test = httpTest(transactionName, (transactions) =>
+      transactions.pipe(
+        filterHttpTransactions(reqFilter, resFilter),
+        mapToTestCase(),
+        generateRequests(),
+        runRequests({ checkResponse: false, origin: targetUrl }),
       ),
     );
 
-    if (body) {
-      const preview =
-        body.length > MAX_BODY_PREVIEW_LENGTH
-          ? body.slice(0, MAX_BODY_PREVIEW_LENGTH) + '…'
-          : body;
+    return test(context);
+  }
 
-      this.log(oclif.ux.colorize('dim', `    Body: ${preview}`));
+  private logFailureDetails(testCase?: HttpTestCase): void {
+    if (!testCase) {
+      this.log(oclif.ux.colorize('dim', '    Reason: No test result.'));
+      return;
+    }
+
+    if (testCase.reason) {
+      this.log(oclif.ux.colorize('dim', `    Reason: ${testCase.reason}`));
+    }
+
+    for (const result of testCase.results) {
+      if (
+        result.type === 'assertion-failure' ||
+        result.type === 'invalid-transaction'
+      ) {
+        this.log(oclif.ux.colorize('dim', `    ${result.message}`));
+      }
     }
   }
 }

--- a/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
@@ -6,7 +6,7 @@ import { generateHook } from '../../../generate-hook.js';
 export default class GenerateHook extends BaseCliRunCommand<
   typeof GenerateHook
 > {
-  static override aliases = ['sampler:g:h', 'sampler:generate:h'];
+  static override aliases = ['sampler g h', 'sampler generate h'];
 
   static override flags = {
     'for-transaction': Flags.string({

--- a/packages/plugin-sampler/src/hooks/hook-runner.ts
+++ b/packages/plugin-sampler/src/hooks/hook-runner.ts
@@ -66,7 +66,7 @@ export class HookRunner {
         'Cannot run hooks before @thymian/plugin-sampler is initialized.',
         {
           name: 'HookRunnerNotInitialized',
-          suggestions: ['Did you run "thymian sampler:init"?'],
+          suggestions: ['Did you run "thymian sampler init"?'],
         },
       );
     }
@@ -132,7 +132,7 @@ export class HookRunner {
         'Cannot run hooks before @thymian/plugin-sampler is initialized.',
         {
           name: 'HookRunnerNotInitialized',
-          suggestions: ['Did you run "thymian sampler:init"?'],
+          suggestions: ['Did you run "thymian sampler init"?'],
         },
       );
     }
@@ -202,7 +202,7 @@ export class HookRunner {
         'Cannot run hooks before @thymian/plugin-sampler is initialized.',
         {
           name: 'HookRunnerNotInitialized',
-          suggestions: ['Did you run "thymian sampler:init"?'],
+          suggestions: ['Did you run "thymian sampler init"?'],
         },
       );
     }

--- a/packages/plugin-sampler/src/index.ts
+++ b/packages/plugin-sampler/src/index.ts
@@ -220,7 +220,7 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
               name: 'VersionMismatchError',
               suggestions: [
                 `The loaded samples were generated at ${requestSampler.timestamp()}. Did you forget to regenerate the samples?`,
-                '$ thymian sampler:init',
+                '$ thymian sampler init',
               ],
               ref: 'https://thymian.dev/guides/samples/update-samples',
             },

--- a/packages/plugin-sampler/src/request-sampler.ts
+++ b/packages/plugin-sampler/src/request-sampler.ts
@@ -82,7 +82,7 @@ export class RequestSampler {
       throw new ThymianBaseError(
         'Cannot sample for transaction before @thymian/plugin-sampler was initialized.',
         {
-          suggestions: ['Did you run "thymian sampler:init"?'],
+          suggestions: ['Did you run "thymian sampler init"?'],
           name: 'SamplerNotInitializedError',
         },
       );


### PR DESCRIPTION
Replace the manual sample/serialize/dispatch cycle in check.ts with the httpTest() pipeline and createContext(), ensuring authorize, beforeEach, and afterEach hooks actually execute during sampler check.

Also:
- Add origin option to runRequests operator for target-url override
- Fix stale colon-syntax command references across 13 source/doc files
- Fix /api/v1/ URL prefixes in 8 documentation files
- Fix 'austronauts' typo in tutorial