### PR TITLE
fix(plugin-http-analyzer): map analytics violations to matched spec transactions

### DIFF
--- a/e2e-tests/src/cli-analyze-har-file.test.ts
+++ b/e2e-tests/src/cli-analyze-har-file.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -106,11 +106,6 @@ describe('thymian analyze with HAR file', () => {
 
   it('should apply api-description-validation rules to HAR traffic with an OpenAPI spec', () => {
     copyFixturesToTempDir(join(fixturesDir, 'analyze-har'), getTempDir());
-
-    cpSync(
-      join(fixturesDir, 'static-lint', 'test.openapi.yaml'),
-      join(getTempDir(), 'test.openapi.yaml'),
-    );
 
     writeFileSync(
       join(getTempDir(), 'parameterized.openapi.yaml'),

--- a/e2e-tests/src/cli-analyze-har-file.test.ts
+++ b/e2e-tests/src/cli-analyze-har-file.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { cpSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -102,5 +102,111 @@ describe('thymian analyze with HAR file', () => {
     );
 
     expect(result.exitCode).toBe(0);
+  }, 90_000);
+
+  it('should apply api-description-validation rules to HAR traffic with an OpenAPI spec', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'analyze-har'), getTempDir());
+
+    cpSync(
+      join(fixturesDir, 'static-lint', 'test.openapi.yaml'),
+      join(getTempDir(), 'test.openapi.yaml'),
+    );
+
+    writeFileSync(
+      join(getTempDir(), 'parameterized.openapi.yaml'),
+      [
+        'openapi: 3.1.0',
+        'info:',
+        "  title: 'Parameterized API'",
+        "  version: '1.0.0'",
+        'paths:',
+        '  /users/{id}:',
+        '    get:',
+        "      summary: 'Get user by id'",
+        "      operationId: 'getUser'",
+        '      parameters:',
+        "        - name: 'id'",
+        "          in: 'path'",
+        '          required: true',
+        '          schema:',
+        "            type: 'integer'",
+        '      responses:',
+        "        '200':",
+        "          description: 'OK'",
+        '          content:',
+        "            'application/json':",
+        '              schema:',
+        "                type: 'object'",
+        '                properties:',
+        '                  id:',
+        "                    type: 'integer'",
+      ].join('\n'),
+      'utf-8',
+    );
+
+    writeFileSync(
+      join(getTempDir(), 'parameterized.har'),
+      JSON.stringify({
+        log: {
+          version: '1.2',
+          entries: [
+            {
+              request: {
+                method: 'GET',
+                url: 'https://api.example.com/users/not-a-number',
+                headers: [{ name: 'Accept', value: 'application/json' }],
+              },
+              response: {
+                status: 200,
+                headers: [{ name: 'Content-Type', value: 'application/json' }],
+                content: {
+                  size: 21,
+                  mimeType: 'application/json',
+                  text: '{"id":"not-a-number"}',
+                },
+              },
+              time: 42,
+            },
+          ],
+        },
+      }),
+      'utf-8',
+    );
+
+    writeConfigToTempDir(
+      getTempDir(),
+      [
+        'ruleSets:',
+        "  - '@thymian/rules-api-description-validation'",
+        'plugins:',
+        "  '@thymian/plugin-har': {}",
+        "  '@thymian/plugin-http-analyzer': {}",
+        "  '@thymian/plugin-openapi': {}",
+        "  '@thymian/plugin-reporter':",
+        '    options:',
+        '      formatters:',
+        '        text: {}',
+      ].join('\n'),
+    );
+
+    const result = execThymianRaw(
+      [
+        'analyze',
+        '--traffic',
+        'har:parameterized.har',
+        '--spec',
+        'openapi:parameterized.openapi.yaml',
+      ],
+      {
+        cwd: getTempDir(),
+        allowFailure: true,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(
+      'thymian/request-path-parameters-must-conform-to-schema',
+    );
+    expect(result.stdout).toContain('Invalid value for path parameter "id"');
   }, 90_000);
 });

--- a/e2e-tests/src/cli-analyze-har-file.test.ts
+++ b/e2e-tests/src/cli-analyze-har-file.test.ts
@@ -119,6 +119,8 @@ describe('thymian analyze with HAR file', () => {
         'info:',
         "  title: 'Parameterized API'",
         "  version: '1.0.0'",
+        'servers:',
+        "  - url: 'https://api.example.com'",
         'paths:',
         '  /users/{id}:',
         '    get:',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10363,6 +10363,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/type-is": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/type-is/-/type-is-1.6.7.tgz",
+      "integrity": "sha512-gEsh7n8824nusZ2Sidh6POxNsIdTSvIAl5gXbeFj+TUaD1CO2r4i7MQYNMfEQkChU42s2bVWAda6x6BzIhtFbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -23558,7 +23568,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -24455,7 +24464,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -24465,7 +24473,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -31812,7 +31819,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -33729,10 +33735,12 @@
         "secure-json-parse": "^3.0.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
+        "type-is": "^1.6.18",
         "url-template": "^3.1.1"
       },
       "devDependencies": {
         "@types/semver": "^7.7.0",
+        "@types/type-is": "^1.6.7",
         "graphology-types": "^0.24.8"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,10 +56,12 @@
     "secure-json-parse": "^3.0.2",
     "semver": "^7.7.3",
     "tinyglobby": "^0.2.15",
+    "type-is": "^1.6.18",
     "url-template": "^3.1.1"
   },
   "devDependencies": {
     "@types/semver": "^7.7.0",
+    "@types/type-is": "^1.6.7",
     "graphology-types": "^0.24.8"
   }
 }

--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -520,37 +520,61 @@ export class ThymianFormat {
     req: HttpRequest,
     res: HttpResponse,
   ): [string, string, string] | undefined {
-    const edgeId = this.graph.findEdge(
-      (id, edge, sourceId, targetId, source, target) => {
-        if (!isEdgeType(edge, 'http-transaction')) {
-          return false;
-        }
+    const reqMediaType = getContentType(req.headers);
+    const resMediaType = getContentType(res.headers);
+    const reqOriginUrl = normalizeUrl(req.origin);
+    const matchingEdges = (ignoreOrigin = false): string[] =>
+      this.graph.reduceEdges(
+        (matches, id, edge, _sourceId, _targetId, source, target) => {
+          if (!isEdgeType(edge, 'http-transaction')) {
+            return matches;
+          }
 
-        const thymianReq = source as ThymianHttpRequest;
-        const thymianRes = target as ThymianHttpResponse;
+          const thymianReq = source as ThymianHttpRequest;
+          const thymianRes = target as ThymianHttpResponse;
 
-        const origin = thymianRequestToOrigin(thymianReq);
-        const reqMediaType = getContentType(req.headers);
-        const resMediaType = getContentType(res.headers);
+          const origin = thymianRequestToOrigin(thymianReq);
+          const pathMatches =
+            equalsIgnoreCase(thymianReq.path, req.path) ||
+            !!match(thymianReq.path.replaceAll(/{([^}]+)}/gi, ':$1'))(req.path);
 
-        const reqOriginUrl = normalizeUrl(req.origin);
+          const originMatches = ignoreOrigin
+            ? true
+            : equalsIgnoreCase(origin, reqOriginUrl.toString());
 
-        return (
-          equalsIgnoreCase(thymianReq.method, req.method) &&
-          equalsIgnoreCase(thymianReq.path, req.path) &&
-          equalsIgnoreCase(origin, reqOriginUrl.toString()) &&
-          thymianRes.statusCode === res.statusCode &&
-          equalsIgnoreCase(reqMediaType, thymianReq.mediaType) &&
-          equalsIgnoreCase(resMediaType, thymianRes.mediaType)
-        );
-      },
-    );
+          if (
+            equalsIgnoreCase(thymianReq.method, req.method) &&
+            pathMatches &&
+            originMatches &&
+            thymianRes.statusCode === res.statusCode &&
+            equalsIgnoreCase(reqMediaType, thymianReq.mediaType) &&
+            equalsIgnoreCase(resMediaType, thymianRes.mediaType)
+          ) {
+            matches.push(id);
+          }
 
-    if (!edgeId) {
+          return matches;
+        },
+        [] as string[],
+      );
+
+    const strictMatches = matchingEdges();
+
+    if (strictMatches[0]) {
+      return [strictMatches[0], ...this.graph.extremities(strictMatches[0])];
+    }
+
+    if (strictMatches.length > 1) {
       return undefined;
     }
 
-    return [edgeId, ...this.graph.extremities(edgeId)];
+    const relaxedMatches = matchingEdges(true);
+
+    if (relaxedMatches.length !== 1) {
+      return undefined;
+    }
+
+    return [relaxedMatches[0]!, ...this.graph.extremities(relaxedMatches[0]!)];
   }
 
   matchHtpRequestByUrl(url: string): MatchResult | undefined {

--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -523,7 +523,11 @@ export class ThymianFormat {
     const reqMediaType = getContentType(req.headers);
     const resMediaType = getContentType(res.headers);
     const reqOriginUrl = normalizeUrl(req.origin);
-    const matchingEdges = (ignoreOrigin = false): string[] =>
+    const reqPath = new URL(req.path, reqOriginUrl).pathname;
+    const matchingEdges = (
+      matcher: (thymianReq: ThymianHttpRequest) => boolean,
+      ignoreOrigin = false,
+    ): string[] =>
       this.graph.reduceEdges(
         (matches, id, edge, _sourceId, _targetId, source, target) => {
           if (!isEdgeType(edge, 'http-transaction')) {
@@ -534,17 +538,13 @@ export class ThymianFormat {
           const thymianRes = target as ThymianHttpResponse;
 
           const origin = thymianRequestToOrigin(thymianReq);
-          const pathMatches =
-            equalsIgnoreCase(thymianReq.path, req.path) ||
-            !!match(thymianReq.path.replaceAll(/{([^}]+)}/gi, ':$1'))(req.path);
-
           const originMatches = ignoreOrigin
             ? true
             : equalsIgnoreCase(origin, reqOriginUrl.toString());
 
           if (
             equalsIgnoreCase(thymianReq.method, req.method) &&
-            pathMatches &&
+            matcher(thymianReq) &&
             originMatches &&
             thymianRes.statusCode === res.statusCode &&
             equalsIgnoreCase(reqMediaType, thymianReq.mediaType) &&
@@ -558,9 +558,27 @@ export class ThymianFormat {
         [] as string[],
       );
 
-    const strictMatches = matchingEdges();
+    const exactPathMatches = matchingEdges((thymianReq) =>
+      equalsIgnoreCase(thymianReq.path, reqPath),
+    );
 
-    if (strictMatches[0]) {
+    if (exactPathMatches.length === 1 && exactPathMatches[0]) {
+      return [
+        exactPathMatches[0],
+        ...this.graph.extremities(exactPathMatches[0]),
+      ];
+    }
+
+    if (exactPathMatches.length > 1) {
+      return undefined;
+    }
+
+    const strictMatches = matchingEdges(
+      (thymianReq) =>
+        !!match(thymianReq.path.replaceAll(/{([^}]+)}/gi, ':$1'))(reqPath),
+    );
+
+    if (strictMatches.length === 1 && strictMatches[0]) {
       return [strictMatches[0], ...this.graph.extremities(strictMatches[0])];
     }
 
@@ -568,7 +586,11 @@ export class ThymianFormat {
       return undefined;
     }
 
-    const relaxedMatches = matchingEdges(true);
+    const relaxedMatches = matchingEdges(
+      (thymianReq) =>
+        !!match(thymianReq.path.replaceAll(/{([^}]+)}/gi, ':$1'))(reqPath),
+      true,
+    );
 
     if (relaxedMatches.length !== 1) {
       return undefined;

--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -18,6 +18,7 @@ import {
   getContentType,
   httpRequestToLabel,
   httpResponseToLabel,
+  matchesMediaType,
   normalizeUrl,
   type PartialBy,
   thymianRequestToOrigin,
@@ -547,8 +548,8 @@ export class ThymianFormat {
             matcher(thymianReq) &&
             originMatches &&
             thymianRes.statusCode === res.statusCode &&
-            equalsIgnoreCase(reqMediaType, thymianReq.mediaType) &&
-            equalsIgnoreCase(resMediaType, thymianRes.mediaType)
+            matchesMediaType(thymianReq, reqMediaType) &&
+            matchesMediaType(thymianRes, resMediaType)
           ) {
             matches.push(id);
           }

--- a/packages/core/src/http-testing/validate/validate-body.ts
+++ b/packages/core/src/http-testing/validate/validate-body.ts
@@ -1,4 +1,5 @@
 import { parse } from 'secure-json-parse';
+import { is } from 'type-is';
 
 import { type ThymianHttpResponse } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
@@ -62,7 +63,7 @@ export function validateBodyForResponse(
     return [];
   }
 
-  if (/^application\/[^+]*[+]?(json);?.*/.test(response.mediaType)) {
+  if (is(response.mediaType, ['*/vnd+json', '*/json', '+json', 'json'])) {
     return validateJsonBody(body, response);
   }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,4 +1,5 @@
 import deepmerge from '@fastify/deepmerge';
+import { is } from 'type-is';
 
 import type {
   ThymianHttpRequest,
@@ -277,6 +278,22 @@ export function queryParamsFromRequest(
 export function createRegExpFromOriginWildcard(pattern: string): RegExp {
   const regexString = `${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}/?(:\\d{1,5})?$`;
   return new RegExp(regexString);
+}
+
+export function matchesMediaType(
+  thyminReq: ThymianHttpRequest,
+  mediaType: string,
+): boolean;
+export function matchesMediaType(
+  thyminRes: ThymianHttpResponse,
+  mediaType: string,
+): boolean;
+export function matchesMediaType(
+  expected: ThymianHttpRequest | ThymianHttpResponse,
+  mediaType: string,
+): boolean {
+  // if the media type of the request or response is empty or undefined, there is no request/response body and we simply return true
+  return !expected.mediaType || !!is(mediaType, expected.mediaType);
 }
 
 export * from 'chalk';

--- a/packages/core/test/format/thymian-format.test.ts
+++ b/packages/core/test/format/thymian-format.test.ts
@@ -7,7 +7,6 @@ import {
   ThymianFormat,
   type ThymianHttpRequest,
   ThymianHttpResponse,
-  ThymianSchema,
 } from '../../src';
 
 describe('ThymianFormat', () => {
@@ -284,6 +283,61 @@ describe('ThymianFormat', () => {
       );
 
       expect(result).toBeUndefined();
+    });
+
+    it('should ignore charset parameter', () => {
+      const format = new ThymianFormat();
+
+      const [, , transactionId] = format.addHttpTransaction(
+        {
+          cookies: {},
+          headers: {},
+          host: 'localhost',
+          label: '',
+          mediaType: '',
+          method: 'get',
+          path: '/api/users',
+          pathParameters: {},
+          port: 3000,
+          protocol: 'http',
+          queryParameters: {},
+          sourceName: '',
+          type: 'http-request',
+        },
+        {
+          headers: {},
+          label: '',
+          mediaType: 'application/json',
+          sourceName: '',
+          statusCode: 200,
+          type: 'http-response',
+          schema: { type: 'object', properties: { name: { type: 'string' } } },
+        },
+        '',
+      );
+
+      const [matchedTransactionID] =
+        format.matchTransaction(
+          {
+            method: 'get',
+            origin: 'http://localhost:3000',
+            path: '/api/users',
+            headers: {},
+            body: undefined,
+          },
+          {
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/json; charset=utf-8',
+            },
+            body: '{"name": "matthyk"}',
+            bodyEncoding: undefined,
+            trailers: {},
+            duration: 0,
+          },
+        ) ?? [];
+
+      expect(matchedTransactionID).toEqual(transactionId);
     });
 
     it('should match a transaction with a different origin when it is the only candidate', () => {

--- a/packages/core/test/format/thymian-format.test.ts
+++ b/packages/core/test/format/thymian-format.test.ts
@@ -165,6 +165,317 @@ describe('ThymianFormat', () => {
     });
   });
 
+  describe('matchTransaction', () => {
+    function createParameterizedFormat() {
+      const format = new ThymianFormat();
+      const [, , transactionId] = format.addHttpTransaction(
+        {
+          type: 'http-request',
+          host: 'api.example.com',
+          port: 443,
+          protocol: 'https',
+          path: '/users/{id}',
+          method: 'GET',
+          headers: {},
+          queryParameters: {},
+          cookies: {},
+          pathParameters: {
+            id: {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'integer',
+              },
+            },
+          },
+          mediaType: '',
+          label: '',
+        },
+        {
+          type: 'http-response',
+          headers: {
+            'content-type': {
+              required: true,
+              schema: {
+                type: 'string',
+              },
+              style: {
+                explode: false,
+                style: 'simple',
+              },
+            },
+          },
+          mediaType: 'application/json',
+          statusCode: 200,
+        },
+        'test-source',
+      );
+
+      return { format, transactionId };
+    }
+
+    it('should match a transaction by templated path while keeping other constraints', () => {
+      const { format, transactionId } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/not-a-number',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.[0]).toBe(transactionId);
+    });
+
+    it('should still match exact paths', () => {
+      const { format, transactionId } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/{id}',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.[0]).toBe(transactionId);
+    });
+
+    it('should not match a transaction when the method differs', () => {
+      const { format } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/123',
+          method: 'post',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should match a transaction with a different origin when it is the only candidate', () => {
+      const { format, transactionId } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://other.example.com',
+          path: '/users/123',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.[0]).toBe(transactionId);
+    });
+
+    it('should not match a transaction when the response status differs', () => {
+      const { format } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/123',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should not match a transaction when the request media type differs', () => {
+      const format = new ThymianFormat();
+      format.addHttpTransaction(
+        {
+          type: 'http-request',
+          host: 'api.example.com',
+          port: 443,
+          protocol: 'https',
+          path: '/users/{id}',
+          method: 'POST',
+          headers: {},
+          queryParameters: {},
+          cookies: {},
+          pathParameters: {},
+          mediaType: 'application/json',
+          label: '',
+        },
+        {
+          type: 'http-response',
+          headers: {},
+          mediaType: 'application/json',
+          statusCode: 200,
+        },
+        'test-source',
+      );
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/123',
+          method: 'post',
+          headers: {
+            'content-type': 'text/plain',
+          },
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should not match a transaction when the response media type differs', () => {
+      const { format } = createParameterizedFormat();
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://api.example.com',
+          path: '/users/123',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'text/plain',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should not match when origin fallback produces multiple candidates', () => {
+      const format = new ThymianFormat();
+
+      format.addHttpTransaction(
+        {
+          type: 'http-request',
+          host: 'api-a.example.com',
+          port: 443,
+          protocol: 'https',
+          path: '/users/{id}',
+          method: 'GET',
+          headers: {},
+          queryParameters: {},
+          cookies: {},
+          pathParameters: {},
+          mediaType: '',
+          label: '',
+        },
+        {
+          type: 'http-response',
+          headers: {},
+          mediaType: 'application/json',
+          statusCode: 200,
+        },
+        'test-source-a',
+      );
+
+      format.addHttpTransaction(
+        {
+          type: 'http-request',
+          host: 'api-b.example.com',
+          port: 443,
+          protocol: 'https',
+          path: '/users/{id}',
+          method: 'GET',
+          headers: {},
+          queryParameters: {},
+          cookies: {},
+          pathParameters: {},
+          mediaType: '',
+          label: '',
+        },
+        {
+          type: 'http-response',
+          headers: {},
+          mediaType: 'application/json',
+          statusCode: 200,
+        },
+        'test-source-b',
+      );
+
+      const result = format.matchTransaction(
+        {
+          origin: 'https://other.example.com',
+          path: '/users/123',
+          method: 'get',
+          headers: {},
+        },
+        {
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+          trailers: {},
+          duration: 42,
+        },
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('filter', () => {
     it('should filter transactions based on expression', () => {
       const format = new ThymianFormat();

--- a/packages/plugin-http-analyzer/src/analytics-api-context.ts
+++ b/packages/plugin-http-analyzer/src/analytics-api-context.ts
@@ -215,13 +215,11 @@ export class AnalyticsApiContext implements AnalyzeContext {
       finalFilter,
       this.roles,
     )) {
-      const matchResult = this.format.matchHtpRequestByUrl(request.data.path);
-      const [, , transactionId] = matchResult?.reqId
-        ? (this.format
-            .getHttpResponsesOf(matchResult.reqId)
-            .find(([, res]) => res.statusCode === response.data.statusCode) ??
-          [])
-        : [];
+      const matchResult = this.format.matchTransaction(
+        request.data,
+        response.data,
+      );
+      const transactionId = matchResult?.[0];
 
       const location: RuleViolationLocation = transactionId
         ? {

--- a/packages/plugin-http-analyzer/src/analytics-api-context.ts
+++ b/packages/plugin-http-analyzer/src/analytics-api-context.ts
@@ -215,11 +215,18 @@ export class AnalyticsApiContext implements AnalyzeContext {
       finalFilter,
       this.roles,
     )) {
-      const matched = this.format.matchTransaction(request.data, response.data);
-      const location: RuleViolationLocation = matched
+      const matchResult = this.format.matchHtpRequestByUrl(request.data.path);
+      const [, , transactionId] = matchResult?.reqId
+        ? (this.format
+            .getHttpResponsesOf(matchResult.reqId)
+            .find(([, res]) => res.statusCode === response.data.statusCode) ??
+          [])
+        : [];
+
+      const location: RuleViolationLocation = transactionId
         ? {
             elementType: 'edge',
-            elementId: matched[0],
+            elementId: transactionId,
             label: httpTransactionToLabel(request.data, response.data),
           }
         : httpTransactionToLabel(request.data, response.data);

--- a/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
+++ b/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
@@ -1146,7 +1146,7 @@ describe('AnalyticsApiContext', () => {
               schema: { type: 'string' },
             },
           },
-          mediaType: 'application/json',
+          mediaType: '',
           pathParameters: {
             id: {
               name: 'id',

--- a/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
+++ b/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
@@ -1,6 +1,7 @@
 import {
   and,
   type CapturedTransaction,
+  httpTransactionToLabel,
   method,
   NoopLogger,
   not,
@@ -10,7 +11,11 @@ import {
   statusCode,
   statusCodeRange,
 } from '@thymian/core';
-import { createThymianFormat } from '@thymian/core-testing';
+import {
+  createHttpRequest,
+  createHttpResponse,
+  createThymianFormat,
+} from '@thymian/core-testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { AnalyticsApiContext } from '../src/analytics-api-context.js';
@@ -1102,6 +1107,99 @@ describe('AnalyticsApiContext', () => {
       const result = contextWithRole.validateHttpTransactions(statusCode(200));
 
       expect(result).toHaveLength(1);
+    });
+
+    it('should resolve transaction edge locations for parameterized paths', async () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users/not-a-number',
+            headers: {
+              accept: 'application/json',
+            },
+          },
+          meta: {},
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+            trailers: {},
+            duration: 100,
+          },
+          meta: {},
+        },
+      });
+
+      const format = createThymianFormat();
+      const [, , transactionId] = format.addHttpTransaction(
+        createHttpRequest({
+          method: 'GET',
+          host: 'api.example.com',
+          path: '/users/{id}',
+          headers: {
+            accept: {
+              schema: { type: 'string' },
+            },
+          },
+          mediaType: 'application/json',
+          pathParameters: {
+            id: {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'integer' },
+            },
+          },
+        }),
+        createHttpResponse({
+          statusCode: 200,
+          mediaType: 'application/json',
+        }),
+        'test-source',
+      );
+
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+      );
+
+      const result = context.validateHttpTransactions(method('get'));
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: {
+              elementType: 'edge',
+              elementId: transactionId,
+              label: httpTransactionToLabel(
+                {
+                  method: 'get',
+                  origin: 'https://api.example.com',
+                  path: '/users/not-a-number',
+                  headers: {
+                    accept: 'application/json',
+                  },
+                },
+                {
+                  statusCode: 200,
+                  headers: {
+                    'content-type': 'application/json',
+                  },
+                  trailers: {},
+                  duration: 100,
+                },
+              ),
+            },
+          }),
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
This pull request adds improved support for parameterized paths in the HTTP analyzer plugin, ensuring that validation and reporting of rule violations correctly resolve transaction edge locations for requests involving path parameters. It introduces a new end-to-end test to verify this behavior when analyzing HAR files with OpenAPI specs, and updates the analytics context logic and tests to match transactions by parameterized paths.

**End-to-end test enhancements:**

* Added a test in `cli-analyze-har-file.test.ts` to verify that `api-description-validation` rules are applied to HAR traffic using an OpenAPI spec with parameterized paths, and that violations are reported with the correct rule and message.

**Core logic improvements:**

* Updated `AnalyticsApiContext` to resolve transaction edge locations by matching HTTP requests to parameterized paths and retrieving the correct transaction ID for reporting rule violations.

**Unit test improvements:**

* Added a test in `analytics-api-context.test.ts` to ensure that parameterized paths correctly resolve transaction edge locations and labels.
* Updated test imports to include helpers for creating HTTP requests and responses with parameterized paths. 