### PR TITLE
fix(plugin-sampler): replace circular references with $ref

### DIFF
--- a/packages/plugin-sampler/src/hooks/generate-request-types.ts
+++ b/packages/plugin-sampler/src/hooks/generate-request-types.ts
@@ -51,7 +51,13 @@ export async function generateTypeForSchema(
   mediaType: string,
   typeName: string,
 ): Promise<GeneratedSchemaType> {
-  if (!(mediaType === 'application/json' || mediaType.includes('+json'))) {
+  const normalizedMediaType = mediaType.split(';', 1)[0]?.trim().toLowerCase();
+  if (
+    !(
+      normalizedMediaType === 'application/json' ||
+      normalizedMediaType?.includes('+json')
+    )
+  ) {
     return { declarations: [], type: 'unknown' };
   }
 

--- a/packages/plugin-sampler/src/hooks/generate-request-types.ts
+++ b/packages/plugin-sampler/src/hooks/generate-request-types.ts
@@ -7,27 +7,75 @@ import {
 import CodeBlockWriter from 'code-block-writer';
 import { compile, type JSONSchema } from 'json-schema-to-typescript';
 
+function escapeJsonPointerSegment(segment: string | number): string {
+  return String(segment).replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+function normalizeCircularSchemaRefs<T>(schema: T): T {
+  const activeStack = new Map<object, string>();
+
+  const recurse = (current: unknown, path: string): unknown => {
+    if (typeof current !== 'object' || current === null) {
+      return current;
+    }
+
+    if (activeStack.has(current)) {
+      return { $ref: activeStack.get(current) };
+    }
+
+    activeStack.set(current, path);
+
+    let result: unknown;
+
+    if (Array.isArray(current)) {
+      result = current.map((item, index) => recurse(item, `${path}/${index}`));
+    } else {
+      result = Object.fromEntries(
+        Object.entries(current).map(([key, value]) => [
+          key,
+          recurse(value, `${path}/${escapeJsonPointerSegment(key)}`),
+        ]),
+      );
+    }
+
+    activeStack.delete(current);
+
+    return result;
+  };
+
+  return recurse(schema, '#') as T;
+}
+
 export async function generateTypeForSchema(
   schema: unknown,
   mediaType: string,
-): Promise<string> {
+  typeName: string,
+): Promise<GeneratedSchemaType> {
   if (!(mediaType === 'application/json' || mediaType.includes('+json'))) {
-    return 'unknown';
+    return { declarations: [], type: 'unknown' };
   }
 
-  const type = await compile(schema as JSONSchema, 'Type', {
-    bannerComment: '',
-    additionalProperties: true,
-    style: {
-      semi: false,
+  const declaration = await compile(
+    normalizeCircularSchemaRefs(schema) as JSONSchema,
+    typeName,
+    {
+      bannerComment: '',
+      additionalProperties: true,
+      style: {
+        semi: false,
+      },
     },
-  });
+  );
 
-  return type.replace(/export (interface|type) Type =?/, '');
+  return {
+    declarations: [declaration],
+    type: typeName,
+  };
 }
 
 export async function generateTypeForParameters2(
   parameters: Record<string, Parameter>,
+  nextTypeName: () => string,
 ): Promise<ParameterType> {
   const schema: {
     properties: Record<string, unknown>;
@@ -48,18 +96,25 @@ export async function generateTypeForParameters2(
   }
 
   return {
-    type: await generateTypeForSchema(schema, "'application/json'"),
+    ...(await generateTypeForSchema(
+      schema,
+      "'application/json'",
+      nextTypeName(),
+    )),
     required: schema.required.length > 0,
   };
 }
 
 export async function generateTypeForParameters(
   parameters: Record<string, Parameter>,
+  nextTypeName: () => string,
 ): Promise<ParameterType> {
   const result: {
+    declarations: string[];
     required: boolean;
     types: Record<string, string>;
   } = {
+    declarations: [],
     required: false,
     types: {},
   };
@@ -67,10 +122,14 @@ export async function generateTypeForParameters(
   for (const [name, param] of Object.entries(parameters)) {
     result.required ||= param.required;
 
-    result.types[name] = await generateTypeForSchema(
+    const generatedType = await generateTypeForSchema(
       param.schema,
       param.contentType ?? 'application/json',
+      nextTypeName(),
     );
+
+    result.types[name] = generatedType.type;
+    result.declarations.push(...generatedType.declarations);
   }
 
   const writer = new CodeBlockWriter({
@@ -84,16 +143,25 @@ export async function generateTypeForParameters(
   });
 
   return {
+    declarations: result.declarations,
     type: writer.toString(),
     required: result.required,
   };
 }
 
-export type ParameterType = { type: string; required: boolean };
+export type GeneratedSchemaType = {
+  declarations: string[];
+  type: string;
+};
+
+export type ParameterType = GeneratedSchemaType & {
+  required: boolean;
+};
 
 export type ResponseType = {
   statusCode: number;
   body?: string;
+  bodyDeclarations?: string[];
   headers: ParameterType;
 };
 
@@ -103,6 +171,7 @@ export type GeneratedTypes = {
     {
       req: {
         body?: string;
+        bodyDeclarations?: string[];
         query: ParameterType;
         path: ParameterType;
         headers: ParameterType;
@@ -111,6 +180,7 @@ export type GeneratedTypes = {
     }
   >;
   keyToTransactionId: Record<string, string>;
+  declarations: string[];
 };
 
 export const staticCode = `
@@ -349,15 +419,19 @@ export const infoText = `
  */
 `;
 
-export function generatedTypesToString(types: GeneratedTypes['types']): string {
+export function generatedTypesToString(generated: GeneratedTypes): string {
   const writer = new CodeBlockWriter({
     indentNumberOfSpaces: 2,
   });
 
   writer.writeLine(infoText).write(staticCode);
 
+  for (const declaration of generated.declarations) {
+    writer.writeLine(declaration);
+  }
+
   writer.writeLine(`export type Endpoints = `).block(() => {
-    for (const [key, { req, res }] of Object.entries(types)) {
+    for (const [key, { req, res }] of Object.entries(generated.types)) {
       writer
         .quote(key)
         .write(':')
@@ -431,9 +505,12 @@ export async function generateTypesForThymianFormat(
   format: ThymianFormat,
 ): Promise<GeneratedTypes> {
   const generated: GeneratedTypes = {
+    declarations: [],
     types: {},
     keyToTransactionId: {},
   };
+  let typeId = 0;
+  const nextTypeName = () => `GeneratedSchema${++typeId}`;
 
   for (const [
     req,
@@ -450,12 +527,24 @@ export async function generateTypesForThymianFormat(
     }
 
     const key = `${req.method.toUpperCase()} ${thymianHttpRequestToUrl(req)}`;
-    const query = await generateTypeForParameters(req.queryParameters);
-    const path = await generateTypeForParameters(req.pathParameters);
-    const headers = await generateTypeForParameters(allHeaders);
+    const query = await generateTypeForParameters(
+      req.queryParameters,
+      nextTypeName,
+    );
+    const path = await generateTypeForParameters(
+      req.pathParameters,
+      nextTypeName,
+    );
+    const headers = await generateTypeForParameters(allHeaders, nextTypeName);
     const body = req.body
-      ? await generateTypeForSchema(req.body, req.mediaType)
+      ? await generateTypeForSchema(req.body, req.mediaType, nextTypeName())
       : undefined;
+    generated.declarations.push(
+      ...query.declarations,
+      ...path.declarations,
+      ...headers.declarations,
+      ...(body?.declarations ?? []),
+    );
     const res: ResponseType[] = await Promise.all(
       responses.map(async (res) => {
         const headers = {
@@ -468,11 +557,20 @@ export async function generateTypesForThymianFormat(
 
         const result: ResponseType = {
           statusCode: res.statusCode,
-          headers: await generateTypeForParameters(headers),
+          headers: await generateTypeForParameters(headers, nextTypeName),
         };
 
+        generated.declarations.push(...result.headers.declarations);
+
         if (res.schema) {
-          result.body = await generateTypeForSchema(res.schema, res.mediaType);
+          const body = await generateTypeForSchema(
+            res.schema,
+            res.mediaType,
+            nextTypeName(),
+          );
+          result.body = body.type;
+          result.bodyDeclarations = body.declarations;
+          generated.declarations.push(...body.declarations);
         }
 
         return result;
@@ -529,7 +627,8 @@ export async function generateTypesForThymianFormat(
         query,
         headers,
         path,
-        body,
+        body: body?.type,
+        bodyDeclarations: body?.declarations,
       },
       res,
     };

--- a/packages/plugin-sampler/src/hooks/generate-request-types.ts
+++ b/packages/plugin-sampler/src/hooks/generate-request-types.ts
@@ -73,38 +73,6 @@ export async function generateTypeForSchema(
   };
 }
 
-export async function generateTypeForParameters2(
-  parameters: Record<string, Parameter>,
-  nextTypeName: () => string,
-): Promise<ParameterType> {
-  const schema: {
-    properties: Record<string, unknown>;
-    required: string[];
-    type: string;
-  } = {
-    type: 'object',
-    properties: {},
-    required: [],
-  };
-
-  for (const [name, param] of Object.entries(parameters)) {
-    schema.properties[name] = param.schema;
-
-    if (param.required) {
-      schema.required.push(name);
-    }
-  }
-
-  return {
-    ...(await generateTypeForSchema(
-      schema,
-      "'application/json'",
-      nextTypeName(),
-    )),
-    required: schema.required.length > 0,
-  };
-}
-
 export async function generateTypeForParameters(
   parameters: Record<string, Parameter>,
   nextTypeName: () => string,
@@ -161,7 +129,6 @@ export type ParameterType = GeneratedSchemaType & {
 export type ResponseType = {
   statusCode: number;
   body?: string;
-  bodyDeclarations?: string[];
   headers: ParameterType;
 };
 
@@ -171,7 +138,6 @@ export type GeneratedTypes = {
     {
       req: {
         body?: string;
-        bodyDeclarations?: string[];
         query: ParameterType;
         path: ParameterType;
         headers: ParameterType;
@@ -545,37 +511,38 @@ export async function generateTypesForThymianFormat(
       ...headers.declarations,
       ...(body?.declarations ?? []),
     );
-    const res: ResponseType[] = await Promise.all(
-      responses.map(async (res) => {
-        const headers = {
-          ...res.headers,
-        };
+    const res: ResponseType[] = [];
 
-        if (res.mediaType) {
-          headers['content-type'] = mediaTypeParameter(res.mediaType);
-        }
+    for (const response of responses) {
+      const responseHeaders = {
+        ...response.headers,
+      };
 
-        const result: ResponseType = {
-          statusCode: res.statusCode,
-          headers: await generateTypeForParameters(headers, nextTypeName),
-        };
+      if (response.mediaType) {
+        responseHeaders['content-type'] = mediaTypeParameter(
+          response.mediaType,
+        );
+      }
 
-        generated.declarations.push(...result.headers.declarations);
+      const result: ResponseType = {
+        statusCode: response.statusCode,
+        headers: await generateTypeForParameters(responseHeaders, nextTypeName),
+      };
 
-        if (res.schema) {
-          const body = await generateTypeForSchema(
-            res.schema,
-            res.mediaType,
-            nextTypeName(),
-          );
-          result.body = body.type;
-          result.bodyDeclarations = body.declarations;
-          generated.declarations.push(...body.declarations);
-        }
+      generated.declarations.push(...result.headers.declarations);
 
-        return result;
-      }),
-    );
+      if (response.schema) {
+        const body = await generateTypeForSchema(
+          response.schema,
+          response.mediaType,
+          nextTypeName(),
+        );
+        result.body = body.type;
+        generated.declarations.push(...body.declarations);
+      }
+
+      res.push(result);
+    }
 
     const default2xxResponse = res
       .filter((r) => r.statusCode >= 200 && r.statusCode < 300)
@@ -628,7 +595,6 @@ export async function generateTypesForThymianFormat(
         headers,
         path,
         body: body?.type,
-        bodyDeclarations: body?.declarations,
       },
       res,
     };

--- a/packages/plugin-sampler/src/index.ts
+++ b/packages/plugin-sampler/src/index.ts
@@ -186,7 +186,7 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
 
       await writeFile(
         join(basePath, 'types.d.ts'),
-        generatedTypesToString(generatedTypes.types),
+        generatedTypesToString(generatedTypes),
       );
 
       await writeFile(

--- a/packages/plugin-sampler/test/generate-request-types.test.ts
+++ b/packages/plugin-sampler/test/generate-request-types.test.ts
@@ -57,7 +57,7 @@ describe('generateRequestTypes', () => {
         'GET http://localhost:8080/users/{username}/orders': transactionId,
       });
 
-      const dtsContent = generatedTypesToString(result.types);
+      const dtsContent = generatedTypesToString(result);
 
       const project = new Project({
         skipAddingFilesFromTsConfig: true,
@@ -843,7 +843,69 @@ describe('generateRequestTypes', () => {
 
     const result = await generateTypesForThymianFormat(format);
 
-    const dtsContent = generatedTypesToString(result.types);
+    const dtsContent = generatedTypesToString(result);
+
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      compilerOptions: {
+        strict: true,
+      },
+    });
+    const sourceFile = project.createSourceFile('generated.d.ts', dtsContent);
+    const diagnostics = sourceFile.getPreEmitDiagnostics();
+
+    expect(
+      diagnostics.length,
+      'Generated source file should not emit any diagnostics',
+    ).toBe(0);
+  });
+
+  it('should generate request type definitions as a string - circular refs', async () => {
+    const format = new ThymianFormat();
+
+    const recursiveSchema: Record<string, unknown> = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+      },
+    };
+
+    recursiveSchema['properties'] = {
+      ...(recursiveSchema['properties'] as Record<string, unknown>),
+      parent: recursiveSchema,
+    };
+
+    format.addHttpTransaction(
+      {
+        cookies: {},
+        headers: {},
+        host: 'localhost',
+        label: '',
+        mediaType: 'application/json',
+        method: 'GET',
+        path: '/recursive',
+        pathParameters: {},
+        port: 8080,
+        protocol: 'http',
+        queryParameters: {},
+        type: 'http-request',
+        body: recursiveSchema,
+      },
+      {
+        headers: {},
+        label: '',
+        mediaType: 'application/json',
+        statusCode: 200,
+        type: 'http-response',
+        schema: recursiveSchema,
+      },
+      '',
+    );
+
+    const result = await generateTypesForThymianFormat(format);
+    const dtsContent = generatedTypesToString(result);
+
+    expect(dtsContent).toContain('parent?: GeneratedSchema');
 
     const project = new Project({
       skipAddingFilesFromTsConfig: true,


### PR DESCRIPTION
This PR:

* Enables sampler init support for OpenAPI files containing circular references.
* Resolves potential naming collisions during type generation for objects with identical resulting names.