### PR TITLE
chore(repo): add npm keywords to all published packages

### DIFF
--- a/packages/common-cli/package.json
+++ b/packages/common-cli/package.json
@@ -15,6 +15,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "cli",
+    "oclif",
+    "api-governance",
+    "command-line",
+    "configuration"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core-testing/package.json
+++ b/packages/core-testing/package.json
@@ -15,6 +15,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "testing",
+    "test-utils",
+    "plugin-testing",
+    "http-mocks",
+    "api-testing"
+  ],
   "main": "./dist/index.js",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-governance",
+    "http",
+    "http-conformance",
+    "plugin-system",
+    "rule-engine",
+    "validation"
+  ],
   "files": [
     "dist",
     "!**/*.tsbuildinfo"

--- a/packages/plugin-http-analyzer/package.json
+++ b/packages/plugin-http-analyzer/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-conformance",
+    "har",
+    "http",
+    "http-analysis",
+    "traffic-analysis",
+    "validator"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-http-linter/package.json
+++ b/packages/plugin-http-linter/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-linter",
+    "lint",
+    "linter",
+    "openapi-linter",
+    "rfc-9110",
+    "static-analysis"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-http-tester/package.json
+++ b/packages/plugin-http-tester/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-testing",
+    "conformance-testing",
+    "http-testing",
+    "rfc-9110",
+    "rest-api",
+    "validator"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "open-api",
+    "openapi",
+    "openapi-parser",
+    "parser",
+    "specification",
+    "swagger"
+  ],
   "files": [
     "dist",
     "!**/*.tsbuildinfo"

--- a/packages/plugin-reporter/package.json
+++ b/packages/plugin-reporter/package.json
@@ -15,6 +15,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-reports",
+    "ci",
+    "reporter",
+    "reporting",
+    "test-reporter"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/plugin-request-dispatcher/package.json
+++ b/packages/plugin-request-dispatcher/package.json
@@ -15,6 +15,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-testing",
+    "http-client",
+    "http-request",
+    "request-dispatcher"
+  ],
   "files": [
     "dist",
     "!**/*.tsbuildinfo"

--- a/packages/plugin-sampler/package.json
+++ b/packages/plugin-sampler/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-examples",
+    "openapi",
+    "openapi-sampler",
+    "request-generation",
+    "sample-data",
+    "test-data"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-websocket-proxy/package.json
+++ b/packages/plugin-websocket-proxy/package.json
@@ -15,6 +15,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "extensibility",
+    "remote-plugins",
+    "websocket"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rules-api-description-validation/package.json
+++ b/packages/rules-api-description-validation/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-design",
+    "api-governance",
+    "lint",
+    "openapi",
+    "openapi-validation",
+    "validation"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rules-rfc-9110/package.json
+++ b/packages/rules-rfc-9110/package.json
@@ -15,6 +15,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api-governance",
+    "http",
+    "http-conformance",
+    "http-rules",
+    "http-semantics",
+    "rfc-9110"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/thymian/package.json
+++ b/packages/thymian/package.json
@@ -15,6 +15,21 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "thymian",
+    "api",
+    "api-governance",
+    "api-linter",
+    "api-testing",
+    "http",
+    "http-conformance",
+    "linter",
+    "openapi",
+    "rest-api",
+    "rfc-9110",
+    "swagger",
+    "validator"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds SEO-optimized `keywords` arrays to all 14 published `package.json` files in the monorepo for improved npm discoverability.

## Main package (`thymian`)

```
thymian, api, api-governance, api-linter, api-testing, http,
http-conformance, linter, openapi, rest-api, rfc-9110, swagger, validator
```

## Approach

- Keywords based on competitor analysis of `eslint`, `@redocly/cli`, and `@apidevtools/swagger-parser`
- High-volume single-word terms (`api`, `http`, `linter`, `validator`) alongside domain-specific compound phrases
- Variant spellings where valuable (`openapi` + `open-api`)
- Every published package includes `thymian` for ecosystem discoverability
- No keywords wasted on terms already present in the package name

## Packages updated

| Package | Keywords |
|---|---|
| `thymian` | thymian, api, api-governance, api-linter, api-testing, http, http-conformance, linter, openapi, rest-api, rfc-9110, swagger, validator |
| `@thymian/core` | thymian, api-governance, http, http-conformance, plugin-system, rule-engine, validation |
| `@thymian/core-testing` | thymian, testing, test-utils, plugin-testing, http-mocks, api-testing |
| `@thymian/common-cli` | thymian, cli, oclif, api-governance, command-line, configuration |
| `@thymian/plugin-http-analyzer` | thymian, api-conformance, har, http, http-analysis, traffic-analysis, validator |
| `@thymian/plugin-http-linter` | thymian, api-linter, lint, linter, openapi-linter, rfc-9110, static-analysis |
| `@thymian/plugin-http-tester` | thymian, api-testing, conformance-testing, http-testing, rfc-9110, rest-api, validator |
| `@thymian/plugin-openapi` | thymian, open-api, openapi, openapi-parser, parser, specification, swagger |
| `@thymian/plugin-reporter` | thymian, api-reports, ci, reporter, reporting, test-reporter |
| `@thymian/plugin-request-dispatcher` | thymian, api-testing, http-client, http-request, request-dispatcher |
| `@thymian/plugin-sampler` | thymian, api-examples, openapi, openapi-sampler, request-generation, sample-data, test-data |
| `@thymian/plugin-websocket-proxy` | thymian, extensibility, remote-plugins, websocket |
| `@thymian/rules-api-description-validation` | thymian, api-design, api-governance, lint, openapi, openapi-validation, validation |
| `@thymian/rules-rfc-9110` | thymian, api-governance, http, http-conformance, http-rules, http-semantics, rfc-9110 |