### PR TITLE
fix(plugin-openapi): make specification input optional for openapi commands

### DIFF
--- a/packages/plugin-openapi/src/cli/commands/openapi/info.ts
+++ b/packages/plugin-openapi/src/cli/commands/openapi/info.ts
@@ -6,6 +6,8 @@ import { ThymianBaseError } from '@thymian/core';
 import { loadOpenApi } from '../../../load-openapi.js';
 
 export default class Info extends BaseCliRunCommand<typeof Info> {
+  static override requiresSpecifications = false;
+
   static override args = {
     content: Args.string({
       description: 'file to read',

--- a/packages/plugin-openapi/src/cli/commands/openapi/load.ts
+++ b/packages/plugin-openapi/src/cli/commands/openapi/load.ts
@@ -5,6 +5,8 @@ import { constant } from '@thymian/core';
 import { loadAndTransform } from '../../../load-openapi.js';
 
 export default class Load extends BaseCliRunCommand<typeof Load> {
+  static override requiresSpecifications = false;
+
   static override args = {
     content: Args.string({
       description: 'file to read',

--- a/packages/plugin-openapi/src/cli/commands/openapi/validate.ts
+++ b/packages/plugin-openapi/src/cli/commands/openapi/validate.ts
@@ -4,6 +4,8 @@ import { BaseCliRunCommand } from '@thymian/common-cli';
 import { Args } from '@thymian/common-cli/oclif';
 
 export default class Validate extends BaseCliRunCommand<typeof Validate> {
+  static override requiresSpecifications = false;
+
   static override args = {
     file: Args.string({ description: 'file to read', required: true }),
   };


### PR DESCRIPTION
This pull request makes a small but important change to the OpenAPI CLI commands. It disables the requirement for specifications when running the `info`, `load`, and `validate` commands, allowing these commands to run even if no specifications are present.

Most important changes:

**CLI command behavior:**

* Added `static override requiresSpecifications = false;` to the `Info`, `Load`, and `Validate` commands in `openapi/info.ts`, `openapi/load.ts`, and `openapi/validate.ts`, respectively, so these commands no longer require specifications to be present. [[1]](diffhunk://#diff-a740bb5cad9781c12fabd39c853a641918fce15a7d03e4cdf39b7248bd0c55d1R9-R10) [[2]](diffhunk://#diff-3476b7b7ac5e337eeae3f33fed16ec79abaa781a8e375c39d8ce95aaa8f34041R8-R9) [[3]](diffhunk://#diff-3f7a75dba0e0bdcf63ca5dfafc5a8f91475b1103db69cc9e807406844cc4424aR7-R8)