### PR TITLE
feat(thymian): add optional traffic source validation

### DIFF
--- a/packages/core/src/actions/traffic-load.action.ts
+++ b/packages/core/src/actions/traffic-load.action.ts
@@ -11,6 +11,7 @@ export interface TrafficInput {
 
 export interface CoreTrafficLoadInput {
   inputs: TrafficInput[];
+  validateTrafficSource: boolean;
   options?: Record<string, unknown>;
 }
 
@@ -36,13 +37,17 @@ export const trafficInputSchema = {
 export const trafficLoadActionSchema = {
   type: 'object',
   nullable: false,
-  required: ['inputs'],
+  required: ['inputs', 'validateTrafficSource'],
   additionalProperties: false,
   properties: {
     inputs: {
       type: 'array',
       nullable: false,
       items: trafficInputSchema,
+    },
+    validateTrafficSource: {
+      type: 'boolean',
+      nullable: false,
     },
     options: {
       type: 'object',

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -67,6 +67,7 @@ export interface AnalyzeWorkflowInput {
   ruleFilter?: RuleFilter;
   options?: Record<string, unknown>;
   validateSpecs?: boolean;
+  validateTrafficSource?: boolean;
 }
 
 export type RegisteredPlugin<
@@ -389,7 +390,10 @@ export class Thymian {
     const { rulesConfig, ruleFilter } = input;
 
     const [traffic, rules, format] = await Promise.all([
-      this.loadTraffic({ inputs: input.traffic }),
+      this.loadTraffic({
+        inputs: input.traffic,
+        validateTrafficSource: input.validateTrafficSource ?? false,
+      }),
       loadRules(input.rules ?? [], ruleFilter, rulesConfig, this.options.cwd),
       input.specification
         ? this.loadFormat(

--- a/packages/core/test/thymian.test.ts
+++ b/packages/core/test/thymian.test.ts
@@ -418,10 +418,12 @@ describe('Thymian', () => {
         specification: [{ type: 'openapi', location: '/tmp/api.yaml' }],
         traffic: [{ type: 'har', location: '/tmp/traffic.har' }],
         options: { includeTraces: true },
+        validateTrafficSource: true,
       });
 
       expect(trafficLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'har', location: '/tmp/traffic.har' }],
+        validateTrafficSource: true,
       });
       expect(formatLoadSpy).toHaveBeenCalledWith({
         inputs: [{ type: 'openapi', location: '/tmp/api.yaml' }],
@@ -450,6 +452,42 @@ describe('Thymian', () => {
             violations: [],
           },
         ],
+      });
+    });
+
+    it('analyze should default traffic-source validation to false', async () => {
+      const trafficLoadSpy = vitest.fn();
+
+      thymian.register(
+        createPluginFor(async (emitter) => {
+          emitter.onAction('core.traffic.load', (input, ctx) => {
+            trafficLoadSpy(input);
+            ctx.reply({ transactions: [] });
+          });
+
+          emitter.onAction('core.analyze', (_, ctx) => {
+            ctx.reply({
+              source: '@thymian/plugin-http-analyzer',
+              status: 'success',
+              violations: [],
+            });
+          });
+
+          emitter.onAction('core.report.flush', (_, ctx) => {
+            ctx.reply({ text: 'analyze report' });
+          });
+        }),
+      );
+
+      await thymian.ready();
+
+      await thymian.analyze({
+        traffic: [{ type: 'har', location: '/tmp/traffic.har' }],
+      });
+
+      expect(trafficLoadSpy).toHaveBeenCalledWith({
+        inputs: [{ type: 'har', location: '/tmp/traffic.har' }],
+        validateTrafficSource: false,
       });
     });
   });

--- a/packages/plugin-har/src/har-schema.ts
+++ b/packages/plugin-har/src/har-schema.ts
@@ -4,17 +4,16 @@ import type { HarLog } from './har-types.js';
 
 /**
  * Minimal JSON Schema for HAR 1.2 structure validation.
- * Validates only the fields consumed by the plugin — additional
- * HAR properties are allowed via `additionalProperties: true`.
+ * Validates only the field types consumed by the plugin.
+ * All fields are optional because there is no official HAR JSON schema
+ * and exporters commonly produce partial variants.
  */
 const harLogSchema = {
   type: 'object' as const,
-  required: ['log'] as const,
   additionalProperties: true,
   properties: {
     log: {
       type: 'object' as const,
-      required: ['entries'] as const,
       additionalProperties: true,
       properties: {
         version: { type: 'string' as const },
@@ -22,13 +21,11 @@ const harLogSchema = {
           type: 'array' as const,
           items: {
             type: 'object' as const,
-            required: ['request', 'time'] as const,
             additionalProperties: true,
             properties: {
               time: { type: 'number' as const },
               request: {
                 type: 'object' as const,
-                required: ['method', 'url', 'headers'] as const,
                 additionalProperties: true,
                 properties: {
                   method: { type: 'string' as const },
@@ -37,7 +34,6 @@ const harLogSchema = {
                     type: 'array' as const,
                     items: {
                       type: 'object' as const,
-                      required: ['name', 'value'] as const,
                       additionalProperties: true,
                       properties: {
                         name: { type: 'string' as const },
@@ -59,7 +55,6 @@ const harLogSchema = {
               response: {
                 type: 'object' as const,
                 nullable: true,
-                required: ['status', 'headers', 'content'] as const,
                 additionalProperties: true,
                 properties: {
                   status: { type: 'number' as const },
@@ -67,7 +62,6 @@ const harLogSchema = {
                     type: 'array' as const,
                     items: {
                       type: 'object' as const,
-                      required: ['name', 'value'] as const,
                       additionalProperties: true,
                       properties: {
                         name: { type: 'string' as const },
@@ -77,7 +71,6 @@ const harLogSchema = {
                   },
                   content: {
                     type: 'object' as const,
-                    required: ['size'] as const,
                     additionalProperties: true,
                     properties: {
                       text: { type: 'string' as const, nullable: true },

--- a/packages/plugin-har/src/index.ts
+++ b/packages/plugin-har/src/index.ts
@@ -111,6 +111,7 @@ export function createHarPlugin(
             maxFileSize,
             clientRole,
             serverRole,
+            input.validateTrafficSource,
           );
 
           // Avoid spread (`allTransactions.push(...transactions)`) because

--- a/packages/plugin-har/src/load-transactions.ts
+++ b/packages/plugin-har/src/load-transactions.ts
@@ -25,6 +25,7 @@ export async function loadTransactionsFromHar(
   maxFileSize: number,
   clientRole: HttpParticipantRole,
   serverRole: HttpParticipantRole,
+  validateTrafficSource: boolean,
 ): Promise<CapturedTransaction[]> {
   const filePath = isAbsolute(location) ? location : join(cwd, location);
 
@@ -60,16 +61,30 @@ export async function loadTransactionsFromHar(
   }
 
   if (!validateHar(parsed)) {
-    throw new ThymianBaseError(
-      `Invalid HAR structure in ${filePath}: ${getValidationErrors()}`,
+    const validationErrors = getValidationErrors();
+
+    if (validateTrafficSource) {
+      throw new ThymianBaseError(
+        `Invalid HAR structure in ${filePath}: ${validationErrors}`,
+      );
+    }
+
+    logger.warn(
+      `HAR schema validation failed for ${filePath}: ${validationErrors}.`,
     );
   }
 
-  const { transactions, skippedCount, skippedReasons } = transformHar(
-    parsed,
-    clientRole,
-    serverRole,
-  );
+  let transformed;
+
+  try {
+    transformed = transformHar(parsed as never, clientRole, serverRole);
+  } catch (err) {
+    throw new ThymianBaseError(`Failed to transform HAR file: ${filePath}`, {
+      cause: err instanceof Error ? err : undefined,
+    });
+  }
+
+  const { transactions, skippedCount, skippedReasons } = transformed;
 
   if (skippedCount > 0) {
     const uniqueReasons = [...new Set(skippedReasons)].join(', ');

--- a/packages/plugin-har/test/har-schema.test.ts
+++ b/packages/plugin-har/test/har-schema.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { getValidationErrors, validateHar } from '../src/har-schema.js';
+
+function createValidHar() {
+  return {
+    log: {
+      version: '1.2',
+      entries: [
+        {
+          time: 42,
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/users',
+            headers: [{ name: 'Accept', value: 'application/json' }],
+          },
+          response: {
+            status: 200,
+            headers: [{ name: 'Content-Type', value: 'application/json' }],
+            content: { size: 8, text: '{"id":1}' },
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe('har-schema', () => {
+  it('validateHar should accept a valid HAR payload', () => {
+    expect(validateHar(createValidHar())).toBe(true);
+  });
+
+  it('validateHar should accept HAR payloads without log.version', () => {
+    const har = createValidHar();
+    // @ts-expect-error test invalid payload
+    delete har.log.version;
+
+    expect(validateHar(har)).toBe(true);
+  });
+
+  it('validateHar should reject invalid response content types', () => {
+    const har = createValidHar();
+    har.log.entries[0]!.response!.content.size = '8' as never;
+
+    expect(validateHar(har)).toBe(false);
+    expect(getValidationErrors()).toContain(
+      '/log/entries/0/response/content/size',
+    );
+  });
+
+  it('validateHar should allow entries without a response', () => {
+    const har = createValidHar();
+    delete har.log.entries[0]!.response;
+
+    expect(validateHar(har)).toBe(true);
+  });
+
+  it('validateHar should accept sparse HAR objects with all fields omitted', () => {
+    expect(validateHar({})).toBe(true);
+  });
+
+  it('validateHar should reject non-object payloads', () => {
+    expect(validateHar('not-a-har')).toBe(false);
+    expect(getValidationErrors()).toContain('must be object');
+  });
+});

--- a/packages/plugin-har/test/plugin-har.test.ts
+++ b/packages/plugin-har/test/plugin-har.test.ts
@@ -52,6 +52,7 @@ describe('plugin-har', () => {
           location: '',
         },
       ],
+      validateTrafficSource: false,
     });
 
     expect(result.transactions).toHaveLength(0);
@@ -74,6 +75,7 @@ describe('plugin-har', () => {
           location: harFile,
         },
       ],
+      validateTrafficSource: false,
     });
 
     expect(result).toMatchObject({
@@ -109,13 +111,14 @@ describe('plugin-har', () => {
             location: harFile,
           },
         ],
+        validateTrafficSource: false,
       }),
     ).rejects.toThrowError(/as JSON/);
   });
 
-  it('should emit core.error for valid JSON but invalid HAR structure', async () => {
-    const harFile = join(tmpDir, 'not-har.har');
-    await writeFile(harFile, JSON.stringify({ foo: 'bar' }));
+  it('should still throw for malformed JSON when validation is enabled', async () => {
+    const harFile = join(tmpDir, 'bad-validated.har');
+    await writeFile(harFile, 'not-json{{{');
 
     const plugin = createHarPlugin();
 
@@ -131,8 +134,126 @@ describe('plugin-har', () => {
             location: harFile,
           },
         ],
+        validateTrafficSource: true,
+      }),
+    ).rejects.toThrowError(/as JSON/);
+  });
+
+  it('should warn but continue for transformable invalid HAR structure when validation is disabled', async () => {
+    const harFile = join(tmpDir, 'not-har.har');
+    await writeFile(
+      harFile,
+      JSON.stringify({
+        log: {
+          version: '1.2',
+          entries: [
+            {
+              ...validEntry,
+              response: {
+                ...validEntry.response,
+                content: { text: '{"id":1}', size: '8' },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const plugin = createHarPlugin();
+    const emitter = createMockEmitter();
+    const logger = createMockLogger();
+
+    await plugin.plugin(emitter, logger, { cwd: tmpDir });
+
+    const onActionCalls = vi.mocked(emitter.onAction).mock.calls;
+    const handler = onActionCalls.find(
+      (call) => call[0] === 'core.traffic.load',
+    )![1];
+
+    const replied = vi.fn();
+    await handler(
+      {
+        inputs: [
+          {
+            type: 'har',
+            location: harFile,
+          },
+        ],
+        validateTrafficSource: false,
+      },
+      {
+        reply: replied,
+      } as any,
+    );
+
+    expect(replied).toHaveBeenCalledWith({
+      transactions: [expect.any(Object)],
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('HAR schema validation failed'),
+    );
+  });
+
+  it('should throw for invalid HAR structure when validation is enabled', async () => {
+    const harFile = join(tmpDir, 'not-har.har');
+    await writeFile(
+      harFile,
+      JSON.stringify({
+        log: {
+          version: '1.2',
+          entries: [
+            {
+              ...validEntry,
+              response: {
+                ...validEntry.response,
+                content: { text: '{"id":1}', size: '8' },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const plugin = createHarPlugin();
+
+    const thymian = new Thymian().register(plugin);
+
+    await thymian.ready();
+
+    await expect(() =>
+      thymian.loadTraffic({
+        inputs: [
+          {
+            type: 'har',
+            location: harFile,
+          },
+        ],
+        validateTrafficSource: true,
       }),
     ).rejects.toThrowError(/Invalid HAR structure/);
+  });
+
+  it('should still throw when HAR is too sparse to transform even if schema validation is enabled', async () => {
+    const harFile = join(tmpDir, 'sparse.har');
+    await writeFile(harFile, JSON.stringify({}));
+
+    const plugin = createHarPlugin();
+
+    const thymian = new Thymian().register(plugin);
+
+    await thymian.ready();
+
+    await expect(() =>
+      thymian.loadTraffic({
+        inputs: [
+          {
+            type: 'har',
+            location: harFile,
+          },
+        ],
+        validateTrafficSource: true,
+      }),
+    ).rejects.toThrowError(/Failed to transform HAR file/);
   });
 
   it('should handle empty HAR file with zero entries', async () => {
@@ -151,9 +272,15 @@ describe('plugin-har', () => {
     )![1];
 
     const replied = vi.fn();
-    await handler({ inputs: [{ type: 'har', location: harFile }] }, {
-      reply: replied,
-    } as any);
+    await handler(
+      {
+        inputs: [{ type: 'har', location: harFile }],
+        validateTrafficSource: false,
+      },
+      {
+        reply: replied,
+      } as any,
+    );
 
     expect(replied).toHaveBeenCalledWith({ transactions: [] });
   });
@@ -174,9 +301,15 @@ describe('plugin-har', () => {
     )![1];
 
     const replied = vi.fn();
-    await handler({ inputs: [{ type: 'har', location: 'relative.har' }] }, {
-      reply: replied,
-    } as any);
+    await handler(
+      {
+        inputs: [{ type: 'har', location: 'relative.har' }],
+        validateTrafficSource: false,
+      },
+      {
+        reply: replied,
+      } as any,
+    );
 
     expect(replied).toHaveBeenCalledWith({
       transactions: [expect.any(Object)],
@@ -210,9 +343,15 @@ describe('plugin-har', () => {
     )![1];
 
     const replied = vi.fn();
-    await handler({ inputs: [{ type: 'har', location: harFile }] }, {
-      reply: replied,
-    } as any);
+    await handler(
+      {
+        inputs: [{ type: 'har', location: harFile }],
+        validateTrafficSource: false,
+      },
+      {
+        reply: replied,
+      } as any,
+    );
 
     expect(replied).toHaveBeenCalledWith({
       transactions: [expect.any(Object)],
@@ -242,6 +381,7 @@ describe('plugin-har', () => {
             location: harFile,
           },
         ],
+        validateTrafficSource: false,
       }),
     ).rejects.toThrowError(/exceeds maximum size/);
   });

--- a/packages/thymian/src/commands/analyze.ts
+++ b/packages/thymian/src/commands/analyze.ts
@@ -5,6 +5,7 @@ import {
   mergeRuleSets,
   resolveRuleSeverity,
 } from '@thymian/common-cli';
+import { Flags } from '@thymian/common-cli/oclif';
 import type {} from '@thymian/plugin-har';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
@@ -20,6 +21,15 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
     '<%= config.bin %> <%= command.id %> --traffic har:./traffic.har',
     '<%= config.bin %> <%= command.id %> --spec openapi:./openapi.yaml --traffic har:./traffic.har',
   ];
+
+  static override flags = {
+    ['validate-traffic-source']: Flags.boolean({
+      default: false,
+      allowNo: true,
+      description:
+        'Validate included traffic sources and fail on source-schema validation errors.',
+    }),
+  };
 
   static override requiresSpecifications = false;
   static override requiresTraffic = true;
@@ -46,6 +56,7 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
         rulesConfig: this.thymianConfig.rules,
         ruleFilter: createSeverityRuleFilter(ruleSeverity),
         validateSpecs: this.flags['validate-specs'],
+        validateTrafficSource: this.flags['validate-traffic-source'],
       });
     });
 


### PR DESCRIPTION
This pull request introduces a new option to validate the structure of traffic source files (such as HAR files) before processing them. This validation is now configurable via the API and CLI, allowing users to choose whether invalid traffic source schemas should cause a failure or just log a warning. The changes also relax the HAR schema validation to better support partial or non-standard HAR files, and add comprehensive tests for these behaviors.

Key changes include:

**Traffic Source Validation Configuration:**

* Added a new `validateTrafficSource` boolean option to the `CoreTrafficLoadInput` and `AnalyzeWorkflowInput` interfaces, and updated the relevant action schemas and method calls to support this option. This allows users to control whether invalid traffic source schemas are treated as errors or warnings.
* Exposed the `--validate-traffic-source` flag in the CLI `analyze` command, enabling users to set this option from the command line. 

**HAR Schema Validation Improvements:**

* Relaxed the HAR schema validation by removing most required fields, allowing for partial or non-standard HAR files to be accepted. This improves compatibility with various HAR exporters.
* Updated the HAR loader to throw an error if validation fails and `validateTrafficSource` is true, or to log a warning and continue if false. Also added error handling for transformation failures.

**Testing Enhancements:**

* Added and updated tests to cover the new validation logic, including cases for valid, invalid, and partial HAR files, as well as CLI and API usage with the new option.