### PR TITLE
feat(core): normalize validation findings into shared report model

### DIFF
--- a/packages/core/src/events/report.event.ts
+++ b/packages/core/src/events/report.event.ts
@@ -1,7 +1,33 @@
 import type { JSONSchemaType } from 'ajv/dist/2020.js';
 
+/**
+ * Severity levels for report items.
+ *
+ * **Mapping from {@link import('../rules/rule-severity.js').RuleSeverity RuleSeverity}:**
+ * - `RuleSeverity 'error'` → `ThymianReportSeverity 'error'`
+ * - `RuleSeverity 'warn'`  → `ThymianReportSeverity 'warn'`
+ * - `RuleSeverity 'hint'`  → `ThymianReportSeverity 'hint'`
+ * - `RuleSeverity 'off'`   → never produces report items (filtered by the rule runner)
+ *
+ * **Non-rule informational items:**
+ * - `'info'` is reserved for operational/informational items that originate
+ *   from direct report emission (e.g., skipped test cases) rather than from
+ *   rule evaluation. There is no corresponding `RuleSeverity` value.
+ */
 export type ThymianReportSeverity = 'info' | 'hint' | 'warn' | 'error';
 
+/**
+ * Location information for a report item or section.
+ *
+ * Supports the location semantics for all three validation contexts:
+ * - **lint**: `file` carries spec file path/URI and position within the document.
+ * - **test**: `format` carries the graph element (node/edge) that identifies the
+ *   endpoint or request path under test.
+ * - **analyze**: `format` carries the graph element for the traffic analysis context,
+ *   optionally combined with `file` when traffic has a source file.
+ *
+ * Both sub-objects are optional and may coexist on the same location.
+ */
 export interface ThymianReportLocation {
   file?: {
     path?: string;
@@ -14,21 +40,56 @@ export interface ThymianReportLocation {
   };
 }
 
+/**
+ * A single finding or informational item within a report section.
+ *
+ * Items produced by the rule-violation pipeline (via `createReportFromViolations`)
+ * always carry `ruleName` sourced from {@link import('../rules/rule-violation.js').EvaluatedRuleViolation EvaluatedRuleViolation}.
+ *
+ * Items produced by direct report emission (via `ctx.report()`) may omit
+ * `ruleName` when they represent operational status rather than rule findings
+ * (e.g., skipped or failed test cases).
+ */
 export interface ThymianReportItem {
   severity: ThymianReportSeverity;
   message: string;
+  /** Stable rule identifier. Present for rule-originated findings; may be absent for operational/informational items. */
   ruleName?: string;
   details?: string;
   links?: { title?: string; url: string }[];
   location?: ThymianReportLocation;
 }
 
+/**
+ * A group of related report items under a common heading.
+ *
+ * In the standard violation pipeline, headings are derived from the resolved
+ * violation location (e.g., "GET /users → 200 OK").
+ */
 export interface ThymianReportSection {
   heading: string;
   items: ThymianReportItem[];
   location?: ThymianReportLocation;
 }
 
+/**
+ * The canonical shared report model for all validation contexts.
+ *
+ * `ThymianReport` is the formatter-agnostic representation of validation
+ * findings emitted through the `core.report` event. All lint, test, and
+ * analyze workflows produce results through this single model before any
+ * formatter-specific rendering occurs.
+ *
+ * - `source` identifies the producing plugin.
+ * - `message` provides a human-readable summary of the validation run.
+ * - `sections` groups findings by location heading.
+ * - `metadata` carries optional context-specific information (e.g., validation
+ *   mode, config source) without polluting the core model structure.
+ *
+ * Formatters (text, markdown, CSV) translate this model into presentation
+ * output. Renderer differences are limited to styling, grouping, and stream
+ * routing — not validation meaning.
+ */
 export interface ThymianReport {
   source: string;
   message: string;

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -511,6 +511,7 @@ export class Thymian {
       source,
       message,
       sections,
+      metadata: result.metadata,
     };
   }
 

--- a/packages/core/test/bridge-reports.test.ts
+++ b/packages/core/test/bridge-reports.test.ts
@@ -1,0 +1,467 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { ThymianReport } from '../src/events/report.event.js';
+import {
+  NoopLogger,
+  Thymian,
+  ThymianFormat,
+  type ThymianPlugin,
+  type ThymianPluginFn,
+} from '../src/index.js';
+
+declare module '../src/events/index.js' {
+  interface ThymianEvents {
+    [event: string]: unknown;
+  }
+}
+
+declare module '../src/actions/index.js' {
+  interface ThymianActions {
+    [action: string]: {
+      event: unknown;
+      response: unknown;
+    };
+  }
+}
+
+function createPluginFor(
+  plugin: ThymianPluginFn<{ cwd: string }>,
+): ThymianPlugin {
+  return {
+    name: '',
+    version: '',
+    plugin,
+  };
+}
+
+describe('bridgeReports and createReportFromViolations', () => {
+  let thymian: Thymian;
+
+  beforeEach(() => {
+    thymian = new Thymian(new NoopLogger());
+  });
+
+  it('should emit a core.report event with correct attribution when lint returns violations', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          const format = new ThymianFormat();
+          format.addHttpTransaction(
+            {
+              type: 'http-request',
+              host: 'localhost',
+              port: 8080,
+              protocol: 'http',
+              path: '/users',
+              method: 'get',
+              headers: {},
+              queryParameters: {},
+              cookies: {},
+              pathParameters: {},
+              mediaType: '',
+            },
+            {
+              type: 'http-response',
+              headers: {},
+              mediaType: 'application/json',
+              statusCode: 200,
+            },
+            'spec-loader',
+          );
+
+          ctx.reply(format.export());
+        });
+
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-linter',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'rfc9110/must-include-date-header',
+                severity: 'error',
+                violation: {
+                  location: 'GET /users → 200 OK',
+                  message: 'Missing Date header in response',
+                },
+              },
+              {
+                ruleName: 'custom/response-must-have-content-type',
+                severity: 'warn',
+                violation: {
+                  location: 'GET /users → 200 OK',
+                  message: 'Content-Type header is missing',
+                },
+              },
+            ],
+            statistics: { rulesRun: 5, rulesWithViolations: 2 },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.lint({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    expect(capturedReports).toHaveLength(1);
+
+    const report = capturedReports[0]!;
+
+    expect(report.source).toBe('@thymian/plugin-http-linter');
+
+    expect(report.message).toContain('5 HTTP rules run successfully');
+    expect(report.message).toContain('2 rules reported a violation');
+
+    expect(report.sections).toHaveLength(1);
+    expect(report.sections![0]!.heading).toBe('GET /users → 200 OK');
+
+    const items = report.sections![0]!.items;
+    expect(items).toHaveLength(2);
+
+    expect(items[0]!.ruleName).toBe('rfc9110/must-include-date-header');
+    expect(items[0]!.severity).toBe('error');
+    expect(items[0]!.message).toBe('Missing Date header in response');
+
+    expect(items[1]!.ruleName).toBe('custom/response-must-have-content-type');
+    expect(items[1]!.severity).toBe('warn');
+    expect(items[1]!.message).toBe('Content-Type header is missing');
+  });
+
+  it('should not emit core.report when there are no violations (clean run)', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-linter',
+            status: 'success',
+            violations: [],
+            statistics: { rulesRun: 5, rulesWithViolations: 0 },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    const result = await thymian.lint({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    expect(capturedReports).toHaveLength(0);
+    expect(result.classification).toBe('clean-run');
+  });
+
+  it('should emit core.report for test workflow violations', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.test', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-tester',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'test/response-status-ok',
+                severity: 'hint',
+                violation: {
+                  location: 'test context',
+                  message: 'Response returned 404 instead of 200',
+                },
+              },
+            ],
+            statistics: { rulesRun: 3, rulesWithViolations: 1 },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.test({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    expect(capturedReports).toHaveLength(1);
+
+    const report = capturedReports[0]!;
+    expect(report.source).toBe('@thymian/plugin-http-tester');
+    expect(report.sections![0]!.items[0]!.ruleName).toBe(
+      'test/response-status-ok',
+    );
+    expect(report.sections![0]!.items[0]!.severity).toBe('hint');
+  });
+
+  it('should emit core.report for analyze workflow violations', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.traffic.load', (_, ctx) => {
+          ctx.reply({ transactions: [], traces: [], metadata: {} });
+        });
+
+        emitter.onAction('core.analyze', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-analyzer',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'analyze/response-time-threshold',
+                severity: 'warn',
+                violation: {
+                  location: 'traffic analysis',
+                  message: 'Response time exceeds 500ms threshold',
+                },
+              },
+            ],
+            statistics: { rulesRun: 2, rulesWithViolations: 1 },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.analyze({
+      traffic: [{ type: 'har', location: '/tmp/traffic.har' }],
+    });
+
+    expect(capturedReports).toHaveLength(1);
+
+    const report = capturedReports[0]!;
+    expect(report.source).toBe('@thymian/plugin-http-analyzer');
+    expect(report.sections![0]!.items[0]!.ruleName).toBe(
+      'analyze/response-time-threshold',
+    );
+    expect(report.sections![0]!.items[0]!.severity).toBe('warn');
+  });
+
+  it('should propagate metadata from ValidationResult to ThymianReport', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-linter',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'test-rule',
+                severity: 'error',
+                violation: {
+                  location: 'test location',
+                  message: 'test message',
+                },
+              },
+            ],
+            metadata: {
+              validationMode: 'lint',
+              configSource: '/tmp/thymian.config.yaml',
+            },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.lint({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    expect(capturedReports).toHaveLength(1);
+    expect(capturedReports[0]!.metadata).toEqual({
+      validationMode: 'lint',
+      configSource: '/tmp/thymian.config.yaml',
+    });
+  });
+
+  it('should group violations into sections by resolved location heading', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-http-linter',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'rule-a',
+                severity: 'error',
+                violation: { location: 'Section A', message: 'Error in A' },
+              },
+              {
+                ruleName: 'rule-b',
+                severity: 'warn',
+                violation: { location: 'Section B', message: 'Warning in B' },
+              },
+              {
+                ruleName: 'rule-c',
+                severity: 'hint',
+                violation: { location: 'Section A', message: 'Hint in A' },
+              },
+            ],
+            statistics: { rulesRun: 3, rulesWithViolations: 3 },
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.lint({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    const report = capturedReports[0]!;
+
+    // Two distinct headings should produce two sections
+    expect(report.sections).toHaveLength(2);
+
+    const sectionA = report.sections!.find((s) => s.heading === 'Section A');
+    const sectionB = report.sections!.find((s) => s.heading === 'Section B');
+
+    expect(sectionA).toBeDefined();
+    expect(sectionA!.items).toHaveLength(2);
+    expect(sectionA!.items[0]!.ruleName).toBe('rule-a');
+    expect(sectionA!.items[1]!.ruleName).toBe('rule-c');
+
+    expect(sectionB).toBeDefined();
+    expect(sectionB!.items).toHaveLength(1);
+    expect(sectionB!.items[0]!.ruleName).toBe('rule-b');
+  });
+
+  it('should handle multiple ValidationResults from different plugins', async () => {
+    const capturedReports: ThymianReport[] = [];
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.format.load', (_, ctx) => {
+          ctx.reply(new ThymianFormat().export());
+        });
+
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-a',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'rule-from-a',
+                severity: 'error',
+                violation: { location: 'loc-a', message: 'Error from A' },
+              },
+            ],
+          });
+        });
+
+        emitter.on('core.report', (report: unknown) => {
+          capturedReports.push(report as ThymianReport);
+        });
+
+        emitter.onAction('core.report.flush', (_, ctx) => {
+          ctx.reply({ text: '' });
+        });
+      }),
+    );
+
+    thymian.register(
+      createPluginFor(async (emitter) => {
+        emitter.onAction('core.lint', (_, ctx) => {
+          ctx.reply({
+            source: '@thymian/plugin-b',
+            status: 'failed',
+            violations: [
+              {
+                ruleName: 'rule-from-b',
+                severity: 'warn',
+                violation: { location: 'loc-b', message: 'Warning from B' },
+              },
+            ],
+          });
+        });
+      }),
+    );
+
+    await thymian.ready();
+    await thymian.lint({
+      specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+    });
+
+    // Each ValidationResult with violations produces one ThymianReport
+    expect(capturedReports).toHaveLength(2);
+    expect(capturedReports[0]!.source).toBe('@thymian/plugin-a');
+    expect(capturedReports[1]!.source).toBe('@thymian/plugin-b');
+  });
+});

--- a/packages/core/test/report-model.test.ts
+++ b/packages/core/test/report-model.test.ts
@@ -1,0 +1,445 @@
+import Ajv from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ThymianReport,
+  ThymianReportItem,
+  ThymianReportLocation,
+  ThymianReportSection,
+  ThymianReportSeverity,
+} from '../src/events/report.event.js';
+import { thymianReportSchema } from '../src/events/report.event.js';
+
+const ajv = new Ajv({ strict: false });
+const validateReport = ajv.compile(thymianReportSchema);
+
+describe('ThymianReport shared model', () => {
+  // ---------------------------------------------------------------------------
+  // Type-level construction tests
+  // ---------------------------------------------------------------------------
+
+  describe('ThymianReport construction', () => {
+    it('should construct a minimal valid report with source and message only', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: '5 HTTP rules run successfully. 0 rules reported a violation.',
+      };
+
+      expect(report.source).toBe('@thymian/plugin-http-linter');
+      expect(report.message).toBeDefined();
+      expect(report.sections).toBeUndefined();
+      expect(report.metadata).toBeUndefined();
+    });
+
+    it('should construct a report with sections containing rule-originated items', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: '3 HTTP rules run successfully. 1 rules reported a violation.',
+        sections: [
+          {
+            heading: 'GET /users → 200 OK',
+            items: [
+              {
+                severity: 'error',
+                message: 'Missing Date header in response',
+                ruleName: 'rfc9110/must-include-date-header',
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(report.sections).toHaveLength(1);
+      expect(report.sections![0]!.items[0]!.ruleName).toBe(
+        'rfc9110/must-include-date-header',
+      );
+    });
+
+    it('should construct a report with operational items that omit ruleName', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-tester',
+        message: '[test-rule] 2 test cases skipped',
+        sections: [
+          {
+            heading: 'Skipped test cases',
+            items: [
+              {
+                severity: 'info',
+                message: 'Test case A',
+                details: 'No matching endpoint',
+              },
+              {
+                severity: 'info',
+                message: 'Test case B',
+                details: 'Endpoint not reachable',
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(report.sections![0]!.items[0]!.ruleName).toBeUndefined();
+      expect(report.sections![0]!.items[0]!.severity).toBe('info');
+    });
+
+    it('should construct a report with full item attribution including details, links, and location', () => {
+      const location: ThymianReportLocation = {
+        file: {
+          path: '/tmp/api.yaml',
+          position: { line: 42, column: 1, offset: 1024 },
+        },
+        format: { elementType: 'node', elementId: 'node-1' },
+      };
+
+      const item: ThymianReportItem = {
+        severity: 'warn',
+        message: 'Deprecated endpoint pattern',
+        ruleName: 'custom/no-deprecated-endpoints',
+        details: 'The /v1/legacy endpoint uses a deprecated pattern.',
+        links: [
+          { title: 'Migration Guide', url: 'https://example.com/migrate' },
+          { url: 'https://example.com/spec' },
+        ],
+        location,
+      };
+
+      expect(item.links).toHaveLength(2);
+      expect(item.links![0]!.title).toBe('Migration Guide');
+      expect(item.links![1]!.title).toBeUndefined();
+      expect(item.location!.file!.path).toBe('/tmp/api.yaml');
+      expect(item.location!.format!.elementType).toBe('node');
+    });
+
+    it('should support metadata on reports for context-specific information', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-tester',
+        message: 'Test run complete',
+        metadata: {
+          validationMode: 'test',
+          configSource: '/tmp/thymian.config.yaml',
+          targetUrl: 'https://api.example.com',
+        },
+      };
+
+      expect(report.metadata).toEqual({
+        validationMode: 'test',
+        configSource: '/tmp/thymian.config.yaml',
+        targetUrl: 'https://api.example.com',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ThymianReportSeverity coverage
+  // ---------------------------------------------------------------------------
+
+  describe('ThymianReportSeverity', () => {
+    it.each(['error', 'warn', 'hint', 'info'] as ThymianReportSeverity[])(
+      'should accept %s as a valid severity',
+      (severity) => {
+        const item: ThymianReportItem = {
+          severity,
+          message: `Item with ${severity} severity`,
+        };
+
+        expect(item.severity).toBe(severity);
+      },
+    );
+
+    it('should map rule-originated severities (error, warn, hint) and reserve info for operational items', () => {
+      // Rule pipeline produces error, warn, hint — never info
+      const ruleOriginatedSeverities: ThymianReportSeverity[] = [
+        'error',
+        'warn',
+        'hint',
+      ];
+
+      // info is only for direct-emission operational items
+      const operationalSeverities: ThymianReportSeverity[] = ['info'];
+
+      const allSeverities = [
+        ...ruleOriginatedSeverities,
+        ...operationalSeverities,
+      ];
+
+      expect(allSeverities).toEqual(['error', 'warn', 'hint', 'info']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ThymianReportLocation semantics for all three contexts
+  // ---------------------------------------------------------------------------
+
+  describe('ThymianReportLocation', () => {
+    it('should represent lint context locations with file path and position', () => {
+      const location: ThymianReportLocation = {
+        file: {
+          path: '/workspace/openapi.yaml',
+          position: { line: 15, column: 3, offset: 200 },
+        },
+      };
+
+      expect(location.file!.path).toBe('/workspace/openapi.yaml');
+      expect(location.file!.position!.line).toBe(15);
+      expect(location.format).toBeUndefined();
+    });
+
+    it('should represent test context locations with format graph elements', () => {
+      const location: ThymianReportLocation = {
+        format: {
+          elementType: 'edge',
+          elementId: 'tx-get-users-200',
+        },
+      };
+
+      expect(location.format!.elementType).toBe('edge');
+      expect(location.format!.elementId).toBe('tx-get-users-200');
+      expect(location.file).toBeUndefined();
+    });
+
+    it('should represent analyze context locations with both file and format', () => {
+      const location: ThymianReportLocation = {
+        file: { uri: 'file:///traffic.har' },
+        format: { elementType: 'node', elementId: 'req-1' },
+      };
+
+      expect(location.file!.uri).toBe('file:///traffic.har');
+      expect(location.format!.elementType).toBe('node');
+    });
+
+    it('should support section-level location', () => {
+      const section: ThymianReportSection = {
+        heading: 'GET /users → 200 OK',
+        items: [{ severity: 'error', message: 'Missing header' }],
+        location: {
+          format: { elementType: 'edge', elementId: 'tx-1' },
+        },
+      };
+
+      expect(section.location!.format!.elementId).toBe('tx-1');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clean-run representation
+  // ---------------------------------------------------------------------------
+
+  describe('clean-run representation', () => {
+    it('should represent a clean lint run with no sections', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message:
+          '10 HTTP rules run successfully. 0 rules reported a violation.',
+      };
+
+      expect(report.sections).toBeUndefined();
+    });
+
+    it('should represent a clean lint run with empty sections array', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message:
+          '10 HTTP rules run successfully. 0 rules reported a violation.',
+        sections: [],
+      };
+
+      expect(report.sections).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Schema validation tests
+  // ---------------------------------------------------------------------------
+
+  describe('thymianReportSchema (AJV validation)', () => {
+    it('should validate a minimal report with source and message', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: 'All clear.',
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(true);
+      expect(validateReport.errors).toBeNull();
+    });
+
+    it('should validate a report with sections and rule-originated items', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Findings detected.',
+        sections: [
+          {
+            heading: 'GET /users → 200 OK',
+            items: [
+              {
+                severity: 'error',
+                message: 'Missing Date header',
+                ruleName: 'rfc9110/must-include-date-header',
+                details: 'RFC 9110 Section 6.6.1 requires a Date header.',
+                links: [
+                  {
+                    title: 'RFC 9110',
+                    url: 'https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1',
+                  },
+                ],
+                location: {
+                  file: {
+                    path: '/tmp/api.yaml',
+                    position: { line: 10, column: 1, offset: 100 },
+                  },
+                  format: { elementType: 'node', elementId: 'resp-1' },
+                },
+              },
+            ],
+            location: {
+              format: { elementType: 'edge', elementId: 'tx-1' },
+            },
+          },
+        ],
+        metadata: { validationMode: 'lint' },
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(true);
+      expect(validateReport.errors).toBeNull();
+    });
+
+    it('should validate a report with items that omit ruleName (operational items)', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-tester',
+        message: 'Skipped test cases.',
+        sections: [
+          {
+            heading: 'Skipped test cases',
+            items: [
+              {
+                severity: 'info',
+                message: 'Test case skipped',
+                details: 'No matching endpoint',
+              },
+            ],
+          },
+        ],
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(true);
+      expect(validateReport.errors).toBeNull();
+    });
+
+    it('should reject a report missing the required source field', () => {
+      const report = {
+        message: 'Missing source.',
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+      expect(validateReport.errors).not.toBeNull();
+    });
+
+    it('should reject a report missing the required message field', () => {
+      const report = {
+        source: '@thymian/plugin-http-linter',
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+      expect(validateReport.errors).not.toBeNull();
+    });
+
+    it('should reject an item missing the required severity field', () => {
+      const report = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Bad item.',
+        sections: [
+          {
+            heading: 'Bad',
+            items: [{ message: 'Missing severity' }],
+          },
+        ],
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+    });
+
+    it('should reject an item missing the required message field', () => {
+      const report = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Bad item.',
+        sections: [
+          {
+            heading: 'Bad',
+            items: [{ severity: 'error' }],
+          },
+        ],
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+    });
+
+    it('should reject an invalid severity value', () => {
+      const report = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Bad severity.',
+        sections: [
+          {
+            heading: 'Bad',
+            items: [{ severity: 'critical', message: 'Invalid' }],
+          },
+        ],
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+    });
+
+    it('should reject additional properties on the report', () => {
+      const report = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Extra field.',
+        extraField: true,
+      };
+
+      const valid = validateReport(report);
+
+      expect(valid).toBe(false);
+    });
+
+    it('should validate all four severity values', () => {
+      for (const severity of ['error', 'warn', 'hint', 'info'] as const) {
+        const report: ThymianReport = {
+          source: 'test',
+          message: 'test',
+          sections: [
+            {
+              heading: 'test',
+              items: [{ severity, message: `${severity} item` }],
+            },
+          ],
+        };
+
+        expect(validateReport(report)).toBe(true);
+      }
+    });
+
+    it('should validate a report with metadata', () => {
+      const report: ThymianReport = {
+        source: 'test',
+        message: 'test',
+        metadata: { mode: 'lint', configPath: '/tmp/config.yaml' },
+      };
+
+      expect(validateReport(report)).toBe(true);
+    });
+  });
+});

--- a/packages/plugin-reporter/test/csv.test.ts
+++ b/packages/plugin-reporter/test/csv.test.ts
@@ -1,0 +1,183 @@
+import type { ThymianReport } from '@thymian/core';
+import { describe, expect, it } from 'vitest';
+
+import { csvSafe, thymianReportToCsvLines } from '../src/formatters/csv.js';
+
+describe('CsvFormatter utilities', () => {
+  describe('csvSafe', () => {
+    it('should return empty string for undefined', () => {
+      expect(csvSafe(undefined)).toBe('');
+    });
+
+    it('should return the string unchanged when no special characters', () => {
+      expect(csvSafe('simple')).toBe('simple');
+    });
+
+    it('should wrap in quotes when string contains comma', () => {
+      expect(csvSafe('hello,world')).toBe('"hello,world"');
+    });
+
+    it('should wrap in quotes when string contains spaces', () => {
+      expect(csvSafe('hello world')).toBe('"hello world"');
+    });
+
+    it('should double-escape internal quotes', () => {
+      expect(csvSafe('say "hello"')).toBe('"say ""hello"""');
+    });
+
+    it('should replace newlines with spaces', () => {
+      expect(csvSafe('line1\nline2')).toBe('"line1 line2"');
+    });
+  });
+
+  describe('thymianReportToCsvLines', () => {
+    it('should produce a single row for a report with no sections', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: 'All clear.',
+      };
+
+      const lines = thymianReportToCsvLines(report);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('@thymian/plugin-http-linter');
+      expect(lines[0]).toContain('All clear.');
+    });
+
+    it('should produce a single row for a report with empty sections', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Empty sections.',
+        sections: [],
+      };
+
+      const lines = thymianReportToCsvLines(report);
+
+      expect(lines).toHaveLength(1);
+    });
+
+    it('should produce one row per item with full attribution', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-linter',
+        message: 'Findings.',
+        sections: [
+          {
+            heading: 'GET /users → 200 OK',
+            items: [
+              {
+                severity: 'error',
+                message: 'Missing Date header',
+                ruleName: 'rfc9110/must-include-date-header',
+                details: 'RFC 9110 requires Date header.',
+              },
+              {
+                severity: 'warn',
+                message: 'Missing Content-Type',
+                ruleName: 'custom/content-type-required',
+              },
+            ],
+          },
+        ],
+      };
+
+      const lines = thymianReportToCsvLines(report);
+
+      expect(lines).toHaveLength(2);
+
+      // First row: source, section heading, severity, ruleName, message, details
+      expect(lines[0]).toContain('@thymian/plugin-http-linter');
+      expect(lines[0]).toContain('error');
+      expect(lines[0]).toContain('rfc9110/must-include-date-header');
+      expect(lines[0]).toContain('Missing Date header');
+
+      // Second row
+      expect(lines[1]).toContain('warn');
+      expect(lines[1]).toContain('custom/content-type-required');
+    });
+
+    it('should handle items without ruleName (operational items)', () => {
+      const report: ThymianReport = {
+        source: '@thymian/plugin-http-tester',
+        message: 'Skipped tests.',
+        sections: [
+          {
+            heading: 'Skipped test cases',
+            items: [
+              {
+                severity: 'info',
+                message: 'Test case skipped',
+                details: 'No matching endpoint',
+              },
+            ],
+          },
+        ],
+      };
+
+      const lines = thymianReportToCsvLines(report);
+
+      expect(lines).toHaveLength(1);
+      // ruleName column should be empty
+      expect(lines[0]).toContain('info');
+      expect(lines[0]).toContain('Test case skipped');
+    });
+
+    it('should produce rows for multiple sections', () => {
+      const report: ThymianReport = {
+        source: 'test-source',
+        message: 'Multi-section.',
+        sections: [
+          {
+            heading: 'Section A',
+            items: [
+              { severity: 'error', message: 'Error A', ruleName: 'rule-a' },
+            ],
+          },
+          {
+            heading: 'Section B',
+            items: [
+              { severity: 'warn', message: 'Warn B', ruleName: 'rule-b' },
+              { severity: 'hint', message: 'Hint B', ruleName: 'rule-c' },
+            ],
+          },
+        ],
+      };
+
+      const lines = thymianReportToCsvLines(report);
+
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toContain('Section A');
+      expect(lines[1]).toContain('Section B');
+      expect(lines[2]).toContain('Section B');
+    });
+
+    it('should preserve the CSV column order: source, section, severity, ruleName, message, details', () => {
+      const report: ThymianReport = {
+        source: 'src',
+        message: 'msg',
+        sections: [
+          {
+            heading: 'hd',
+            items: [
+              {
+                severity: 'error',
+                message: 'err-msg',
+                ruleName: 'rule-1',
+                details: 'dtl',
+              },
+            ],
+          },
+        ],
+      };
+
+      const lines = thymianReportToCsvLines(report);
+      const columns = lines[0]!.trim().split(',');
+
+      expect(columns[0]).toBe('src');
+      expect(columns[1]).toBe('hd');
+      expect(columns[2]).toBe('error');
+      expect(columns[3]).toBe('rule-1');
+      expect(columns[4]).toBe('err-msg');
+      expect(columns[5]).toBe('dtl');
+    });
+  });
+});

--- a/packages/plugin-reporter/test/formatter-attribution.test.ts
+++ b/packages/plugin-reporter/test/formatter-attribution.test.ts
@@ -1,0 +1,277 @@
+import type { Logger, ThymianReport } from '@thymian/core';
+import chalk from 'chalk';
+import { writeFile } from 'fs/promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MarkdownFormatter } from '../src/formatters/markdown.js';
+import { TextFormatter } from '../src/formatters/text.js';
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+/** Minimal no-op logger satisfying the Logger interface for MarkdownFormatter. */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+const noopLogger: Logger = {
+  namespace: '',
+  level: 'silent',
+  info: noop,
+  warn: noop,
+  error: noop,
+  debug: noop,
+  trace: noop,
+  out: noop,
+  child: () => noopLogger,
+};
+
+/**
+ * Formatter attribution preservation tests (AC 3).
+ *
+ * These tests feed the same ThymianReport to text, markdown, and CSV formatters
+ * and verify each preserves the finding content and attribution (rule name,
+ * severity, source, location) from the shared report model.
+ */
+describe('formatter attribution preservation', () => {
+  chalk.level = 0;
+
+  const sharedReport: ThymianReport = {
+    source: '@thymian/plugin-http-linter',
+    message: '5 HTTP rules run. 2 reported violations.',
+    sections: [
+      {
+        heading: 'GET /users → 200 OK',
+        items: [
+          {
+            severity: 'error',
+            message: 'Missing Date header in response',
+            ruleName: 'rfc9110/must-include-date-header',
+            details: 'RFC 9110 Section 6.6.1 requires a Date header.',
+            links: [
+              {
+                title: 'RFC 9110',
+                url: 'https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1',
+              },
+            ],
+          },
+          {
+            severity: 'warn',
+            message: 'Content-Type header is missing',
+            ruleName: 'custom/content-type-required',
+          },
+        ],
+      },
+      {
+        heading: 'POST /users → 201 Created',
+        items: [
+          {
+            severity: 'hint',
+            message: 'Consider adding Location header',
+            ruleName: 'best-practice/location-header-on-create',
+          },
+        ],
+      },
+    ],
+    metadata: { validationMode: 'lint' },
+  };
+
+  const reportWithoutRuleName: ThymianReport = {
+    source: '@thymian/plugin-http-tester',
+    message: '2 test cases skipped',
+    sections: [
+      {
+        heading: 'Skipped test cases',
+        items: [
+          {
+            severity: 'info',
+            message: 'Test case A',
+            details: 'No matching endpoint',
+          },
+        ],
+      },
+    ],
+  };
+
+  describe('TextFormatter', () => {
+    let formatter: TextFormatter;
+
+    beforeEach(() => {
+      formatter = new TextFormatter();
+      formatter.init({});
+    });
+
+    it('should preserve source attribution', async () => {
+      formatter.report(sharedReport);
+      const result = await formatter.flush();
+
+      expect(result).toContain('@thymian/plugin-http-linter');
+    });
+
+    it('should preserve rule name for rule-originated items', async () => {
+      formatter.report(sharedReport);
+      const result = await formatter.flush();
+
+      expect(result).toContain('rfc9110/must-include-date-header');
+      expect(result).toContain('custom/content-type-required');
+      expect(result).toContain('best-practice/location-header-on-create');
+    });
+
+    it('should preserve severity in output', async () => {
+      formatter.report(sharedReport);
+      const result = await formatter.flush();
+
+      expect(result).toContain('error');
+      expect(result).toContain('warning');
+      expect(result).toContain('hint');
+    });
+
+    it('should preserve message content', async () => {
+      formatter.report(sharedReport);
+      const result = await formatter.flush();
+
+      expect(result).toContain('Missing Date header in response');
+      expect(result).toContain('Content-Type header is missing');
+      expect(result).toContain('Consider adding Location header');
+    });
+
+    it('should preserve section headings', async () => {
+      formatter.report(sharedReport);
+      const result = await formatter.flush();
+
+      expect(result).toContain('GET /users → 200 OK');
+      expect(result).toContain('POST /users → 201 Created');
+    });
+
+    it('should handle items without ruleName gracefully', async () => {
+      formatter.report(reportWithoutRuleName);
+      const result = await formatter.flush();
+
+      expect(result).toContain('Test case A');
+      expect(result).not.toContain('undefined');
+    });
+  });
+
+  describe('MarkdownFormatter', () => {
+    let formatter: MarkdownFormatter;
+
+    beforeEach(async () => {
+      vi.mocked(writeFile).mockClear();
+      formatter = new MarkdownFormatter(noopLogger);
+      await formatter.init({ path: '/tmp/report.md' });
+      vi.mocked(writeFile).mockResolvedValue();
+    });
+
+    it('should preserve source attribution as heading', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('## @thymian/plugin-http-linter');
+    });
+
+    it('should preserve rule name for rule-originated items', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('*Rule: rfc9110/must-include-date-header*');
+      expect(content).toContain('*Rule: custom/content-type-required*');
+      expect(content).toContain(
+        '*Rule: best-practice/location-header-on-create*',
+      );
+    });
+
+    it('should preserve severity badges', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('**✖ error**');
+      expect(content).toContain('**⚠ warning**');
+      expect(content).toContain('**ℹ hint**');
+    });
+
+    it('should preserve message content', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('Missing Date header in response');
+      expect(content).toContain('Content-Type header is missing');
+      expect(content).toContain('Consider adding Location header');
+    });
+
+    it('should preserve section headings', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('### GET /users → 200 OK');
+      expect(content).toContain('### POST /users → 201 Created');
+    });
+
+    it('should preserve details in collapsible block', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain(
+        'RFC 9110 Section 6.6.1 requires a Date header.',
+      );
+    });
+
+    it('should preserve links', async () => {
+      formatter.report(sharedReport);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain(
+        '[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1)',
+      );
+    });
+
+    it('should handle items without ruleName by not including Rule line', async () => {
+      formatter.report(reportWithoutRuleName);
+      await formatter.flush();
+
+      const [, content] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(content).toContain('Test case A');
+      expect(content).not.toContain('*Rule:');
+    });
+  });
+
+  describe('cross-formatter consistency', () => {
+    it('should preserve the same finding count across all formatters', async () => {
+      // Text formatter
+      const textFormatter = new TextFormatter();
+      textFormatter.init({});
+      textFormatter.report(sharedReport);
+      const textResult = await textFormatter.flush();
+
+      // All three rule-originated items should appear
+      expect(textResult).toContain('rfc9110/must-include-date-header');
+      expect(textResult).toContain('custom/content-type-required');
+      expect(textResult).toContain('best-practice/location-header-on-create');
+
+      // Markdown formatter
+      const mdFormatter = new MarkdownFormatter(noopLogger);
+      await mdFormatter.init({ path: '/tmp/report.md' });
+      vi.mocked(writeFile).mockResolvedValue();
+      mdFormatter.report(sharedReport);
+      await mdFormatter.flush();
+
+      const [, mdContent] =
+        vi.mocked(writeFile).mock.calls[
+          vi.mocked(writeFile).mock.calls.length - 1
+        ]!;
+      expect(mdContent).toContain('3 items');
+
+      // CSV lines
+      const { thymianReportToCsvLines } =
+        await import('../src/formatters/csv.js');
+      const csvLines = thymianReportToCsvLines(sharedReport);
+      expect(csvLines).toHaveLength(3);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces comprehensive tests for the CSV, text, and markdown report formatters, and enhances the documentation and model for the core reporting types. The main focus is on ensuring that all formatter outputs preserve the attribution and content of findings from the shared report model (`ThymianReport`). Additionally, the core report model is improved with richer documentation and the propagation of metadata.

**Formatter Testing and Attribution Preservation:**

* Added a new test suite (`formatter-attribution.test.ts`) to verify that the text and markdown formatters preserve all finding attributes (source, rule name, severity, message, details, links, etc.) and handle both rule-originated and operational items correctly. Also checks cross-formatter consistency in finding counts.
* Added a dedicated test suite (`csv.test.ts`) for the CSV formatter utilities, covering correct CSV escaping, row generation for various report structures, and column order.

**Core Report Model Improvements:**

* Enhanced the documentation for the core report types in `report.event.ts`, clarifying the meaning and mapping of severity levels, the structure and semantics of locations, and the distinction between rule findings and operational items. [[1]](diffhunk://#diff-f4cb0d6a7435020ce4f2bad79e1566d7eb10614044ddd9cfc22c85b007f14cb1R3-R30) [[2]](diffhunk://#diff-f4cb0d6a7435020ce4f2bad79e1566d7eb10614044ddd9cfc22c85b007f14cb1R43-R92)
* Updated the `Thymian` class to propagate the `metadata` field from validation results into the shared `ThymianReport` model, ensuring downstream formatters receive all context.