### PR TITLE
fix(common-cli): fix ErrorCache test failing on Windows CI

### DIFF
--- a/packages/common-cli/test/error-cache.test.ts
+++ b/packages/common-cli/test/error-cache.test.ts
@@ -109,7 +109,9 @@ describe('ErrorCache', () => {
     });
 
     it('should handle write failures gracefully', async () => {
-      const invalidCache = new ErrorCache('/invalid/readonly/path');
+      // Use a null byte in the path to guarantee an invalid path on all OSes.
+      // A plain '/invalid/...' path is writable on Windows (resolves to D:\invalid\...).
+      const invalidCache = new ErrorCache('/invalid/\0/path');
       const error: CachedError = {
         name: 'TestError',
         message: 'Test',
@@ -198,7 +200,9 @@ describe('ErrorCache', () => {
     });
 
     it('should handle file read failures gracefully', async () => {
-      const invalidCache = new ErrorCache('/invalid/readonly/path');
+      // Use a null byte in the path to guarantee an invalid path on all OSes.
+      // A plain '/invalid/...' path is writable on Windows (resolves to D:\invalid\...).
+      const invalidCache = new ErrorCache('/invalid/\0/path');
 
       const result = await invalidCache.read();
 

--- a/packages/common-cli/test/error-cache.test.ts
+++ b/packages/common-cli/test/error-cache.test.ts
@@ -110,7 +110,8 @@ describe('ErrorCache', () => {
 
     it('should handle write failures gracefully', async () => {
       // Use a null byte in the path to guarantee an invalid path on all OSes.
-      // A plain '/invalid/...' path is writable on Windows (resolves to D:\invalid\...).
+      // A plain '/invalid/...' path may be writable on Windows because it resolves
+      // to the current drive root (for example, C:\invalid\...).
       const invalidCache = new ErrorCache('/invalid/\0/path');
       const error: CachedError = {
         name: 'TestError',
@@ -201,7 +202,8 @@ describe('ErrorCache', () => {
 
     it('should handle file read failures gracefully', async () => {
       // Use a null byte in the path to guarantee an invalid path on all OSes.
-      // A plain '/invalid/...' path is writable on Windows (resolves to D:\invalid\...).
+      // A plain '/invalid/...' path may resolve on Windows to the current drive root
+      // (for example, C:\invalid\...), so it is not reliably invalid there.
       const invalidCache = new ErrorCache('/invalid/\0/path');
 
       const result = await invalidCache.read();


### PR DESCRIPTION
The `ErrorCache` tests `should handle write failures gracefully` and `should handle file read failures gracefully` both used `/invalid/readonly/path` as an intentionally-invalid directory. This works on Unix where creating directories under `/invalid/` requires root, but on **Windows** it resolves to `D:\invalid\readonly\path` and `mkdir` happily succeeds.

The write test then creates a real cache file, which the read test subsequently finds — returning data instead of `undefined`, causing the assertion to fail.

**Fix:** Use a null byte in the path (`/invalid/\\0/path`), which is universally rejected by all operating systems' filesystem APIs.

All three Windows matrix jobs (Node 20, 22, 24) were failing on this test.