### PR TITLE
feat(thymian): skip schema validation for specification by default

### DIFF
--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -138,6 +138,13 @@ export abstract class BaseCliRunCommand<
       description: 'Suppress feedback messages from Thymian.',
       helpGroup: 'BASE',
     }),
+    ['skip-spec-validation']: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description:
+        'Skip schema validation when loading specifications. Use --no-skip-spec-validation to enable validation.',
+      helpGroup: 'BASE',
+    }),
   };
 
   protected flags!: CommandFlags<T>;

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -138,11 +138,11 @@ export abstract class BaseCliRunCommand<
       description: 'Suppress feedback messages from Thymian.',
       helpGroup: 'BASE',
     }),
-    ['skip-spec-validation']: Flags.boolean({
-      default: true,
+    ['validate-specs']: Flags.boolean({
+      default: false,
       allowNo: true,
       description:
-        'Do not fail on schema validation errors when loading specifications.',
+        'Validate included specifications and fail on schema validation errors.',
       helpGroup: 'BASE',
     }),
   };

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -142,7 +142,7 @@ export abstract class BaseCliRunCommand<
       default: true,
       allowNo: true,
       description:
-        'Skip schema validation when loading specifications. Use --no-skip-spec-validation to enable validation.',
+        'Do not fail on schema validation errors when loading specifications.',
       helpGroup: 'BASE',
     }),
   };

--- a/packages/core/src/actions/format-load.action.ts
+++ b/packages/core/src/actions/format-load.action.ts
@@ -11,6 +11,7 @@ export interface SpecificationInput {
 
 export interface CoreFormatLoadInput {
   inputs: SpecificationInput[];
+  skipSpecValidation?: boolean;
   options?: Record<string, unknown>;
 }
 
@@ -46,6 +47,10 @@ export const formatLoadActionSchema = {
       type: 'array',
       nullable: false,
       items: specificationInputSchema,
+    },
+    skipSpecValidation: {
+      type: 'boolean',
+      nullable: true,
     },
     options: {
       type: 'object',

--- a/packages/core/src/actions/format-load.action.ts
+++ b/packages/core/src/actions/format-load.action.ts
@@ -40,7 +40,7 @@ export const specificationInputSchema = {
 export const formatLoadActionSchema = {
   type: 'object',
   nullable: false,
-  required: ['inputs'],
+  required: ['inputs', 'skipSpecValidation'],
   additionalProperties: false,
   properties: {
     inputs: {
@@ -50,7 +50,7 @@ export const formatLoadActionSchema = {
     },
     skipSpecValidation: {
       type: 'boolean',
-      nullable: true,
+      nullable: false,
     },
     options: {
       type: 'object',

--- a/packages/core/src/actions/format-load.action.ts
+++ b/packages/core/src/actions/format-load.action.ts
@@ -11,7 +11,7 @@ export interface SpecificationInput {
 
 export interface CoreFormatLoadInput {
   inputs: SpecificationInput[];
-  skipSpecValidation: boolean;
+  validateSpecs: boolean;
   options?: Record<string, unknown>;
 }
 
@@ -40,7 +40,7 @@ export const specificationInputSchema = {
 export const formatLoadActionSchema = {
   type: 'object',
   nullable: false,
-  required: ['inputs', 'skipSpecValidation'],
+  required: ['inputs', 'validateSpecs'],
   additionalProperties: false,
   properties: {
     inputs: {
@@ -48,7 +48,7 @@ export const formatLoadActionSchema = {
       nullable: false,
       items: specificationInputSchema,
     },
-    skipSpecValidation: {
+    validateSpecs: {
       type: 'boolean',
       nullable: false,
     },

--- a/packages/core/src/actions/format-load.action.ts
+++ b/packages/core/src/actions/format-load.action.ts
@@ -11,7 +11,7 @@ export interface SpecificationInput {
 
 export interface CoreFormatLoadInput {
   inputs: SpecificationInput[];
-  skipSpecValidation?: boolean;
+  skipSpecValidation: boolean;
   options?: Record<string, unknown>;
 }
 

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -324,7 +324,7 @@ export class Thymian {
       this.loadFormat(
         {
           inputs: input.specification,
-          skipSpecValidation: input.skipSpecValidation,
+          skipSpecValidation: input.skipSpecValidation ?? true,
         },
         { emitFormat: false },
       ),
@@ -359,7 +359,7 @@ export class Thymian {
     const [format, rules] = await Promise.all([
       this.loadFormat({
         inputs: input.specification,
-        skipSpecValidation: input.skipSpecValidation,
+        skipSpecValidation: input.skipSpecValidation ?? true,
       }),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
     ]);
@@ -395,7 +395,7 @@ export class Thymian {
         ? this.loadFormat(
             {
               inputs: input.specification,
-              skipSpecValidation: input.skipSpecValidation,
+              skipSpecValidation: input.skipSpecValidation ?? true,
             },
             { emitFormat: false },
           )

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -46,6 +46,7 @@ export interface LintWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
+  skipSpecValidation?: boolean;
 }
 
 export interface TestWorkflowInput {
@@ -54,6 +55,7 @@ export interface TestWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
+  skipSpecValidation?: boolean;
   targetUrl?: string;
 }
 
@@ -64,6 +66,7 @@ export interface AnalyzeWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
+  skipSpecValidation?: boolean;
 }
 
 export type RegisteredPlugin<
@@ -318,7 +321,13 @@ export class Thymian {
     this.logger.info('Loading specification and rules...');
 
     const [format, rules] = await Promise.all([
-      this.loadFormat({ inputs: input.specification }, { emitFormat: false }),
+      this.loadFormat(
+        {
+          inputs: input.specification,
+          options: { skipSpecValidation: input.skipSpecValidation },
+        },
+        { emitFormat: false },
+      ),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
     ]);
 
@@ -348,7 +357,10 @@ export class Thymian {
     const { rulesConfig, ruleFilter } = input;
 
     const [format, rules] = await Promise.all([
-      this.loadFormat({ inputs: input.specification }),
+      this.loadFormat({
+        inputs: input.specification,
+        options: { skipSpecValidation: input.skipSpecValidation },
+      }),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
     ]);
 
@@ -381,7 +393,10 @@ export class Thymian {
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
       input.specification
         ? this.loadFormat(
-            { inputs: input.specification },
+            {
+              inputs: input.specification,
+              options: { skipSpecValidation: input.skipSpecValidation },
+            },
             { emitFormat: false },
           )
         : Promise.resolve(undefined),

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -46,7 +46,7 @@ export interface LintWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
-  skipSpecValidation?: boolean;
+  validateSpecs?: boolean;
 }
 
 export interface TestWorkflowInput {
@@ -55,7 +55,7 @@ export interface TestWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
-  skipSpecValidation?: boolean;
+  validateSpecs?: boolean;
   targetUrl?: string;
 }
 
@@ -66,7 +66,7 @@ export interface AnalyzeWorkflowInput {
   rulesConfig?: RulesConfiguration;
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
-  skipSpecValidation?: boolean;
+  validateSpecs?: boolean;
 }
 
 export type RegisteredPlugin<
@@ -324,7 +324,7 @@ export class Thymian {
       this.loadFormat(
         {
           inputs: input.specification,
-          skipSpecValidation: input.skipSpecValidation ?? true,
+          validateSpecs: input.validateSpecs ?? false,
         },
         { emitFormat: false },
       ),
@@ -359,7 +359,7 @@ export class Thymian {
     const [format, rules] = await Promise.all([
       this.loadFormat({
         inputs: input.specification,
-        skipSpecValidation: input.skipSpecValidation ?? true,
+        validateSpecs: input.validateSpecs ?? false,
       }),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
     ]);
@@ -395,7 +395,7 @@ export class Thymian {
         ? this.loadFormat(
             {
               inputs: input.specification,
-              skipSpecValidation: input.skipSpecValidation ?? true,
+              validateSpecs: input.validateSpecs ?? false,
             },
             { emitFormat: false },
           )

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -324,7 +324,7 @@ export class Thymian {
       this.loadFormat(
         {
           inputs: input.specification,
-          options: { skipSpecValidation: input.skipSpecValidation },
+          skipSpecValidation: input.skipSpecValidation,
         },
         { emitFormat: false },
       ),
@@ -359,7 +359,7 @@ export class Thymian {
     const [format, rules] = await Promise.all([
       this.loadFormat({
         inputs: input.specification,
-        options: { skipSpecValidation: input.skipSpecValidation },
+        skipSpecValidation: input.skipSpecValidation,
       }),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
     ]);
@@ -395,7 +395,7 @@ export class Thymian {
         ? this.loadFormat(
             {
               inputs: input.specification,
-              options: { skipSpecValidation: input.skipSpecValidation },
+              skipSpecValidation: input.skipSpecValidation,
             },
             { emitFormat: false },
           )

--- a/packages/core/test/thymian.test.ts
+++ b/packages/core/test/thymian.test.ts
@@ -232,7 +232,7 @@ describe('Thymian', () => {
 
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
-        skipSpecValidation: true,
+        validateSpecs: false,
       });
       expect(coreLintSpy).toHaveBeenCalledTimes(1);
       expect(coreLintSpy.mock.calls[0]?.[0]).toMatchObject({
@@ -295,7 +295,7 @@ describe('Thymian', () => {
 
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
-        skipSpecValidation: true,
+        validateSpecs: false,
       });
       expect(coreTestSpy).toHaveBeenCalledTimes(1);
       expect(coreTestSpy.mock.calls[0]?.[0]).toMatchObject({
@@ -425,7 +425,7 @@ describe('Thymian', () => {
       });
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
-        skipSpecValidation: true,
+        validateSpecs: false,
       });
       expect(coreAnalyzeSpy).toHaveBeenCalledTimes(1);
       expect(coreAnalyzeSpy.mock.calls[0]?.[0]).toMatchObject({

--- a/packages/core/test/thymian.test.ts
+++ b/packages/core/test/thymian.test.ts
@@ -232,6 +232,7 @@ describe('Thymian', () => {
 
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+        skipSpecValidation: true,
       });
       expect(coreLintSpy).toHaveBeenCalledTimes(1);
       expect(coreLintSpy.mock.calls[0]?.[0]).toMatchObject({
@@ -294,6 +295,7 @@ describe('Thymian', () => {
 
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+        skipSpecValidation: true,
       });
       expect(coreTestSpy).toHaveBeenCalledTimes(1);
       expect(coreTestSpy.mock.calls[0]?.[0]).toMatchObject({
@@ -423,6 +425,7 @@ describe('Thymian', () => {
       });
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
+        skipSpecValidation: true,
       });
       expect(coreAnalyzeSpy).toHaveBeenCalledTimes(1);
       expect(coreAnalyzeSpy.mock.calls[0]?.[0]).toMatchObject({

--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -75,8 +75,10 @@ export const openApiPlugin: ThymianPlugin = {
       ctx.reply(thymianFormat.export());
     });
 
-    emitter.onAction('core.format.load', async ({ inputs }, ctx) => {
+    emitter.onAction('core.format.load', async ({ inputs, options }, ctx) => {
       let format = new ThymianFormat();
+
+      const skipValidation = options?.['skipSpecValidation'] === true;
 
       const descriptions = inputs.length
         ? inputs
@@ -110,6 +112,7 @@ export const openApiPlugin: ThymianPlugin = {
             sourceName: description.sourceName,
             cwd: opts.cwd,
             filter: constant(true),
+            skipValidation,
           },
         );
         format = thymianFormat;

--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -75,56 +75,57 @@ export const openApiPlugin: ThymianPlugin = {
       ctx.reply(thymianFormat.export());
     });
 
-    emitter.onAction('core.format.load', async ({ inputs, options }, ctx) => {
-      let format = new ThymianFormat();
+    emitter.onAction(
+      'core.format.load',
+      async ({ inputs, skipSpecValidation }, ctx) => {
+        let format = new ThymianFormat();
 
-      const skipValidation = options?.['skipSpecValidation'] === true;
+        const descriptions = inputs.length
+          ? inputs
+              .filter((input) => input.type === 'openapi')
+              .map((input) => ({
+                source: String(input.location),
+                sourceName:
+                  typeof input.options?.['sourceName'] === 'string'
+                    ? input.options['sourceName']
+                    : undefined,
+                serverInfo:
+                  typeof input.options?.['serverInfo'] === 'object' &&
+                  input.options['serverInfo'] !== null
+                    ? (input.options['serverInfo'] as ServerInfo)
+                    : undefined,
+              }))
+          : [];
 
-      const descriptions = inputs.length
-        ? inputs
-            .filter((input) => input.type === 'openapi')
-            .map((input) => ({
-              source: String(input.location),
-              sourceName:
-                typeof input.options?.['sourceName'] === 'string'
-                  ? input.options['sourceName']
-                  : undefined,
-              serverInfo:
-                typeof input.options?.['serverInfo'] === 'object' &&
-                input.options['serverInfo'] !== null
-                  ? (input.options['serverInfo'] as ServerInfo)
-                  : undefined,
-            }))
-        : [];
+        if (descriptions.length === 0) {
+          ctx.reply(format.export());
+          return;
+        }
 
-      if (descriptions.length === 0) {
+        for (const description of descriptions) {
+          const [document, thymianFormat, filePath] = await loadAndTransform(
+            description.source,
+            {
+              logger,
+              format,
+              serverInfo: description.serverInfo ?? defaultServerInfo,
+              sourceName: description.sourceName,
+              cwd: opts.cwd,
+              filter: constant(true),
+              skipSpecValidation,
+            },
+          );
+          format = thymianFormat;
+
+          emitter.emit('openapi.document', {
+            document,
+            filePath,
+          });
+        }
+
         ctx.reply(format.export());
-        return;
-      }
-
-      for (const description of descriptions) {
-        const [document, thymianFormat, filePath] = await loadAndTransform(
-          description.source,
-          {
-            logger,
-            format,
-            serverInfo: description.serverInfo ?? defaultServerInfo,
-            sourceName: description.sourceName,
-            cwd: opts.cwd,
-            filter: constant(true),
-            skipValidation,
-          },
-        );
-        format = thymianFormat;
-
-        emitter.emit('openapi.document', {
-          document,
-          filePath,
-        });
-      }
-
-      ctx.reply(format.export());
-    });
+      },
+    );
   },
 };
 

--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -77,7 +77,7 @@ export const openApiPlugin: ThymianPlugin = {
 
     emitter.onAction(
       'core.format.load',
-      async ({ inputs, skipSpecValidation }, ctx) => {
+      async ({ inputs, validateSpecs }, ctx) => {
         let format = new ThymianFormat();
 
         const descriptions = inputs.length
@@ -112,7 +112,7 @@ export const openApiPlugin: ThymianPlugin = {
               sourceName: description.sourceName,
               cwd: opts.cwd,
               filter: constant(true),
-              skipSpecValidation,
+              validateSpecs,
             },
           );
           format = thymianFormat;

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -163,8 +163,19 @@ export async function loadAndUpgrade(
         },
       );
     } else {
+      const formattedValidationErrors =
+        validationResult.errors
+          ?.map((e) => {
+            const errorPath =
+              'path' in e
+                ? ` (at ${(e as Record<string, unknown>)['path']})`
+                : '';
+            return `  - ${e.message}${errorPath}`;
+          })
+          .join('\n') ?? '';
+
       logger.warn(
-        `Schema validation for ${sourceLabel} failed. Errors:${validationResult?.errors?.map((e) => '\n  - ' + e.message + ('path' in e ? ` (at ${(e as Record<string, unknown>)['path']})` : '')).join('. ') ?? ''}`,
+        `Schema validation for ${sourceLabel} failed.${formattedValidationErrors ? `\nErrors:\n${formattedValidationErrors}` : ''}`,
       );
     }
   } else {

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -149,7 +149,7 @@ export async function loadAndUpgrade(
 
     if (skipSpecValidation) {
       logger.warn(
-        `Schema validation for ${sourceLabel} failed. But \`skipSpecValidation\` is set to true.`,
+        `Schema validation for ${sourceLabel} failed. Errors:${validationResult?.errors?.map((e) => '\n  - ' + e.message + ('path' in e ? ` (at ${(e as Record<string, unknown>)['path']})` : '')).join('. ') ?? ''}`,
       );
     } else {
       throw new ThymianBaseError(

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -115,7 +115,7 @@ export async function loadAndUpgrade(
   value: string,
   cwd: string = process.cwd(),
   logger: Logger,
-  skipValidation = false,
+  skipSpecValidation = false,
 ): Promise<LoadResult> {
   const { document, filePath } = await loadOpenApi(value, cwd);
   const relativePath = filePath ? getRelativePath(filePath, cwd) : undefined;
@@ -147,9 +147,9 @@ export async function loadAndUpgrade(
       );
     }
 
-    if (skipValidation) {
+    if (skipSpecValidation) {
       logger.warn(
-        `Schema validation for ${sourceLabel} failed, but --skip-spec-validation is set. Continuing anyway.`,
+        `Schema validation for ${sourceLabel} failed. But \`skipSpecValidation\` is set to true.`,
       );
     } else {
       throw new ThymianBaseError(
@@ -255,14 +255,14 @@ export async function loadAndTransform(
     filter: HttpFilterExpression;
     format?: ThymianFormat;
     sourceName?: string;
-    skipValidation?: boolean;
+    skipSpecValidation?: boolean;
   },
 ): Promise<[OpenAPI.Document, ThymianFormat, string | undefined]> {
   const loadResult = await loadAndUpgrade(
     value,
     options.cwd,
     options.logger,
-    options.skipValidation,
+    options.skipSpecValidation,
   );
   const relativePath = loadResult.filePath
     ? getRelativePath(loadResult.filePath, options.cwd)

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -115,6 +115,7 @@ export async function loadAndUpgrade(
   value: string,
   cwd: string = process.cwd(),
   logger: Logger,
+  skipValidation = false,
 ): Promise<LoadResult> {
   const { document, filePath } = await loadOpenApi(value, cwd);
   const relativePath = filePath ? getRelativePath(filePath, cwd) : undefined;
@@ -146,20 +147,29 @@ export async function loadAndUpgrade(
       );
     }
 
-    throw new ThymianBaseError(`Schema validation for ${sourceLabel} failed.`, {
-      name: 'OpenAPIValidationError',
-      ref: 'https://thymian.dev/references/errors/openapi-validation-error/',
-      cause: new Error(
-        validationResult.errors.map((e) => e.message).join('; '),
-      ),
-      suggestions: [
-        'This indicates that your OpenAPI document does not match the OpenAPI specification. Use `thymian openapi:validate` to get detailed validation errors',
-        'Ensure all required fields are present (openapi, info, paths)',
-      ],
-    });
+    if (skipValidation) {
+      logger.warn(
+        `Schema validation for ${sourceLabel} failed, but --skip-spec-validation is set. Continuing anyway.`,
+      );
+    } else {
+      throw new ThymianBaseError(
+        `Schema validation for ${sourceLabel} failed.`,
+        {
+          name: 'OpenAPIValidationError',
+          ref: 'https://thymian.dev/references/errors/openapi-validation-error/',
+          cause: new Error(
+            validationResult.errors.map((e) => e.message).join('; '),
+          ),
+          suggestions: [
+            'This indicates that your OpenAPI document does not match the OpenAPI specification. Use `thymian openapi:validate` to get detailed validation errors',
+            'Ensure all required fields are present (openapi, info, paths)',
+          ],
+        },
+      );
+    }
+  } else {
+    logger.debug(`Successfully validated ${sourceLabel}.`);
   }
-
-  logger.debug(`Successfully validated ${sourceLabel}.`);
 
   const upgradedObject = upgrade(structuredClone(document), '3.1');
 
@@ -245,9 +255,15 @@ export async function loadAndTransform(
     filter: HttpFilterExpression;
     format?: ThymianFormat;
     sourceName?: string;
+    skipValidation?: boolean;
   },
 ): Promise<[OpenAPI.Document, ThymianFormat, string | undefined]> {
-  const loadResult = await loadAndUpgrade(value, options.cwd, options.logger);
+  const loadResult = await loadAndUpgrade(
+    value,
+    options.cwd,
+    options.logger,
+    options.skipValidation,
+  );
   const relativePath = loadResult.filePath
     ? getRelativePath(loadResult.filePath, options.cwd)
     : undefined;

--- a/packages/plugin-openapi/src/load-openapi.ts
+++ b/packages/plugin-openapi/src/load-openapi.ts
@@ -115,7 +115,7 @@ export async function loadAndUpgrade(
   value: string,
   cwd: string = process.cwd(),
   logger: Logger,
-  skipSpecValidation = false,
+  validateSpecs = false,
 ): Promise<LoadResult> {
   const { document, filePath } = await loadOpenApi(value, cwd);
   const relativePath = filePath ? getRelativePath(filePath, cwd) : undefined;
@@ -147,11 +147,7 @@ export async function loadAndUpgrade(
       );
     }
 
-    if (skipSpecValidation) {
-      logger.warn(
-        `Schema validation for ${sourceLabel} failed. Errors:${validationResult?.errors?.map((e) => '\n  - ' + e.message + ('path' in e ? ` (at ${(e as Record<string, unknown>)['path']})` : '')).join('. ') ?? ''}`,
-      );
-    } else {
+    if (validateSpecs) {
       throw new ThymianBaseError(
         `Schema validation for ${sourceLabel} failed.`,
         {
@@ -165,6 +161,10 @@ export async function loadAndUpgrade(
             'Ensure all required fields are present (openapi, info, paths)',
           ],
         },
+      );
+    } else {
+      logger.warn(
+        `Schema validation for ${sourceLabel} failed. Errors:${validationResult?.errors?.map((e) => '\n  - ' + e.message + ('path' in e ? ` (at ${(e as Record<string, unknown>)['path']})` : '')).join('. ') ?? ''}`,
       );
     }
   } else {
@@ -255,14 +255,14 @@ export async function loadAndTransform(
     filter: HttpFilterExpression;
     format?: ThymianFormat;
     sourceName?: string;
-    skipSpecValidation?: boolean;
+    validateSpecs?: boolean;
   },
 ): Promise<[OpenAPI.Document, ThymianFormat, string | undefined]> {
   const loadResult = await loadAndUpgrade(
     value,
     options.cwd,
     options.logger,
-    options.skipSpecValidation,
+    options.validateSpecs,
   );
   const relativePath = loadResult.filePath
     ? getRelativePath(loadResult.filePath, options.cwd)

--- a/packages/plugin-openapi/test/fixtures/invalid-openapi.yaml
+++ b/packages/plugin-openapi/test/fixtures/invalid-openapi.yaml
@@ -1,0 +1,5 @@
+openapi: '3.0.3'
+info:
+  version: '1.0.0'
+  # Missing required 'title' field
+paths: {}

--- a/packages/plugin-openapi/test/index.test.ts
+++ b/packages/plugin-openapi/test/index.test.ts
@@ -40,17 +40,17 @@ describe('OpenApi plugin', () => {
 
     await thymian.register(openApiPlugin).ready();
 
-    // petstore-v2 is a valid doc, but this tests the options propagation path
     const formats = await thymian.emitter.emitAction('core.format.load', {
       inputs: [
         {
           type: 'openapi',
-          location: 'test/fixtures/petstore-v2.yaml',
+          location: 'test/fixtures/invalid-openapi.yaml',
         },
       ],
-      options: { skipSpecValidation: true },
+      skipSpecValidation: true,
     });
 
+    // Invalid doc should still load when skipSpecValidation is true (warning logged instead of error)
     expect(formats).toHaveLength(1);
   });
 

--- a/packages/plugin-openapi/test/index.test.ts
+++ b/packages/plugin-openapi/test/index.test.ts
@@ -28,6 +28,7 @@ describe('OpenApi plugin', () => {
           location: 'test/fixtures/petstore-v2.yaml',
         },
       ],
+      skipSpecValidation: false,
     });
 
     expect(formats).toHaveLength(1);

--- a/packages/plugin-openapi/test/index.test.ts
+++ b/packages/plugin-openapi/test/index.test.ts
@@ -28,13 +28,13 @@ describe('OpenApi plugin', () => {
           location: 'test/fixtures/petstore-v2.yaml',
         },
       ],
-      skipSpecValidation: false,
+      validateSpecs: true,
     });
 
     expect(formats).toHaveLength(1);
   });
 
-  it('loads openapi document with skipSpecValidation skipping schema errors', async () => {
+  it('loads openapi document when validateSpecs is disabled', async () => {
     const thymian = new Thymian(new NoopLogger(), {
       cwd: join(import.meta.dirname, '..'),
     });
@@ -48,10 +48,10 @@ describe('OpenApi plugin', () => {
           location: 'test/fixtures/invalid-openapi.yaml',
         },
       ],
-      skipSpecValidation: true,
+      validateSpecs: false,
     });
 
-    // Invalid doc should still load when skipSpecValidation is true (warning logged instead of error)
+    // Invalid doc should still load when validateSpecs is false (warning logged instead of error)
     expect(formats).toHaveLength(1);
   });
 

--- a/packages/plugin-openapi/test/index.test.ts
+++ b/packages/plugin-openapi/test/index.test.ts
@@ -33,6 +33,27 @@ describe('OpenApi plugin', () => {
     expect(formats).toHaveLength(1);
   });
 
+  it('loads openapi document with skipSpecValidation skipping schema errors', async () => {
+    const thymian = new Thymian(new NoopLogger(), {
+      cwd: join(import.meta.dirname, '..'),
+    });
+
+    await thymian.register(openApiPlugin).ready();
+
+    // petstore-v2 is a valid doc, but this tests the options propagation path
+    const formats = await thymian.emitter.emitAction('core.format.load', {
+      inputs: [
+        {
+          type: 'openapi',
+          location: 'test/fixtures/petstore-v2.yaml',
+        },
+      ],
+      options: { skipSpecValidation: true },
+    });
+
+    expect(formats).toHaveLength(1);
+  });
+
   it('loads and transforms openapi document from file via transform action', async () => {
     const thymian = new Thymian(new NoopLogger());
 

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 import { constant, NoopLogger, ThymianBaseError } from '@thymian/core';
 import type { OpenAPIV3_1 } from 'openapi-types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vitest } from 'vitest';
 import yaml from 'yaml';
 
 import { loadAndUpgrade, openapiToThymianFormat } from '../src/load-openapi.js';
@@ -197,11 +197,8 @@ describe('load-openapi', () => {
         paths: {},
       };
 
-      const warnings: string[] = [];
       const logger = new NoopLogger();
-      logger.warn = (msg: unknown) => {
-        warnings.push(String(msg));
-      };
+      const wantSpy = vitest.spyOn(logger, 'warn');
 
       const result = await loadAndUpgrade(
         JSON.stringify(invalidDocument),
@@ -212,11 +209,10 @@ describe('load-openapi', () => {
 
       // Should succeed — validation ran but only warned
       expect(result.document.openapi).toBe('3.1.1');
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain('--skip-spec-validation');
+      expect(wantSpy).toBeCalledTimes(1);
     });
 
-    it('still throws on $ref errors when skipValidation is true', async () => {
+    it('still throws on $ref errors when skipSpecValidation is true', async () => {
       const documentWithBadRef = {
         openapi: '3.1.0',
         info: {

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -113,7 +113,7 @@ describe('load-openapi', () => {
       }
     });
 
-    it('throws OpenAPIValidationError when validation fails', async () => {
+    it('throws OpenAPIValidationError when validation fails and validateSpecs is enabled', async () => {
       const invalidDocument = {
         swagger: '2.0',
         info: {
@@ -128,6 +128,7 @@ describe('load-openapi', () => {
           JSON.stringify(invalidDocument),
           process.cwd(),
           new NoopLogger(),
+          true,
         );
         expect.fail('Error should have been thrown');
       } catch (error) {
@@ -187,7 +188,7 @@ describe('load-openapi', () => {
       }
     });
 
-    it('warns but does not throw on schema validation failure when skipSpecValidation is true', async () => {
+    it('warns but does not throw on schema validation failure when validateSpecs is false', async () => {
       const invalidDocument = {
         swagger: '2.0',
         info: {
@@ -204,7 +205,7 @@ describe('load-openapi', () => {
         JSON.stringify(invalidDocument),
         process.cwd(),
         logger,
-        true,
+        false,
       );
 
       // Should succeed — validation ran but only warned
@@ -212,7 +213,7 @@ describe('load-openapi', () => {
       expect(wantSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('still throws on $ref errors when skipSpecValidation is true', async () => {
+    it('still throws on $ref errors when validateSpecs is false', async () => {
       const documentWithBadRef = {
         openapi: '3.1.0',
         info: {
@@ -244,7 +245,7 @@ describe('load-openapi', () => {
           JSON.stringify(documentWithBadRef),
           process.cwd(),
           new NoopLogger(),
-          true,
+          false,
         );
         expect.fail('Error should have been thrown');
       } catch (error) {
@@ -255,7 +256,7 @@ describe('load-openapi', () => {
       }
     });
 
-    it('validates schema when skipValidation is false', async () => {
+    it('validates schema when validateSpecs is true', async () => {
       const invalidDocument = {
         swagger: '2.0',
         info: {
@@ -270,7 +271,7 @@ describe('load-openapi', () => {
           JSON.stringify(invalidDocument),
           process.cwd(),
           new NoopLogger(),
-          false,
+          true,
         );
         expect.fail('Error should have been thrown');
       } catch (error) {

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -186,6 +186,104 @@ describe('load-openapi', () => {
         );
       }
     });
+
+    it('warns but does not throw on schema validation failure when skipValidation is true', async () => {
+      const invalidDocument = {
+        swagger: '2.0',
+        info: {
+          // Missing required 'title' field
+          version: '1.0.0',
+        },
+        paths: {},
+      };
+
+      const warnings: string[] = [];
+      const logger = new NoopLogger();
+      logger.warn = (msg: unknown) => {
+        warnings.push(String(msg));
+      };
+
+      const result = await loadAndUpgrade(
+        JSON.stringify(invalidDocument),
+        process.cwd(),
+        logger,
+        true,
+      );
+
+      // Should succeed — validation ran but only warned
+      expect(result.document.openapi).toBe('3.1.1');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('--skip-spec-validation');
+    });
+
+    it('still throws on $ref errors when skipValidation is true', async () => {
+      const documentWithBadRef = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: '#/components/schemas/NonExistent',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      try {
+        await loadAndUpgrade(
+          JSON.stringify(documentWithBadRef),
+          process.cwd(),
+          new NoopLogger(),
+          true,
+        );
+        expect.fail('Error should have been thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ThymianBaseError);
+        expect((error as ThymianBaseError).options.name).toBe(
+          'OpenAPIDereferenceError',
+        );
+      }
+    });
+
+    it('validates schema when skipValidation is false', async () => {
+      const invalidDocument = {
+        swagger: '2.0',
+        info: {
+          // Missing required 'title' field
+          version: '1.0.0',
+        },
+        paths: {},
+      };
+
+      try {
+        await loadAndUpgrade(
+          JSON.stringify(invalidDocument),
+          process.cwd(),
+          new NoopLogger(),
+          false,
+        );
+        expect.fail('Error should have been thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ThymianBaseError);
+        expect((error as ThymianBaseError).options.name).toBe(
+          'OpenAPIValidationError',
+        );
+      }
+    });
   });
 
   describe('openapiToThymianFormat', () => {

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -187,7 +187,7 @@ describe('load-openapi', () => {
       }
     });
 
-    it('warns but does not throw on schema validation failure when skipValidation is true', async () => {
+    it('warns but does not throw on schema validation failure when skipSpecValidation is true', async () => {
       const invalidDocument = {
         swagger: '2.0',
         info: {
@@ -209,7 +209,7 @@ describe('load-openapi', () => {
 
       // Should succeed — validation ran but only warned
       expect(result.document.openapi).toBe('3.1.1');
-      expect(wantSpy).toBeCalledTimes(1);
+      expect(wantSpy).toHaveBeenCalledTimes(1);
     });
 
     it('still throws on $ref errors when skipSpecValidation is true', async () => {

--- a/packages/plugin-openapi/test/load-openapi.test.ts
+++ b/packages/plugin-openapi/test/load-openapi.test.ts
@@ -255,32 +255,6 @@ describe('load-openapi', () => {
         );
       }
     });
-
-    it('validates schema when validateSpecs is true', async () => {
-      const invalidDocument = {
-        swagger: '2.0',
-        info: {
-          // Missing required 'title' field
-          version: '1.0.0',
-        },
-        paths: {},
-      };
-
-      try {
-        await loadAndUpgrade(
-          JSON.stringify(invalidDocument),
-          process.cwd(),
-          new NoopLogger(),
-          true,
-        );
-        expect.fail('Error should have been thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ThymianBaseError);
-        expect((error as ThymianBaseError).options.name).toBe(
-          'OpenAPIValidationError',
-        );
-      }
-    });
   });
 
   describe('openapiToThymianFormat', () => {

--- a/packages/plugin-sampler/src/cli/commands/sampler/check.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/check.ts
@@ -46,6 +46,7 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
 
       const format = await this.thymian.loadFormat({
         inputs: specifications,
+        skipSpecValidation: this.flags['skip-spec-validation'],
       });
 
       const transactions = format.getThymianHttpTransactions();

--- a/packages/plugin-sampler/src/cli/commands/sampler/check.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/check.ts
@@ -46,7 +46,7 @@ export default class Check extends BaseCliRunCommand<typeof Check> {
 
       const format = await this.thymian.loadFormat({
         inputs: specifications,
-        skipSpecValidation: this.flags['skip-spec-validation'],
+        validateSpecs: this.flags['validate-specs'],
       });
 
       const transactions = format.getThymianHttpTransactions();

--- a/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
@@ -22,7 +22,7 @@ export default class GenerateHook extends BaseCliRunCommand<
         emitter,
         this,
         this.flags.cwd,
-        this.flags['skip-spec-validation'],
+        this.flags['validate-specs'],
         this.flags['for-transaction'],
       );
     });

--- a/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/generate/hook.ts
@@ -22,6 +22,7 @@ export default class GenerateHook extends BaseCliRunCommand<
         emitter,
         this,
         this.flags.cwd,
+        this.flags['skip-spec-validation'],
         this.flags['for-transaction'],
       );
     });

--- a/packages/plugin-sampler/src/cli/commands/sampler/init.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/init.ts
@@ -33,7 +33,7 @@ export default class Init extends BaseCliRunCommand<typeof Init> {
       const format = await this.thymian.loadFormat(
         {
           inputs: this.thymianConfig.specifications ?? [],
-          skipSpecValidation: this.flags['skip-spec-validation'],
+          validateSpecs: this.flags['validate-specs'],
         },
         {
           emitFormat: true,

--- a/packages/plugin-sampler/src/cli/commands/sampler/init.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/init.ts
@@ -31,7 +31,10 @@ export default class Init extends BaseCliRunCommand<typeof Init> {
       }
 
       const format = await this.thymian.loadFormat(
-        { inputs: this.thymianConfig.specifications ?? [] },
+        {
+          inputs: this.thymianConfig.specifications ?? [],
+          skipSpecValidation: this.flags['skip-spec-validation'],
+        },
         {
           emitFormat: true,
         },

--- a/packages/plugin-sampler/src/cli/generate-hook.ts
+++ b/packages/plugin-sampler/src/cli/generate-hook.ts
@@ -25,11 +25,16 @@ export async function generateHook<
   emitter: ThymianEmitter,
   command: BaseCliRunCommand<T>,
   cwd: string,
+  skipSpecValidation: boolean,
   forTransaction?: string,
   loadedThymianFormat?: ThymianFormat,
 ): Promise<void> {
   const thymianFormat =
-    loadedThymianFormat ?? (await thymian.loadFormat({ inputs: [] }));
+    loadedThymianFormat ??
+    (await thymian.loadFormat({
+      inputs: [],
+      skipSpecValidation,
+    }));
 
   const titleToTransaction = new Map<string, ThymianHttpTransaction>();
 

--- a/packages/plugin-sampler/src/cli/generate-hook.ts
+++ b/packages/plugin-sampler/src/cli/generate-hook.ts
@@ -25,7 +25,7 @@ export async function generateHook<
   emitter: ThymianEmitter,
   command: BaseCliRunCommand<T>,
   cwd: string,
-  skipSpecValidation: boolean,
+  validateSpecs: boolean,
   forTransaction?: string,
   loadedThymianFormat?: ThymianFormat,
 ): Promise<void> {
@@ -33,7 +33,7 @@ export async function generateHook<
     loadedThymianFormat ??
     (await thymian.loadFormat({
       inputs: [],
-      skipSpecValidation,
+      validateSpecs,
     }));
 
   const titleToTransaction = new Map<string, ThymianHttpTransaction>();

--- a/packages/plugin-sampler/test/generate-request-types.test.ts
+++ b/packages/plugin-sampler/test/generate-request-types.test.ts
@@ -75,42 +75,94 @@ describe('generateRequestTypes', () => {
     },
   );
 
-  it('should generate request type definitions as a string - large', async () => {
-    const format = ThymianFormat.import(
-      {
-        options: { type: 'directed', multi: true, allowSelfLoops: true },
-        attributes: { hash: '' },
-        nodes: [
-          {
-            key: 'ff4df09d-9c26-4903-81c7-3643b384b7c4',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects',
-              method: 'get',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {},
-              queryParameters: {},
-              headers: {},
+  it(
+    'should generate request type definitions as a string - large',
+    { timeout: 10_000 },
+    async () => {
+      const format = ThymianFormat.import(
+        {
+          options: { type: 'directed', multi: true, allowSelfLoops: true },
+          attributes: { hash: '' },
+          nodes: [
+            {
+              key: 'ff4df09d-9c26-4903-81c7-3643b384b7c4',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects',
+                method: 'get',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {},
+                queryParameters: {},
+                headers: {},
+              },
             },
-          },
-          {
-            key: 'bf76d1f8-fae9-464d-8025-2eb4ab88ec8a',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'array',
-                items: {
+            {
+              key: 'bf76d1f8-fae9-464d-8025-2eb4ab88ec8a',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                      id: { type: 'string' },
+                      name: { type: 'string' },
+                      description: { type: 'string' },
+                    },
+                    required: ['id', 'name'],
+                  },
+                },
+              },
+            },
+            {
+              key: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects',
+                method: 'post',
+                bodyRequired: true,
+                body: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    description: { type: 'string' },
+                  },
+                  required: ['name'],
+                },
+                mediaType: 'application/json',
+                extensions: { openapiV3: {} },
+                queryParameters: {},
+                cookies: {},
+                pathParameters: {},
+                headers: {},
+              },
+            },
+            {
+              key: '17edfa3a-598e-40ba-9e8d-872f6cd38176',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 201,
+                schema: {
                   type: 'object',
                   additionalProperties: false,
                   properties: {
@@ -122,283 +174,171 @@ describe('generateRequestTypes', () => {
                 },
               },
             },
-          },
-          {
-            key: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects',
-              method: 'post',
-              bodyRequired: true,
-              body: {
-                type: 'object',
-                properties: {
-                  name: { type: 'string' },
-                  description: { type: 'string' },
-                },
-                required: ['name'],
-              },
-              mediaType: 'application/json',
-              extensions: { openapiV3: {} },
-              queryParameters: {},
-              cookies: {},
-              pathParameters: {},
-              headers: {},
-            },
-          },
-          {
-            key: '17edfa3a-598e-40ba-9e8d-872f6cd38176',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 201,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  name: { type: 'string' },
-                  description: { type: 'string' },
-                },
-                required: ['id', 'name'],
-              },
-            },
-          },
-          {
-            key: 'af62f2b5-0197-44ae-80a0-d381efee468a',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 400,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects/{id}',
-              method: 'get',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string', examples: ['1'] },
-                  style: { style: 'simple', explode: false },
+            {
+              key: 'af62f2b5-0197-44ae-80a0-d381efee468a',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 400,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
                 },
               },
-              queryParameters: {},
-              headers: {},
             },
-          },
-          {
-            key: 'eb0097f0-1252-4d7a-b5f0-d4645a7d1270',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  name: { type: 'string' },
-                  description: { type: 'string' },
+            {
+              key: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects/{id}',
+                method: 'get',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string', examples: ['1'] },
+                    style: { style: 'simple', explode: false },
+                  },
                 },
-                required: ['id', 'name'],
+                queryParameters: {},
+                headers: {},
               },
             },
-          },
-          {
-            key: 'eb813cce-5e95-4f7a-9ed8-a4523a3f93cf',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 404,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects/{id}',
-              method: 'delete',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: 'eb0097f0-1252-4d7a-b5f0-d4645a7d1270',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    description: { type: 'string' },
+                  },
+                  required: ['id', 'name'],
                 },
               },
-              queryParameters: {},
-              headers: {},
             },
-          },
-          {
-            key: '745b1b85-da18-4fc0-9382-0829ea0cd3e6',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: '',
-              statusCode: 204,
-            },
-          },
-          {
-            key: '0e5523c2-ad5c-476c-9335-1e522e56311d',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 404,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects/{id}/todos',
-              method: 'post',
-              bodyRequired: true,
-              body: {
-                type: 'object',
-                properties: { title: { type: 'string' } },
-                required: ['title'],
-              },
-              mediaType: 'application/json',
-              extensions: { openapiV3: {} },
-              queryParameters: {},
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: 'eb813cce-5e95-4f7a-9ed8-a4523a3f93cf',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 404,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
                 },
               },
-              headers: {},
             },
-          },
-          {
-            key: '55a5ca94-282a-40e6-9c36-67ec9915ccc4',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 201,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  title: { type: 'string' },
-                  done: { type: 'boolean' },
-                  projectId: { type: ['null', 'string'] },
+            {
+              key: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects/{id}',
+                method: 'delete',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
                 },
-                required: ['id', 'title', 'done'],
+                queryParameters: {},
+                headers: {},
               },
             },
-          },
-          {
-            key: 'a1bd73ac-f4a2-40e8-9e10-ac5f5128fa3e',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 400,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
+            {
+              key: '745b1b85-da18-4fc0-9382-0829ea0cd3e6',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: '',
+                statusCode: 204,
               },
             },
-          },
-          {
-            key: '0b856f44-865a-4781-9d82-1ce95089c30a',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/projects/{id}/todos',
-              method: 'get',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: '0e5523c2-ad5c-476c-9335-1e522e56311d',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 404,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
                 },
               },
-              queryParameters: {},
-              headers: {},
             },
-          },
-          {
-            key: 'dfc47bcb-6d11-4c44-92a0-c11e6dd2d991',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'array',
-                items: {
+            {
+              key: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects/{id}/todos',
+                method: 'post',
+                bodyRequired: true,
+                body: {
+                  type: 'object',
+                  properties: { title: { type: 'string' } },
+                  required: ['title'],
+                },
+                mediaType: 'application/json',
+                extensions: { openapiV3: {} },
+                queryParameters: {},
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
+                },
+                headers: {},
+              },
+            },
+            {
+              key: '55a5ca94-282a-40e6-9c36-67ec9915ccc4',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 201,
+                schema: {
                   type: 'object',
                   additionalProperties: false,
                   properties: {
@@ -411,37 +351,148 @@ describe('generateRequestTypes', () => {
                 },
               },
             },
-          },
-          {
-            key: '6873b02b-73aa-4410-818a-53874d51d69a',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/todos',
-              method: 'get',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {},
-              queryParameters: {},
-              headers: {},
+            {
+              key: 'a1bd73ac-f4a2-40e8-9e10-ac5f5128fa3e',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 400,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
+                },
+              },
             },
-          },
-          {
-            key: '6abb0086-ae73-405d-b72d-d9534bde0fbb',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'array',
-                items: {
+            {
+              key: '0b856f44-865a-4781-9d82-1ce95089c30a',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/projects/{id}/todos',
+                method: 'get',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
+                },
+                queryParameters: {},
+                headers: {},
+              },
+            },
+            {
+              key: 'dfc47bcb-6d11-4c44-92a0-c11e6dd2d991',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                      id: { type: 'string' },
+                      title: { type: 'string' },
+                      done: { type: 'boolean' },
+                      projectId: { type: ['null', 'string'] },
+                    },
+                    required: ['id', 'title', 'done'],
+                  },
+                },
+              },
+            },
+            {
+              key: '6873b02b-73aa-4410-818a-53874d51d69a',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/todos',
+                method: 'get',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {},
+                queryParameters: {},
+                headers: {},
+              },
+            },
+            {
+              key: '6abb0086-ae73-405d-b72d-d9534bde0fbb',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                      id: { type: 'string' },
+                      title: { type: 'string' },
+                      done: { type: 'boolean' },
+                      projectId: { type: ['null', 'string'] },
+                    },
+                    required: ['id', 'title', 'done'],
+                  },
+                },
+              },
+            },
+            {
+              key: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/todos',
+                method: 'post',
+                bodyRequired: true,
+                body: {
+                  additionalProperties: false,
+                  type: 'object',
+                  properties: { title: { type: 'string' } },
+                  required: ['title'],
+                },
+                mediaType: 'application/json',
+                extensions: { openapiV3: {} },
+                queryParameters: {},
+                cookies: {},
+                pathParameters: {},
+                headers: {},
+              },
+            },
+            {
+              key: '2c9a2158-eebe-4398-b1da-b10ecfa709c1',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 201,
+                schema: {
                   type: 'object',
                   additionalProperties: false,
                   properties: {
@@ -454,409 +505,362 @@ describe('generateRequestTypes', () => {
                 },
               },
             },
-          },
-          {
-            key: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/todos',
-              method: 'post',
-              bodyRequired: true,
-              body: {
-                additionalProperties: false,
-                type: 'object',
-                properties: { title: { type: 'string' } },
-                required: ['title'],
-              },
-              mediaType: 'application/json',
-              extensions: { openapiV3: {} },
-              queryParameters: {},
-              cookies: {},
-              pathParameters: {},
-              headers: {},
-            },
-          },
-          {
-            key: '2c9a2158-eebe-4398-b1da-b10ecfa709c1',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 201,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  title: { type: 'string' },
-                  done: { type: 'boolean' },
-                  projectId: { type: ['null', 'string'] },
-                },
-                required: ['id', 'title', 'done'],
-              },
-            },
-          },
-          {
-            key: '90fdfaf9-5ea3-4249-83aa-0a009f3512bc',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 400,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/todos/{id}',
-              method: 'get',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: '90fdfaf9-5ea3-4249-83aa-0a009f3512bc',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 400,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
                 },
               },
-              queryParameters: {},
-              headers: {},
             },
-          },
-          {
-            key: 'a235e5e0-58b0-483d-b439-ca32f35a404d',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  title: { type: 'string' },
-                  done: { type: 'boolean' },
-                  projectId: { type: ['null', 'string'] },
+            {
+              key: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/todos/{id}',
+                method: 'get',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
                 },
-                required: ['id', 'title', 'done'],
+                queryParameters: {},
+                headers: {},
               },
             },
-          },
-          {
-            key: 'b5fb6ed7-f121-4c6f-8646-783a38c0aa4e',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 404,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/todos/{id}',
-              method: 'put',
-              bodyRequired: false,
-              body: {
-                type: 'object',
-                properties: {
-                  title: { type: 'string' },
-                  done: { type: 'boolean' },
-                  projectId: { type: 'string' },
-                },
-                additionalProperties: false,
-              },
-              mediaType: 'application/json',
-              extensions: { openapiV3: {} },
-              queryParameters: {},
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: 'a235e5e0-58b0-483d-b439-ca32f35a404d',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    id: { type: 'string' },
+                    title: { type: 'string' },
+                    done: { type: 'boolean' },
+                    projectId: { type: ['null', 'string'] },
+                  },
+                  required: ['id', 'title', 'done'],
                 },
               },
-              headers: {},
             },
-          },
-          {
-            key: 'c13d99ee-39b6-49f7-9679-a58372c288a6',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 200,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  id: { type: 'string' },
-                  title: { type: 'string' },
-                  done: { type: 'boolean' },
-                  projectId: { type: ['null', 'string'] },
-                },
-                required: ['id', 'title', 'done'],
-              },
-            },
-          },
-          {
-            key: 'fee801d0-f004-49a0-9bcf-6a0c21e13bca',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 400,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: 'a1390ef4-9e58-47ff-bfa5-3213870e2b23',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 404,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
-              },
-            },
-          },
-          {
-            key: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
-            attributes: {
-              label: '',
-              type: 'http-request',
-              host: 'localhost',
-              port: 8080,
-              protocol: 'http',
-              path: '/todos/{id}',
-              method: 'delete',
-              mediaType: '',
-              extensions: { openapiV3: {} },
-              cookies: {},
-              pathParameters: {
-                id: {
-                  required: true,
-                  schema: { type: 'string' },
-                  style: { style: 'simple', explode: false },
+            {
+              key: 'b5fb6ed7-f121-4c6f-8646-783a38c0aa4e',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 404,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
                 },
               },
-              queryParameters: {},
-              headers: {},
             },
-          },
-          {
-            key: '376073c4-17b0-42d0-a9d5-401186ac4393',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: '',
-              statusCode: 204,
-            },
-          },
-          {
-            key: 'e82f1215-cc61-4e27-af90-c34ee831e37b',
-            attributes: {
-              label: '',
-              type: 'http-response',
-              description: 'Default Response',
-              headers: {},
-              mediaType: 'application/json',
-              statusCode: 404,
-              schema: {
-                type: 'object',
-                properties: { error: { type: 'string' } },
+            {
+              key: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/todos/{id}',
+                method: 'put',
+                bodyRequired: false,
+                body: {
+                  type: 'object',
+                  properties: {
+                    title: { type: 'string' },
+                    done: { type: 'boolean' },
+                    projectId: { type: 'string' },
+                  },
+                  additionalProperties: false,
+                },
+                mediaType: 'application/json',
+                extensions: { openapiV3: {} },
+                queryParameters: {},
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
+                },
+                headers: {},
               },
             },
-          },
-        ],
-        edges: [
-          {
-            key: 'geid_187_0',
-            source: 'ff4df09d-9c26-4903-81c7-3643b384b7c4',
-            target: 'bf76d1f8-fae9-464d-8025-2eb4ab88ec8a',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_1',
-            source: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
-            target: '17edfa3a-598e-40ba-9e8d-872f6cd38176',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_2',
-            source: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
-            target: 'af62f2b5-0197-44ae-80a0-d381efee468a',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_3',
-            source: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
-            target: 'eb0097f0-1252-4d7a-b5f0-d4645a7d1270',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_4',
-            source: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
-            target: 'eb813cce-5e95-4f7a-9ed8-a4523a3f93cf',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_5',
-            source: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
-            target: '745b1b85-da18-4fc0-9382-0829ea0cd3e6',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_6',
-            source: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
-            target: '0e5523c2-ad5c-476c-9335-1e522e56311d',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_7',
-            source: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
-            target: '55a5ca94-282a-40e6-9c36-67ec9915ccc4',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_8',
-            source: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
-            target: 'a1bd73ac-f4a2-40e8-9e10-ac5f5128fa3e',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_9',
-            source: '0b856f44-865a-4781-9d82-1ce95089c30a',
-            target: 'dfc47bcb-6d11-4c44-92a0-c11e6dd2d991',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_10',
-            source: '6873b02b-73aa-4410-818a-53874d51d69a',
-            target: '6abb0086-ae73-405d-b72d-d9534bde0fbb',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_11',
-            source: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
-            target: '2c9a2158-eebe-4398-b1da-b10ecfa709c1',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_12',
-            source: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
-            target: '90fdfaf9-5ea3-4249-83aa-0a009f3512bc',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_13',
-            source: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
-            target: 'a235e5e0-58b0-483d-b439-ca32f35a404d',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_14',
-            source: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
-            target: 'b5fb6ed7-f121-4c6f-8646-783a38c0aa4e',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_15',
-            source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
-            target: 'c13d99ee-39b6-49f7-9679-a58372c288a6',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_16',
-            source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
-            target: 'fee801d0-f004-49a0-9bcf-6a0c21e13bca',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_17',
-            source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
-            target: 'a1390ef4-9e58-47ff-bfa5-3213870e2b23',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_18',
-            source: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
-            target: '376073c4-17b0-42d0-a9d5-401186ac4393',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-          {
-            key: 'geid_187_19',
-            source: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
-            target: 'e82f1215-cc61-4e27-af90-c34ee831e37b',
-            attributes: { label: '', type: 'http-transaction' },
-          },
-        ],
-      },
-      'test',
-    );
+            {
+              key: 'c13d99ee-39b6-49f7-9679-a58372c288a6',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 200,
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    id: { type: 'string' },
+                    title: { type: 'string' },
+                    done: { type: 'boolean' },
+                    projectId: { type: ['null', 'string'] },
+                  },
+                  required: ['id', 'title', 'done'],
+                },
+              },
+            },
+            {
+              key: 'fee801d0-f004-49a0-9bcf-6a0c21e13bca',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 400,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
+                },
+              },
+            },
+            {
+              key: 'a1390ef4-9e58-47ff-bfa5-3213870e2b23',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 404,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
+                },
+              },
+            },
+            {
+              key: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
+              attributes: {
+                label: '',
+                type: 'http-request',
+                host: 'localhost',
+                port: 8080,
+                protocol: 'http',
+                path: '/todos/{id}',
+                method: 'delete',
+                mediaType: '',
+                extensions: { openapiV3: {} },
+                cookies: {},
+                pathParameters: {
+                  id: {
+                    required: true,
+                    schema: { type: 'string' },
+                    style: { style: 'simple', explode: false },
+                  },
+                },
+                queryParameters: {},
+                headers: {},
+              },
+            },
+            {
+              key: '376073c4-17b0-42d0-a9d5-401186ac4393',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: '',
+                statusCode: 204,
+              },
+            },
+            {
+              key: 'e82f1215-cc61-4e27-af90-c34ee831e37b',
+              attributes: {
+                label: '',
+                type: 'http-response',
+                description: 'Default Response',
+                headers: {},
+                mediaType: 'application/json',
+                statusCode: 404,
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
+                },
+              },
+            },
+          ],
+          edges: [
+            {
+              key: 'geid_187_0',
+              source: 'ff4df09d-9c26-4903-81c7-3643b384b7c4',
+              target: 'bf76d1f8-fae9-464d-8025-2eb4ab88ec8a',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_1',
+              source: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
+              target: '17edfa3a-598e-40ba-9e8d-872f6cd38176',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_2',
+              source: 'f52fba20-4e21-460b-b0bb-10c14aa448a2',
+              target: 'af62f2b5-0197-44ae-80a0-d381efee468a',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_3',
+              source: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
+              target: 'eb0097f0-1252-4d7a-b5f0-d4645a7d1270',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_4',
+              source: '64338bca-eda4-4dcb-b822-ad3c7703cd78',
+              target: 'eb813cce-5e95-4f7a-9ed8-a4523a3f93cf',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_5',
+              source: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
+              target: '745b1b85-da18-4fc0-9382-0829ea0cd3e6',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_6',
+              source: 'a2e8d334-fc8e-4ab2-ba9e-0fe0de34b18f',
+              target: '0e5523c2-ad5c-476c-9335-1e522e56311d',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_7',
+              source: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
+              target: '55a5ca94-282a-40e6-9c36-67ec9915ccc4',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_8',
+              source: '7a8a1884-c467-4e2b-8146-92c7f76b99f8',
+              target: 'a1bd73ac-f4a2-40e8-9e10-ac5f5128fa3e',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_9',
+              source: '0b856f44-865a-4781-9d82-1ce95089c30a',
+              target: 'dfc47bcb-6d11-4c44-92a0-c11e6dd2d991',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_10',
+              source: '6873b02b-73aa-4410-818a-53874d51d69a',
+              target: '6abb0086-ae73-405d-b72d-d9534bde0fbb',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_11',
+              source: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
+              target: '2c9a2158-eebe-4398-b1da-b10ecfa709c1',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_12',
+              source: 'ef3be3d0-949c-40a7-ac33-dbf229ea16c7',
+              target: '90fdfaf9-5ea3-4249-83aa-0a009f3512bc',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_13',
+              source: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
+              target: 'a235e5e0-58b0-483d-b439-ca32f35a404d',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_14',
+              source: '074a4dfa-ff69-4af5-b9a8-eba416d9186c',
+              target: 'b5fb6ed7-f121-4c6f-8646-783a38c0aa4e',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_15',
+              source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
+              target: 'c13d99ee-39b6-49f7-9679-a58372c288a6',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_16',
+              source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
+              target: 'fee801d0-f004-49a0-9bcf-6a0c21e13bca',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_17',
+              source: '5faa233d-acc1-485e-a910-f1084a5bc7c8',
+              target: 'a1390ef4-9e58-47ff-bfa5-3213870e2b23',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_18',
+              source: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
+              target: '376073c4-17b0-42d0-a9d5-401186ac4393',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+            {
+              key: 'geid_187_19',
+              source: 'd64088ba-45fc-49a0-b4f5-bfe1e591d2e7',
+              target: 'e82f1215-cc61-4e27-af90-c34ee831e37b',
+              attributes: { label: '', type: 'http-transaction' },
+            },
+          ],
+        },
+        'test',
+      );
 
-    const result = await generateTypesForThymianFormat(format);
+      const result = await generateTypesForThymianFormat(format);
 
-    const dtsContent = generatedTypesToString(result.types);
+      const dtsContent = generatedTypesToString(result.types);
 
-    const project = new Project({
-      skipAddingFilesFromTsConfig: true,
-      compilerOptions: {
-        strict: true,
-      },
-    });
-    const sourceFile = project.createSourceFile('generated.d.ts', dtsContent);
-    const diagnostics = sourceFile.getPreEmitDiagnostics();
+      const project = new Project({
+        skipAddingFilesFromTsConfig: true,
+        compilerOptions: {
+          strict: true,
+        },
+      });
+      const sourceFile = project.createSourceFile('generated.d.ts', dtsContent);
+      const diagnostics = sourceFile.getPreEmitDiagnostics();
 
-    expect(
-      diagnostics.length,
-      'Generated source file should not emit any diagnostics',
-    ).toBe(0);
-  });
+      expect(
+        diagnostics.length,
+        'Generated source file should not emit any diagnostics',
+      ).toBe(0);
+    },
+  );
 });

--- a/packages/thymian/src/commands/analyze.ts
+++ b/packages/thymian/src/commands/analyze.ts
@@ -44,7 +44,7 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
         rules: ruleSets,
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
-        skipSpecValidation: this.flags['skip-spec-validation'],
+        validateSpecs: this.flags['validate-specs'],
       });
     });
 

--- a/packages/thymian/src/commands/analyze.ts
+++ b/packages/thymian/src/commands/analyze.ts
@@ -44,6 +44,7 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
         rules: ruleSets,
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
+        skipSpecValidation: this.flags['skip-spec-validation'],
       });
     });
 

--- a/packages/thymian/src/commands/lint.ts
+++ b/packages/thymian/src/commands/lint.ts
@@ -39,6 +39,7 @@ export default class Lint extends BaseCliRunCommand<typeof Lint> {
         rules: ruleSets,
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
+        skipSpecValidation: this.flags['skip-spec-validation'],
       });
     });
 

--- a/packages/thymian/src/commands/lint.ts
+++ b/packages/thymian/src/commands/lint.ts
@@ -39,7 +39,7 @@ export default class Lint extends BaseCliRunCommand<typeof Lint> {
         rules: ruleSets,
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
-        skipSpecValidation: this.flags['skip-spec-validation'],
+        validateSpecs: this.flags['validate-specs'],
       });
     });
 

--- a/packages/thymian/src/commands/test.ts
+++ b/packages/thymian/src/commands/test.ts
@@ -51,7 +51,7 @@ export default class Test extends BaseCliRunCommand<typeof Test> {
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
         targetUrl,
-        skipSpecValidation: this.flags['skip-spec-validation'],
+        validateSpecs: this.flags['validate-specs'],
       });
     });
 

--- a/packages/thymian/src/commands/test.ts
+++ b/packages/thymian/src/commands/test.ts
@@ -51,6 +51,7 @@ export default class Test extends BaseCliRunCommand<typeof Test> {
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
         targetUrl,
+        skipSpecValidation: this.flags['skip-spec-validation'],
       });
     });
 


### PR DESCRIPTION
This pull request introduces a new `validateSpecs` option throughout the Thymian CLI, core, and OpenAPI plugin, allowing users to control whether input specifications are strictly validated against their schemas. When enabled, schema validation errors cause failures; when disabled, validation errors only produce warnings. The changes propagate this option through CLI flags, core APIs, plugin interfaces, and test coverage.

**CLI and Core API changes:**

* Added a `--validate-specs` CLI flag (default: false) to relevant commands in `BaseCliRunCommand`, enabling users to opt in to strict schema validation for specifications. [[1]](diffhunk://#diff-0f84d238b21658a78115f0698514878cf6506833e21eac83428aaefb813b1678R141-R147) [[2]](diffhunk://#diff-3d5df83eabc9a9b56a4fa4e4de7463c4bc723d00e31232d0c7b64531b25241a4R49) [[3]](diffhunk://#diff-cec159a1ce99749a9f7bf19504297114c5a3ae23d828057908f2fac5b19d8e28R25) [[4]](diffhunk://#diff-68dfa142dd7a44dec33ae68a55fa3c6f9834bd1eb041f934325122e03431f9d9L34-R37)
* Updated core interfaces (`CoreFormatLoadInput`, `LintWorkflowInput`, `TestWorkflowInput`, `AnalyzeWorkflowInput`) and related schema definitions to accept and require the `validateSpecs` boolean option. [[1]](diffhunk://#diff-6d9f46fa5da8dd207ef3d0995a23f84d90e43a3a4ccbae3f74f4c9b10cdfe0ceR14) [[2]](diffhunk://#diff-6d9f46fa5da8dd207ef3d0995a23f84d90e43a3a4ccbae3f74f4c9b10cdfe0ceL42-R54) [[3]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7R49) [[4]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7R58) [[5]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7R69)
* Propagated the `validateSpecs` option through the `Thymian` class methods so that all workflows (lint, test, analyze) respect this setting when loading specifications. [[1]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7L321-R330) [[2]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7L351-R363) [[3]](diffhunk://#diff-db8779053dbf54e38f00592e84e1c727e46fc27d4d92a832b1333336f16ed4f7L384-R399)

**OpenAPI Plugin changes:**

* Updated the OpenAPI plugin to accept and forward the `validateSpecs` option, and to pass it to the `loadAndUpgrade` and `loadAndTransform` functions. [[1]](diffhunk://#diff-75e0632266e37b41d091221f254b59813ade24492048e7933510201cf5f85731L78-R80) [[2]](diffhunk://#diff-75e0632266e37b41d091221f254b59813ade24492048e7933510201cf5f85731R115) [[3]](diffhunk://#diff-75e0632266e37b41d091221f254b59813ade24492048e7933510201cf5f85731L124-R128) [[4]](diffhunk://#diff-b0f9302e2d64e794d6fbbd853b889ed62ad4cf773c9a24e68b2479d9b9f6d6cfR118) [[5]](diffhunk://#diff-b0f9302e2d64e794d6fbbd853b889ed62ad4cf773c9a24e68b2479d9b9f6d6cfR258-R266)
* Modified `loadAndUpgrade` so that, when `validateSpecs` is true, schema validation errors throw an error; when false, errors are only logged as warnings. Reference errors (`$ref`) still throw regardless of this flag. [[1]](diffhunk://#diff-b0f9302e2d64e794d6fbbd853b889ed62ad4cf773c9a24e68b2479d9b9f6d6cfL149-R153) [[2]](diffhunk://#diff-b0f9302e2d64e794d6fbbd853b889ed62ad4cf773c9a24e68b2479d9b9f6d6cfL159-R172)

**Testing and validation:**

* Added and updated tests to cover both strict and non-strict validation scenarios, including new fixtures for invalid OpenAPI documents and checks for warning logs vs. thrown errors. [[1]](diffhunk://#diff-d01fe4ba767891273db871abf2c93f7dc88a55f0e5139275b7a2ea224b570602R1-R5) [[2]](diffhunk://#diff-9f11a2d8824dd024fa586eab8a8d802cc8ee69fd15b5e380b471ee2978db70c2R31-R57) [[3]](diffhunk://#diff-c49cc75f6623e3ba5f662bd8965eaf2741feb7a4309de07a99f5323a2e771815L116-R116) [[4]](diffhunk://#diff-c49cc75f6623e3ba5f662bd8965eaf2741feb7a4309de07a99f5323a2e771815R131) [[5]](diffhunk://#diff-c49cc75f6623e3ba5f662bd8965eaf2741feb7a4309de07a99f5323a2e771815R190-R283)
* Updated existing tests to expect the `validateSpecs` parameter in calls and ensure correct propagation of the flag. [[1]](diffhunk://#diff-dbbb72173735a4ed30bd23f2af76e5f3ed1367496b484dc416bdcb883c4bbf8dR235) [[2]](diffhunk://#diff-dbbb72173735a4ed30bd23f2af76e5f3ed1367496b484dc416bdcb883c4bbf8dR298) [[3]](diffhunk://#diff-dbbb72173735a4ed30bd23f2af76e5f3ed1367496b484dc416bdcb883c4bbf8dR428)

**Sampler plugin integration:**

* Propagated the `validateSpecs` flag throughout the sampler plugin's CLI and hook generation utilities, ensuring consistent behavior when generating hooks or running checks.

**Miscellaneous:**

* Minor improvements to test timeouts and code formatting in test files. [[1]](diffhunk://#diff-b01bdb1e6070f7fe636fe192bd438f2da8d2497f6790591fe4fc34ddbfa3eccdL78-R81) [[2]](diffhunk://#diff-b01bdb1e6070f7fe636fe192bd438f2da8d2497f6790591fe4fc34ddbfa3eccdL861-R865)

These changes provide users with more control over schema validation behavior and ensure consistent handling and propagation of the `validateSpecs` option across the CLI, core, and plugins.