### PR TITLE
chore(deps): update better-sqlite3 to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14504,6 +14504,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -35877,23 +35891,12 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@thymian/core": "0.0.0-PLACEHOLDER",
-        "better-sqlite3": "^11.8.1",
+        "better-sqlite3": "^12.9.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@thymian/core-testing": "0.0.0-PLACEHOLDER",
         "@types/better-sqlite3": "^7.6.12"
-      }
-    },
-    "packages/plugin-http-analyzer/node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
       }
     },
     "packages/plugin-http-linter": {

--- a/packages/plugin-http-analyzer/package.json
+++ b/packages/plugin-http-analyzer/package.json
@@ -32,11 +32,11 @@
   ],
   "dependencies": {
     "@thymian/core": "0.0.0-PLACEHOLDER",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.9.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.12",
-    "@thymian/core-testing": "0.0.0-PLACEHOLDER"
+    "@thymian/core-testing": "0.0.0-PLACEHOLDER",
+    "@types/better-sqlite3": "^7.6.12"
   }
 }


### PR DESCRIPTION
This resolves problems when Thymian is installed with Node v24. For **better-sqlite3** v11, no prebuilts for Node v24 are available