### PR TITLE
fix: dynamic import in windows

### DIFF
--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { inspect } from 'node:util';
 
 import { Command, Flags, Interfaces, settings, ux } from '@oclif/core';
@@ -462,8 +463,14 @@ export abstract class BaseCliRunCommand<
     this.debug('Load plugin module from location "%s".', location);
 
     try {
-      pluginModule = (await import(require.resolve(location))).default;
+      const resolvedPath = require.resolve(location);
+      pluginModule = (await import(pathToFileURL(resolvedPath).href)).default;
     } catch (e) {
+      this.logger.debug(
+        'Failed to load plugin module from "%s": %s',
+        location,
+        inspect(e),
+      );
       pluginModule = {};
     }
 

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { inspect } from 'node:util';
 
@@ -455,7 +455,7 @@ export abstract class BaseCliRunCommand<
     const options = this.thymianConfig.plugins[nameOrPath] ?? {};
     const location =
       isRelativePath || typeof options.path === 'string'
-        ? join(this.flags.cwd, options.path ?? nameOrPath)
+        ? resolve(this.flags.cwd, options.path ?? nameOrPath)
         : nameOrPath;
 
     let pluginModule;
@@ -471,7 +471,13 @@ export abstract class BaseCliRunCommand<
         location,
         inspect(e),
       );
-      pluginModule = {};
+      throw new ThymianBaseError(
+        `Failed to load plugin module "${options.path ?? nameOrPath}".`,
+        {
+          name: 'PluginLoadError',
+          cause: e,
+        },
+      );
     }
 
     if (!isPlugin(pluginModule)) {

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { glob } from 'tinyglobby';
 
@@ -132,7 +133,7 @@ export async function loadRules(
     });
   }
 
-  const module = await import(resolved);
+  const module = await import(pathToFileURL(resolved).href);
 
   if (!('default' in module)) {
     throw new ThymianBaseError(

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -116,7 +116,7 @@ export async function loadRules(
   }
 
   let location = input;
-  const fileLocation = path.join(cwd, input);
+  const fileLocation = path.resolve(cwd, input);
 
   if (existsSync(fileLocation)) {
     location = fileLocation;


### PR DESCRIPTION
This pull request updates how plugin and rule modules are dynamically loaded in both the CLI and core rule loader. The main improvement is switching from path-based dynamic imports to using file URLs, which increases compatibility and reliability, especially on different platforms and with ESM modules. Additionally, improved error logging has been added for plugin loading failures.

**Module loading improvements:**

* Updated `BaseCliRunCommand` in `base-cli-run-command.ts` to resolve module paths to file URLs before importing, ensuring compatibility with ESM modules. [[1]](diffhunk://#diff-0f84d238b21658a78115f0698514878cf6506833e21eac83428aaefb813b1678R3) [[2]](diffhunk://#diff-0f84d238b21658a78115f0698514878cf6506833e21eac83428aaefb813b1678L465-R473)
* Updated `loadRules` in `rule-loader.ts` to import rule modules using file URLs instead of direct paths. [[1]](diffhunk://#diff-3f886390a69de578140931eb8c3def1e5049b76bcaac4101dd67bf2455a38754R4) [[2]](diffhunk://#diff-3f886390a69de578140931eb8c3def1e5049b76bcaac4101dd67bf2455a38754L135-R136)

**Error handling enhancements:**

* Added detailed debug logging for plugin module load failures in `BaseCliRunCommand`, making troubleshooting easier.