### PR TITLE
chore(repo): add meaningful descriptions to all package.json files

### DIFF
--- a/astro-docs/package.json
+++ b/astro-docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "astro-docs",
   "version": "0.0.1",
+  "description": "Documentation website for Thymian built with Astro Starlight",
   "type": "module",
   "dependencies": {
     "@astrojs/starlight": "^0.35.2",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "e2e-tests",
+  "description": "End-to-end tests for the Thymian CLI and plugins",
   "type": "module",
   "devDependencies": {
     "@types/ws": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/source",
   "version": "0.0.0",
+  "description": "Thymian monorepo — API resilience testing and HTTP conformance linting",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/packages/common-cli/package.json
+++ b/packages/common-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/common-cli",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Shared CLI utilities, commands, and configuration management for Thymian",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/core-testing/package.json
+++ b/packages/core-testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/core-testing",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Testing utilities, factories, and mocks for writing Thymian plugin tests",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/core",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Core library with the plugin system, rule engine, and HTTP primitives for Thymian",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-http-analyzer/package.json
+++ b/packages/plugin-http-analyzer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-http-analyzer",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for analyzing captured HTTP traffic against conformance rules",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-http-linter/package.json
+++ b/packages/plugin-http-linter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-http-linter",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for static linting of API descriptions against HTTP conformance rules",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-http-tester/package.json
+++ b/packages/plugin-http-tester/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-http-tester",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for runtime HTTP conformance testing against live API endpoints",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-openapi",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for loading, parsing, and transforming OpenAPI specifications",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-reporter/package.json
+++ b/packages/plugin-reporter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-reporter",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for formatting and outputting conformance analysis reports",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-request-dispatcher/package.json
+++ b/packages/plugin-request-dispatcher/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-request-dispatcher",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for dispatching HTTP requests with concurrency control",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-sampler/package.json
+++ b/packages/plugin-sampler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-sampler",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin for generating HTTP request samples from API descriptions",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-websocket-proxy/package.json
+++ b/packages/plugin-websocket-proxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/plugin-websocket-proxy",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian plugin providing a WebSocket proxy server for capturing HTTP traffic",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/plugin-websocket-proxy/package.json
+++ b/packages/plugin-websocket-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thymian/plugin-websocket-proxy",
   "version": "0.0.0-PLACEHOLDER",
-  "description": "Thymian plugin providing a WebSocket proxy server for capturing HTTP traffic",
+  "description": "Thymian plugin providing a WebSocket-based communication bridge for remote rule plugins",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/rules-api-description-validation/package.json
+++ b/packages/rules-api-description-validation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/rules-api-description-validation",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian rule set for validating API description documents",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/rules-rfc-9110/package.json
+++ b/packages/rules-rfc-9110/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@thymian/rules-rfc-9110",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "Thymian rule set implementing RFC 9110 HTTP semantics validation",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"

--- a/packages/thymian/package.json
+++ b/packages/thymian/package.json
@@ -1,6 +1,7 @@
 {
   "name": "thymian",
   "version": "0.0.0-PLACEHOLDER",
+  "description": "AI-ready API governance engine - lint, test & analyze HTTP conformance across your entire API lifecycle",
   "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/thymianofficial/thymian/issues"


### PR DESCRIPTION
Adds npm-visible `description` fields to all 17 package.json files in the monorepo.

**Highlights:**
- `thymian` (main CLI): *AI-ready API governance engine: lint, test & analyze HTTP conformance across your entire API lifecycle*
- All `@thymian/*` packages get concise, meaningful descriptions for npm discoverability
- Internal packages (astro-docs, e2e-tests, root) also get descriptions for repo clarity