### PR TITLE
fix(release): override NODE_AUTH_TOKEN to force OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,10 @@ jobs:
 
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
+        env:
+          # Explicitly unset NODE_AUTH_TOKEN so npm uses OIDC (trusted publishing)
+          # instead of the stale token injected by the npm environment secret.
+          NODE_AUTH_TOKEN: ''
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -89,3 +93,7 @@ jobs:
 
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
+        env:
+          # Explicitly unset NODE_AUTH_TOKEN so npm uses OIDC (trusted publishing)
+          # instead of the stale token injected by the npm environment secret.
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
The `npm` GitHub environment has an `NPM_TOKEN` secret that gets injected as `NODE_AUTH_TOKEN`. `setup-node`'s `registry-url` writes `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, causing npm to use this token instead of OIDC.

Since the token predates the trusted publishing setup, npm uses it, gets a 404 on `@thymian/core`, and bails.

**Fix:** Set `NODE_AUTH_TOKEN: ''` on both publish steps to force npm 11 to fall through to OIDC token exchange.

Once verified working, the `NPM_TOKEN` secret should be deleted from the `npm` environment entirely.