### PR TITLE
fix(release): upgrade release workflow to Node 24 for trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
@@ -73,7 +73,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Node 22 ships with npm 10.9.7 which does not support npm trusted publishing (requires npm 11.5.1+). The 0.1.5 release failed because `setup-node` auto-set `NPM_CONFIG_PROVENANCE=true` (due to `id-token: write`), but npm 10.x can't handle the OIDC flow, resulting in a 404 on `@thymian/core`.

Node 24 ships with npm 11.x which supports trusted publishing natively.

Fixes: https://github.com/thymianofficial/thymian/actions/runs/24469015085