### PR TITLE
fix(release): strip _authToken from .npmrc to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
+        env:
+          NODE_AUTH_TOKEN: ''
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -103,3 +105,5 @@ jobs:
 
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,26 +58,11 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      # NX constructs `npm publish ... --"@thymian:registry=..."` for scoped packages.
-      # This scope-specific registry flag prevents npm from triggering the OIDC token
-      # exchange required for trusted publishing — npm looks for @thymian:_authToken
-      # instead of the OIDC flow. This is a fundamental design in NX (unchanged in
-      # latest master). Workaround: use NX for versioning only (--skip-publish), then
-      # publish each package directly via `npm publish` which correctly uses OIDC.
-      - name: Version packages via NX
-        id: nx-version
-        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local --skip-publish
+      - name: Publish canary release
+        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ''
-
-      - name: Publish canary to npm
-        run: |
-          for pkg in packages/*/; do
-            echo "Publishing $pkg..."
-            (cd "$pkg" && npm publish --access public --tag canary)
-          done
-        env:
-          NODE_AUTH_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: 'true'
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -92,6 +77,10 @@ jobs:
             TAG="${{ inputs.tag }}"
           else
             TAG="${{ github.event.release.tag_name }}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Tag is required for publish-latest-release but was empty"
+            exit 1
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Using tag: $TAG"
@@ -132,10 +121,10 @@ jobs:
       # NX constructs `npm publish ... --"@thymian:registry=..."` for scoped packages.
       # This scope-specific registry flag prevents npm from triggering the OIDC token
       # exchange required for trusted publishing — npm looks for @thymian:_authToken
-      # instead of the OIDC flow. This is a fundamental design in NX (unchanged in
-      # latest master). Workaround: use NX for versioning only (--skip-publish), then
-      # publish each package directly via `npm publish` which correctly uses OIDC.
-      - name: Version packages via NX
+      # instead of the OIDC flow. This is unfixed in NX as of v22.5+.
+      # Workaround: use NX for versioning only (--skip-publish), then publish each
+      # package directly via `npm publish` which correctly uses OIDC.
+      - name: Version and build packages via NX
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local --skip-publish
         env:
           NODE_AUTH_TOKEN: ''
@@ -148,3 +137,4 @@ jobs:
           done
         env:
           NODE_AUTH_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,17 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag to publish'
+      job:
+        description: 'Which job to run'
         required: true
+        type: choice
+        options:
+          - publish-latest-release
+          - canary-release
+        default: publish-latest-release
+      tag:
+        description: 'Tag to publish (required for publish-latest-release)'
+        required: false
         type: string
 
 permissions:
@@ -23,7 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
+    if: |
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.job == 'canary-release')
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -41,6 +51,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Compute canary version
+        id: canary-version
+        run: |
+          HASH=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y%m%d%H%M%S)
+          # Derive next semver base from latest tag
+          BASE=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo '0.0.0')
+          CANARY="${BASE}-canary.${DATE}.${HASH}"
+          echo "version=$CANARY" >> $GITHUB_OUTPUT
+          echo "Canary version: $CANARY"
+
       - name: Strip token auth from .npmrc for OIDC
         run: |
           NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
@@ -48,8 +69,29 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Publish canary release
-        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
+      - name: Version all packages to ${{ steps.canary-version.outputs.version }}
+        run: |
+          VERSION="${{ steps.canary-version.outputs.version }}"
+          for f in packages/*/package.json; do
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('$f', 'utf8'));
+              pkg.version = '$VERSION';
+              fs.writeFileSync('$f', JSON.stringify(pkg, null, 2) + '\\n');
+            "
+            echo "Versioned $f to $VERSION"
+          done
+
+      - name: Build packages
+        run: npx nx run-many -t build --exclude astro --no-tui
+
+      - name: Publish canary to npm
+        run: |
+          for pkg in packages/*/; do
+            pkgname=$(node -e "const d=require('./${pkg}package.json'); console.log(d.name)")
+            echo "Publishing $pkgname..."
+            (cd "$pkg" && npm publish --access public --tag canary)
+          done
         env:
           NODE_AUTH_TOKEN: ''
 
@@ -57,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.job == 'publish-latest-release')
     steps:
       - name: Determine tag
         id: determine-tag
@@ -103,7 +145,28 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Publish to npm
-        run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
+      - name: Version all packages to ${{ steps.extract-version.outputs.version }}
+        run: |
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          for f in packages/*/package.json; do
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('$f', 'utf8'));
+              pkg.version = '$VERSION';
+              fs.writeFileSync('$f', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Versioned $f to $VERSION"
+          done
+
+      - name: Build packages
+        run: npx nx run-many -t build --exclude astro --no-tui
+
+      - name: Publish packages to npm
+        run: |
+          for pkg in packages/*/; do
+            pkgname=$(node -e "const d=require('./${pkg}package.json'); console.log(d.name)")
+            echo "Publishing $pkgname..."
+            (cd "$pkg" && npm publish --access public)
+          done
         env:
           NODE_AUTH_TOKEN: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,11 +58,26 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Publish canary release
-        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
+      # NX constructs `npm publish ... --"@thymian:registry=..."` for scoped packages.
+      # This scope-specific registry flag prevents npm from triggering the OIDC token
+      # exchange required for trusted publishing — npm looks for @thymian:_authToken
+      # instead of the OIDC flow. This is a fundamental design in NX (unchanged in
+      # latest master). Workaround: use NX for versioning only (--skip-publish), then
+      # publish each package directly via `npm publish` which correctly uses OIDC.
+      - name: Version packages via NX
+        id: nx-version
+        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local --skip-publish
         env:
           NODE_AUTH_TOKEN: ''
-          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Publish canary to npm
+        run: |
+          for pkg in packages/*/; do
+            echo "Publishing $pkg..."
+            (cd "$pkg" && npm publish --access public --tag canary)
+          done
+        env:
+          NODE_AUTH_TOKEN: ''
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -114,6 +129,12 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
+      # NX constructs `npm publish ... --"@thymian:registry=..."` for scoped packages.
+      # This scope-specific registry flag prevents npm from triggering the OIDC token
+      # exchange required for trusted publishing — npm looks for @thymian:_authToken
+      # instead of the OIDC flow. This is a fundamental design in NX (unchanged in
+      # latest master). Workaround: use NX for versioning only (--skip-publish), then
+      # publish each package directly via `npm publish` which correctly uses OIDC.
       - name: Version packages via NX
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local --skip-publish
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,17 +9,9 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      job:
-        description: 'Which job to run'
-        required: true
-        type: choice
-        options:
-          - publish-latest-release
-          - canary-release
-        default: publish-latest-release
       tag:
-        description: 'Tag to publish (required for publish-latest-release)'
-        required: false
+        description: 'Tag to publish'
+        required: true
         type: string
 
 permissions:
@@ -31,9 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: |
-      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')) ||
-      (github.event_name == 'workflow_dispatch' && inputs.job == 'canary-release')
+    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-canary]')"
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -46,29 +36,20 @@ jobs:
         with:
           node-version: '24'
           cache: npm
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Strip token auth from .npmrc for OIDC
-        run: |
-          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          if [ -f "$NPMRC" ]; then
-            sed -i '/_authToken/d' "$NPMRC"
-          fi
-
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
         env:
-          NODE_AUTH_TOKEN: ''
-          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_PROVENANCE: true
 
   publish-latest-release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
-    if: (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && inputs.job == 'publish-latest-release')
+    if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Determine tag
         id: determine-tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,8 +114,16 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Publish to npm
-        run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
+      - name: Version packages via NX
+        run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local --skip-publish
         env:
           NODE_AUTH_TOKEN: ''
-          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Publish packages to npm
+        run: |
+          for pkg in packages/*/; do
+            echo "Publishing $pkg..."
+            (cd "$pkg" && npm publish --access public --tag latest)
+          done
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,11 @@ jobs:
         run: npm ci
 
       - name: Strip token auth from .npmrc for OIDC
-        run: sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        run: |
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          if [ -f "$NPMRC" ]; then
+            sed -i '/_authToken/d' "$NPMRC"
+          fi
 
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
@@ -93,10 +97,9 @@ jobs:
       - name: Strip token auth from .npmrc for OIDC
         run: |
           NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          echo "Removing _authToken from $NPMRC to enable OIDC trusted publishing"
-          sed -i '/_authToken/d' "$NPMRC"
-          echo "--- .npmrc after strip ---"
-          cat "$NPMRC"
+          if [ -f "$NPMRC" ]; then
+            sed -i '/_authToken/d' "$NPMRC"
+          fi
 
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,28 +114,8 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Version all packages to ${{ steps.extract-version.outputs.version }}
-        run: |
-          VERSION="${{ steps.extract-version.outputs.version }}"
-          for f in packages/*/package.json; do
-            node -e "
-              const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('$f', 'utf8'));
-              pkg.version = '$VERSION';
-              fs.writeFileSync('$f', JSON.stringify(pkg, null, 2) + '\n');
-            "
-            echo "Versioned $f to $VERSION"
-          done
-
-      - name: Build packages
-        run: npx nx run-many -t build --exclude astro --no-tui
-
-      - name: Publish packages to npm
-        run: |
-          for pkg in packages/*/; do
-            pkgname=$(node -e "const d=require('./${pkg}package.json'); console.log(d.name)")
-            echo "Publishing $pkgname..."
-            (cd "$pkg" && npm publish --access public)
-          done
+      - name: Publish to npm
+        run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,17 +51,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Compute canary version
-        id: canary-version
-        run: |
-          HASH=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y%m%d%H%M%S)
-          # Derive next semver base from latest tag
-          BASE=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo '0.0.0')
-          CANARY="${BASE}-canary.${DATE}.${HASH}"
-          echo "version=$CANARY" >> $GITHUB_OUTPUT
-          echo "Canary version: $CANARY"
-
       - name: Strip token auth from .npmrc for OIDC
         run: |
           NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
@@ -69,31 +58,11 @@ jobs:
             sed -i '/_authToken/d' "$NPMRC"
           fi
 
-      - name: Version all packages to ${{ steps.canary-version.outputs.version }}
-        run: |
-          VERSION="${{ steps.canary-version.outputs.version }}"
-          for f in packages/*/package.json; do
-            node -e "
-              const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('$f', 'utf8'));
-              pkg.version = '$VERSION';
-              fs.writeFileSync('$f', JSON.stringify(pkg, null, 2) + '\\n');
-            "
-            echo "Versioned $f to $VERSION"
-          done
-
-      - name: Build packages
-        run: npx nx run-many -t build --exclude astro --no-tui
-
-      - name: Publish canary to npm
-        run: |
-          for pkg in packages/*/; do
-            pkgname=$(node -e "const d=require('./${pkg}package.json'); console.log(d.name)")
-            echo "Publishing $pkgname..."
-            (cd "$pkg" && npm publish --access public --tag canary)
-          done
+      - name: Publish canary release
+        run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
         env:
           NODE_AUTH_TOKEN: ''
+          NPM_CONFIG_PROVENANCE: 'true'
 
   publish-latest-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,12 +41,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Strip token auth from .npmrc for OIDC
+        run: sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+
       - name: Publish canary release
         run: node ./scripts/release.ts --dist-tag canary --no-dry-run --no-local
-        env:
-          # Explicitly unset NODE_AUTH_TOKEN so npm uses OIDC (trusted publishing)
-          # instead of the stale token injected by the npm environment secret.
-          NODE_AUTH_TOKEN: ''
 
   publish-latest-release:
     runs-on: ubuntu-latest
@@ -91,26 +90,13 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
-      - name: Debug OIDC environment
-        if: github.event_name == 'workflow_dispatch'
+      - name: Strip token auth from .npmrc for OIDC
         run: |
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: $(test -n "$ACTIONS_ID_TOKEN_REQUEST_URL" && echo true || echo false)"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN length: ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
-          echo "NODE_AUTH_TOKEN length: ${#NODE_AUTH_TOKEN}"
           NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          echo "npmrc path: $NPMRC"
-          if [ -f "$NPMRC" ]; then
-            grep -v '_authToken\|_password\|_auth' "$NPMRC" || echo "(no non-auth lines)"
-          else
-            echo "No .npmrc found at $NPMRC"
-          fi
-          npm config list
-        env:
-          NODE_AUTH_TOKEN: ''
+          echo "Removing _authToken from $NPMRC to enable OIDC trusted publishing"
+          sed -i '/_authToken/d' "$NPMRC"
+          echo "--- .npmrc after strip ---"
+          cat "$NPMRC"
 
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
-        env:
-          # Explicitly unset NODE_AUTH_TOKEN so npm uses OIDC (trusted publishing)
-          # instead of the stale token injected by the npm environment secret.
-          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,17 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
+      - name: Debug OIDC environment
+        run: |
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN length: ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
+          echo "NODE_AUTH_TOKEN length: ${#NODE_AUTH_TOKEN}"
+          echo "NPM_CONFIG_USERCONFIG: $NPM_CONFIG_USERCONFIG"
+          cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null || echo "No .npmrc found"
+          npm config list
+        env:
+          NODE_AUTH_TOKEN: ''
+
       - name: Publish to npm
         run: node ./scripts/release.ts --dist-tag latest --version ${{ steps.extract-version.outputs.version }} --no-dry-run --no-local
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,12 +92,18 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Debug OIDC environment
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL is set: $(test -n "$ACTIONS_ID_TOKEN_REQUEST_URL" && echo true || echo false)"
           echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN length: ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
           echo "NODE_AUTH_TOKEN length: ${#NODE_AUTH_TOKEN}"
-          echo "NPM_CONFIG_USERCONFIG: $NPM_CONFIG_USERCONFIG"
-          cat "$NPM_CONFIG_USERCONFIG" 2>/dev/null || echo "No .npmrc found"
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "npmrc path: $NPMRC"
+          if [ -f "$NPMRC" ]; then
+            grep -v '_authToken\|_password\|_auth' "$NPMRC" || echo "(no non-auth lines)"
+          else
+            echo "No .npmrc found at $NPMRC"
+          fi
           npm config list
         env:
           NODE_AUTH_TOKEN: ''

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -25,6 +25,7 @@ interface ValidatedArguments {
   firstRelease: boolean;
   verbose: boolean;
   local: boolean;
+  skipPublish: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ function validateAndDetermineMode(argv: {
   firstRelease: boolean;
   verbose: boolean;
   local: boolean;
+  skipPublish: boolean;
 }): ValidatedArguments {
   const isCanary = argv.distTag === 'canary';
   const isLatest = argv.distTag === 'latest';
@@ -88,6 +90,7 @@ function validateAndDetermineMode(argv: {
     firstRelease: argv.firstRelease,
     verbose: argv.verbose,
     local: argv.local,
+    skipPublish: argv.skipPublish,
   };
 }
 
@@ -323,6 +326,13 @@ async function runCIPublishRelease(
     gitTag: false,
   });
 
+  if (argv.skipPublish) {
+    console.log(
+      '\n📋 SKIP-PUBLISH: Versioning complete. Skipping NX publish — publishing handled externally.\n',
+    );
+    process.exit(0);
+  }
+
   // Publish to npm (skip changelog - already created during local release)
   const publishResults = await client.releasePublish({
     releaseGraph,
@@ -458,6 +468,12 @@ async function runLocalRelease(
       type: 'boolean',
       default: true,
     })
+    .option('skipPublish', {
+      description:
+        'Skip the NX publish step after versioning. Use for trusted publishing where npm publish is called directly.',
+      type: 'boolean',
+      default: false,
+    })
     .parseAsync();
 
   // Validate arguments and determine mode
@@ -468,6 +484,7 @@ async function runLocalRelease(
     firstRelease: argv.firstRelease,
     verbose: argv.verbose,
     local: argv.local,
+    skipPublish: argv.skipPublish,
   });
 
   // Display configuration

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -152,6 +152,19 @@ async function runCanaryRelease(
     gitTag: false,
   });
 
+  if (argv.skipPublish) {
+    // Emit the computed version for the workflow to capture via GITHUB_OUTPUT
+    const githubOutput = process.env.GITHUB_OUTPUT;
+    if (githubOutput) {
+      const { appendFileSync } = await import('node:fs');
+      appendFileSync(githubOutput, `canary_version=${canaryVersionString}\n`);
+    }
+    console.log(
+      `\n📋 SKIP-PUBLISH: Versioning complete at ${canaryVersionString}. Skipping NX publish — publishing handled externally.\n`,
+    );
+    process.exit(0);
+  }
+
   // Publish with canary dist-tag (no changelog for canary)
   const publishResults = await client.releasePublish({
     releaseGraph,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -126,21 +126,14 @@ async function runCanaryRelease(
     });
 
     if (!nextVersion) {
-      // No conventional-commit bump detected — fall back to current latest tag
-      // so canary builds on branches still get a meaningful version.
-      const fallback = execSync(
-        'git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0"',
-      )
-        .toString()
-        .trim()
-        .replace(/^v/, '');
       console.log(
-        `ℹ️  No conventional-commit bump detected. Using latest tag as base: ${fallback}\n`,
+        'ℹ️  No release needed (no relevant commits since last release)',
       );
-      baseVersion = fallback;
-    } else {
-      baseVersion = nextVersion;
+      console.log('   Exiting gracefully.\n');
+      process.exit(0);
     }
+
+    baseVersion = nextVersion;
   }
 
   const commitHash = getCurrentCommitHash();

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -159,19 +159,6 @@ async function runCanaryRelease(
     gitTag: false,
   });
 
-  if (argv.skipPublish) {
-    // Emit the computed version for the workflow to capture via GITHUB_OUTPUT
-    const githubOutput = process.env.GITHUB_OUTPUT;
-    if (githubOutput) {
-      const { appendFileSync } = await import('node:fs');
-      appendFileSync(githubOutput, `canary_version=${canaryVersionString}\n`);
-    }
-    console.log(
-      `\n📋 SKIP-PUBLISH: Versioning complete at ${canaryVersionString}. Skipping NX publish — publishing handled externally.\n`,
-    );
-    process.exit(0);
-  }
-
   // Publish with canary dist-tag (no changelog for canary)
   const publishResults = await client.releasePublish({
     releaseGraph,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -126,14 +126,21 @@ async function runCanaryRelease(
     });
 
     if (!nextVersion) {
+      // No conventional-commit bump detected — fall back to current latest tag
+      // so canary builds on branches still get a meaningful version.
+      const fallback = execSync(
+        'git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0"',
+      )
+        .toString()
+        .trim()
+        .replace(/^v/, '');
       console.log(
-        'ℹ️  No release needed (no relevant commits since last release)',
+        `ℹ️  No conventional-commit bump detected. Using latest tag as base: ${fallback}\n`,
       );
-      console.log('   Exiting gracefully.\n');
-      process.exit(0);
+      baseVersion = fallback;
+    } else {
+      baseVersion = nextVersion;
     }
-
-    baseVersion = nextVersion;
   }
 
   const commitHash = getCurrentCommitHash();


### PR DESCRIPTION
**Root cause:** `setup-node` creates `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`. Even when `NODE_AUTH_TOKEN` is empty, npm sees the `_authToken` config entry and tries token auth (empty token → "not logged in") instead of falling through to OIDC.

Debug output confirmed OIDC env vars ARE available (`ACTIONS_ID_TOKEN_REQUEST_URL` set, token length 4051).

**Fix:** Strip the `_authToken` line from `.npmrc` before publish so npm detects the OIDC environment and does the token exchange. Guarded with `-f` check so the step is a no-op if no `.npmrc` exists.

Applied to both `canary-release` and `publish-latest-release` jobs.

**To test:** Merge, then trigger `workflow_dispatch` with tag `0.1.6`.