### PR TITLE
fix(common-cli): disable json flag

### DIFF
--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -42,7 +42,7 @@ export type CommandArgs<T extends typeof Command> = Interfaces.InferredArgs<
 export abstract class BaseCliRunCommand<
   T extends typeof Command,
 > extends Command {
-  static override enableJsonFlag = true;
+  static override enableJsonFlag = false;
 
   /**
    * Whether this command requires API specifications to run.

--- a/packages/common-cli/src/thymian-base-command.ts
+++ b/packages/common-cli/src/thymian-base-command.ts
@@ -12,7 +12,7 @@ type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>;
 export abstract class ThymianBaseCommand<
   T extends typeof Command,
 > extends Command {
-  static override enableJsonFlag = true;
+  static override enableJsonFlag = false;
 
   static override baseFlags = {
     ['suppress-feedback']: Flags.boolean({


### PR DESCRIPTION
Currently, the `help` output still indicates that the `--json` flag is supported. This PR updates the output accordingly. We plan to implement broad support for this flag in the future.