### PR TITLE
fix(common-cli): add api description validation rules to default config

### DIFF
--- a/e2e-tests/src/cli-init.test.ts
+++ b/e2e-tests/src/cli-init.test.ts
@@ -38,7 +38,10 @@ describe('thymian generate config', () => {
     ]);
 
     // Verify default ruleSets and severity
-    expect(config.ruleSets).toEqual(['@thymian/rules-rfc-9110']);
+    expect(config.ruleSets).toEqual([
+      '@thymian/rules-rfc-9110',
+      '@thymian/rules-api-description-validation',
+    ]);
     expect(config.ruleSeverity).toBe('error');
     expect(config.rules).toEqual({});
 

--- a/packages/common-cli/src/default-config.ts
+++ b/packages/common-cli/src/default-config.ts
@@ -3,7 +3,10 @@ import type { ThymianConfig } from './thymian-config.js';
 export const defaultConfig: ThymianConfig = {
   specifications: [],
   traffic: [],
-  ruleSets: ['@thymian/rules-rfc-9110'],
+  ruleSets: [
+    '@thymian/rules-rfc-9110',
+    '@thymian/rules-api-description-validation',
+  ],
   ruleSeverity: 'error',
   rules: {},
   plugins: {

--- a/packages/thymian/eslint.config.mjs
+++ b/packages/thymian/eslint.config.mjs
@@ -29,6 +29,7 @@ export default [
             '@thymian/plugin-websocket-proxy',
             '@thymian/plugin-reporter',
             '@thymian/evaluation',
+            '@thymian/rules-api-description-validation',
           ],
         },
       ],

--- a/packages/thymian/package.json
+++ b/packages/thymian/package.json
@@ -61,6 +61,7 @@
     "@thymian/plugin-sampler": "0.0.0-PLACEHOLDER",
     "@thymian/plugin-websocket-proxy": "0.0.0-PLACEHOLDER",
     "@thymian/rules-rfc-9110": "0.0.0-PLACEHOLDER",
+    "@thymian/rules-api-description-validation": "0.0.0-PLACEHOLDER",
     "open": "^8.4.2",
     "tslib": "^2.3.0",
     "@thymian/core": "0.0.0-PLACEHOLDER"


### PR DESCRIPTION
The former `format-validation` plugin was migrated to a rule set. We should include this rule set to the default config, which is used for generating new configs and when users run Thymian without any config.