### PR TITLE
fix(rules-rfc-9110): make rule informational

### DIFF
--- a/packages/rules-rfc-9110/src/rules/fields/field-values/recipient-must-reject-or-replace-invalid-characters.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/field-values/recipient-must-reject-or-replace-invalid-characters.rule.ts
@@ -1,5 +1,4 @@
-import { constant, requestHeader } from '@thymian/core';
-import { httpRule, singleTestCase } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 // TODO: Implement ABNF validation for invalid character detection
 // Requires detecting CR (%x0D), LF (%x0A), or NUL (%x00) in field values
@@ -8,7 +7,7 @@ export default httpRule(
   'rfc9110/recipient-must-reject-or-replace-invalid-characters',
 )
   .severity('error')
-  .type('test')
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5')
   .description(
     'Field values containing CR, LF, or NUL characters are invalid and dangerous, due to the varying ways that implementations might parse and interpret those characters; a recipient of CR, LF, or NUL within a field value MUST either reject the message or replace each of those characters with SP before further processing or forwarding of that message.',
@@ -17,13 +16,4 @@ export default httpRule(
     'Recipient MUST either reject messages or replace CR, LF, or NUL characters with SP in field values.',
   )
   .tags('fields', 'field-values', 'security')
-  .rule((ctx) =>
-    ctx.httpTest(
-      singleTestCase()
-        .forTransactionsWith(constant(true))
-        .set(requestHeader('x-my-bad-header'), constant('value\r'))
-        .run()
-        .done(),
-    ),
-  )
   .done();


### PR DESCRIPTION
We need to make this rule `informational` for now. In the future, we should add the functionality to send invalid HTTP requests to test implementations and see how they respond to invalid requests. 