### PR TITLE
fix(rules-rfc-9110): reclassify content-negotiation rule execution contexts

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.17"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
+      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.17",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
+      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/origin-server-should-send-response-without-content-coding.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/origin-server-should-send-response-without-content-coding.rule.ts
@@ -4,7 +4,10 @@ export default httpRule(
   'rfc9110/origin-server-should-send-response-without-content-coding',
 )
   .severity('warn')
-  .type('static')
+  // informational: requires understanding of available representations and
+  // content coding negotiation semantics that cannot be automatically validated
+  // from a spec, live response, or recorded traffic alone.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding')
   .description(
     'If a non-empty Accept-Encoding header field is present in a request and none of the available representations for the response have a content coding that is listed as acceptable, the origin server SHOULD send a response without any content coding unless the identity coding is indicated as unacceptable.',

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/server-must-not-include-accept-encoding-for-non-content-coding-415-errors.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/server-must-not-include-accept-encoding-for-non-content-coding-415-errors.rule.ts
@@ -11,7 +11,7 @@ export default httpRule(
   'rfc9110/server-must-not-include-accept-encoding-for-non-content-coding-415-errors',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding')
   .description(
     'In order to avoid confusion with issues related to media types, servers that fail a request with a 415 status for reasons unrelated to content codings MUST NOT include the Accept-Encoding header field.',

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-language/user-agent-must-not-send-accept-language-without-user-control.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-language/user-agent-must-not-send-accept-language-without-user-control.rule.ts
@@ -4,7 +4,10 @@ export default httpRule(
   'rfc9110/user-agent-must-not-send-accept-language-without-user-control',
 )
   .severity('error')
-  .type('analytics')
+  // informational: whether a user agent provides user control over language
+  // preferences is an implementation detail that cannot be determined from
+  // HTTP traffic or API descriptions.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-language')
   .description(
     'Since intelligibility is highly dependent on the individual user, user agents need to allow user control over the linguistic preference (either through configuration of the user agent itself or by defaulting to a user controllable system setting). A user agent that does not provide such control to the user MUST NOT send an Accept-Language header field.',

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept/recipient-should-process-q-parameter-as-weight.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept/recipient-should-process-q-parameter-as-weight.rule.ts
@@ -4,7 +4,10 @@ export default httpRule(
   'rfc9110/recipient-should-process-q-parameter-as-weight',
 )
   .severity('warn')
-  .type('static')
+  // informational: whether a recipient internally processes "q" as weight
+  // is an implementation behavior that cannot be observed or validated
+  // from outside the system.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-accept')
   .description(
     'Recipients SHOULD process any parameter named "q" as weight, regardless of parameter ordering.',

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/cache-must-not-use-response-without-matching-vary-headers.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/cache-must-not-use-response-without-matching-vary-headers.rule.ts
@@ -16,7 +16,7 @@ export default httpRule(
   'rfc9110/cache-must-not-use-response-without-matching-vary-headers',
 )
   .severity('error')
-  .type('analytics')
+  .type('analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-vary')
   .description(
     'To inform cache recipients that they MUST NOT use this response to satisfy a later request unless the later request has the same values for the listed header fields as the original request (Section 4.1 of [CACHING]) or reuse of the response has been validated by the origin server.',

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/origin-server-should-generate-vary-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/origin-server-should-generate-vary-header.rule.ts
@@ -2,7 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/origin-server-should-generate-vary-header')
   .severity('warn')
-  .type('static')
+  // TODO: implement rule function to validate Vary header presence on cacheable
+  // responses. Security-relevant: missing Vary headers can enable cache poisoning.
+  // - lint: check if API description declares Vary for endpoints with content negotiation
+  // - test: validate live responses include appropriate Vary headers
+  // - analyze: detect missing Vary in recorded traffic (infrastructure-level gaps)
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-vary')
   .description(
     "An origin server SHOULD generate a Vary header field on a cacheable response when it wishes that response to be selectively reused for subsequent requests. Generally, that is the case when the response content has been tailored to better fit the preferences expressed by those selecting header fields, such as when an origin server has selected the response's language based on the request's Accept-Language header field.",

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/proxy-must-not-generate-vary-wildcard.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/proxy-must-not-generate-vary-wildcard.rule.ts
@@ -3,7 +3,7 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/proxy-must-not-generate-vary-wildcard')
   .severity('error')
-  .type('analytics')
+  .type('analytics', 'test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-vary')
   .description(
     'A list containing the member "*" signals that other aspects of the request might have played a role in selecting the response representation, possibly including aspects outside the message syntax (e.g., the client\'s network address). A recipient will not be able to determine whether this response is appropriate for a later request without forwarding the request to the origin server. A proxy MUST NOT generate "*" in a Vary field value.',


### PR DESCRIPTION
## Summary

Reviewed and updated execution context assignments for all 11 content-negotiation rules in `@thymian/rules-rfc-9110` to align with the intended lint/test/analyze execution model.

Closes part of thymianofficial/thymian-internal#327

## Rationale

Content-negotiation rules deal with headers like `Accept`, `Accept-Encoding`, `Vary`, and quality values. Whether a rule belongs in `test` depends on whether it validates **response-side** (server) behavior or **request-side** (client/sender) behavior:

- **Response-side rules** belong in `test` because Thymian sends a request and can observe the server's response. The server's behavior is what's being validated.
- **Request-side rules** do not belong in `test` because Thymian generates requests from the OpenAPI spec — it is the sender. Validating Thymian's own generated requests is meaningless. These rules belong in `analyze`, where recorded traffic contains requests made by real clients (developers, third-party consumers) who had full control over what they sent.

Three rules were assigned to executable contexts (`static` or `analytics`) despite having no `.rule()` function and describing behaviors that cannot be observed from outside the system. Keeping these as executable types is misleading — they will never produce findings, and their presence in rule listings for those modes sets false expectations.

The `origin-server-should-generate-vary-header` rule is security-relevant: a missing `Vary` header on cacheable responses can enable cache poisoning. Expanding it to all three contexts ensures it will be flagged in lint (spec review), test (live validation of server responses), and analyze (production traffic audit) once the rule function is implemented.

## Changes

### Rules expanded to include `test` context (3 rules)

These rules validate **server/response-side behavior** and have existing `.rule()` functions. In `test` mode, Thymian sends a request and the server's response can be checked — adding `test` is correct because the server's behavior is what's under validation.

- `server-must-not-include-accept-encoding-for-non-content-coding-415-errors` — `static, analytics` → `static, analytics, test`
  **Why**: Validates that a server returning 415 for non-content-coding reasons does not include `Accept-Encoding` in the response. This is observable in live server responses.
- `cache-must-not-use-response-without-matching-vary-headers` — `analytics` → `analytics, test`
  **Why**: Validates caching correctness by checking Vary-related headers in responses. Observable when testing against a live server with caching infrastructure.
- `proxy-must-not-generate-vary-wildcard` — `analytics` → `analytics, test`
  **Why**: Validates that `Vary: *` is not present in responses. Observable in live responses from servers behind proxies.

### Rules reclassified to `informational` (3 rules)

These rules had no `.rule()` function and describe requirements that depend on internal implementation details not observable through HTTP traffic or API descriptions. Automatic validation is not feasible.

- `origin-server-should-send-response-without-content-coding` — `static` → `informational`
  **Why**: Determining whether "none of the available representations have an acceptable content coding" requires knowledge of the server's full representation set, which is not available from a spec or traffic alone.
- `user-agent-must-not-send-accept-language-without-user-control` — `analytics` → `informational`
  **Why**: Whether a user agent exposes language preference controls to the user is an implementation detail that cannot be inferred from the presence or absence of `Accept-Language` in traffic.
- `recipient-should-process-q-parameter-as-weight` — `static` → `informational`
  **Why**: How a recipient internally interprets the `q` parameter is unobservable — there is no external signal that distinguishes correct from incorrect processing.

### Rules expanded with TODO for implementation (1 rule)

- `origin-server-should-generate-vary-header` — `static` → `static, test, analytics`
  **Why**: Vary header presence on cacheable responses is a **response-side** check, valid in all three contexts. In lint, the API description can declare Vary on negotiated endpoints. In test, live server responses reveal whether Vary is actually sent. In analyze, recorded traffic exposes gaps introduced by infrastructure (proxies, CDNs) that may strip or fail to add Vary. This is security-relevant because missing Vary enables cache poisoning. A TODO stub is added; the rule function implementation will follow.

### No change (4 rules)

- `user-agent-may-associate-quality-value-with-charset` — stays `static, analytics`
  **Why**: Validates request-side behavior (`Accept-Charset` header). Does not belong in `test` because Thymian generates the request — validating its own output is not meaningful. Correctly present in `analytics` where real client requests can be checked.
- `codings-value-may-be-given-quality-value` — stays `analytics, static`
  **Why**: Validates request-side behavior (`Accept-Encoding` header). Same reasoning — request originates from Thymian in test mode, not from a real client.
- `sender-should-send-q-parameter-last` — stays `analytics, static`
  **Why**: Validates request-side behavior (`Accept` header q-parameter ordering). The analytics override inspects actual header values from real client traffic, which is where this check is meaningful.
- `user-agent-may-send-preference-headers-for-proactive-negotiation` — stays `informational`
  **Why**: General allowance ("a user agent MAY send preference headers") with no specific condition to validate.

## Verification
- `nx run rules-rfc-9110:test` — 64/64 passing
- `nx run rules-rfc-9110:lint` — 0 errors