### PR TITLE
chore(repo): switch to npm trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -92,4 +92,4 @@ jobs:
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Replaces `NPM_TOKEN` secret authentication with OIDC-based [npm trusted publishing](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions).

**Changes:**
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from both publish jobs
- Add `NPM_CONFIG_PROVENANCE: true` to enable provenance attestation via OIDC

**Prerequisites (already done):**
- Workflow has `permissions.id-token: write`
- Both jobs use `environment: npm`
- All 14 packages registered with trusted publisher on npmjs.com (`thymianofficial/thymian` / `release.yaml` / `npm`)

After merging, the first canary release will validate the setup. Once confirmed working, the `NPM_TOKEN` secret can be removed from the repo.