### PR TITLE
chore(rules-rfc-9110): review authentication rule execution contexts

### DIFF
--- a/packages/rules-rfc-9110/src/rules/authentication/credentials/origin-server-should-send-401-for-invalid-credentials.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/credentials/origin-server-should-send-401-for-invalid-credentials.rule.ts
@@ -4,7 +4,12 @@ export default httpRule(
   'rfc9110/origin-server-should-send-401-for-invalid-credentials',
 )
   .severity('warn')
-  .type('informational')
+  // TODO: implement rule function to validate 401 response with WWW-Authenticate header.
+  // - test: send a request without valid credentials to a protected endpoint and verify
+  //   the server responds with 401 and includes a WWW-Authenticate header field.
+  // - analyze: inspect recorded traffic for responses to unauthenticated requests and
+  //   verify 401 status with WWW-Authenticate is present.
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-credentials')
   .description(
     'Upon receipt of a request for a protected resource that omits credentials, contains invalid credentials, or partial credentials, an origin server SHOULD send a 401 (Unauthorized) response that contains a WWW-Authenticate header field.',

--- a/packages/rules-rfc-9110/src/rules/authentication/credentials/proxy-should-send-407-for-invalid-proxy-credentials.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/credentials/proxy-should-send-407-for-invalid-proxy-credentials.rule.ts
@@ -4,7 +4,12 @@ export default httpRule(
   'rfc9110/proxy-should-send-407-for-invalid-proxy-credentials',
 )
   .severity('warn')
-  .type('informational')
+  // TODO: implement rule function to validate 407 response with Proxy-Authenticate header.
+  // - test: when testing through a proxy that requires authentication, verify the proxy
+  //   responds with 407 and includes a Proxy-Authenticate header field.
+  // - analyze: inspect recorded traffic for proxy authentication failures and verify
+  //   407 status with Proxy-Authenticate is present.
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-credentials')
   .description(
     'Upon receipt of a request that omits proxy credentials or contains invalid or partial proxy credentials, a proxy that requires authentication SHOULD generate a 407 (Proxy Authentication Required) response with a Proxy-Authenticate header field.',


### PR DESCRIPTION
## Summary

Reviewed and updated execution context assignments for all 11 authentication rules in `@thymian/rules-rfc-9110` to align with the intended lint/test/analyze execution model.

Closes part of thymianofficial/thymian-internal#327

## Rationale

Authentication rules deal with challenges, credentials, realm parameters, and proxy authentication headers. The key classification considerations:

- **Response-side rules** (401/407 responses, WWW-Authenticate/Proxy-Authenticate headers) belong in `test` and `analytics` because they validate server or proxy behavior observable in responses.
- **Infrastructure rules** (proxy modification of headers) stay in `analytics` even without a `.rule()` implementation, because observability depends on infrastructure provisioning — the user configures contexts per origin. These are not reclassified to `informational`.
- **Genuinely unobservable rules** (internal implementation details like scheme parameter syntax acceptance) stay `informational`.

## Changes

### Rules expanded from `informational` to `test, analytics` with TODO (2 rules)

These rules validate **response-side behavior** and are observable in both live testing and recorded traffic. TODO stubs are added for the `.rule()` implementations.

- `origin-server-should-send-401-for-invalid-credentials` — `informational` → `test, analytics`
  **Why**: A server SHOULD respond with 401 + `WWW-Authenticate` when credentials are missing or invalid. In `test`, Thymian can send a request without valid credentials and verify the response. In `analytics`, recorded traffic can be inspected for proper authentication failure handling.

- `proxy-should-send-407-for-invalid-proxy-credentials` — `informational` → `test, analytics`
  **Why**: A proxy SHOULD respond with 407 + `Proxy-Authenticate` when proxy credentials are missing or invalid. In `test`, the user may configure Thymian to test through a proxy depending on the origin. In `analytics`, recorded proxy traffic can be inspected. Included in `test` because the user can overwrite context settings per origin (localhost, dev, prod, etc.).

### No change (9 rules)

- `realm-parameter-must-use-quoted-string-syntax` — stays `test, analytics`
  **Why**: Validates response-side header syntax in actual HTTP exchanges. Not applicable to `static` since realm formatting is not declared in API specs.

- `authentication-parameter-name-must-occur-once-per-challenge` — stays `test, analytics`
  **Why**: Same reasoning — validates actual header content, not spec-level declarations.

- `server-may-send-www-authenticate-in-other-responses` — stays `static, analytics, test`
  **Why**: Already correctly assigned to all three contexts with a working `.rule()` implementation.

- `proxy-must-not-modify-authorization` — stays `analytics`
  **Why**: Proxy modification behavior. No `.rule()` yet, but stays `analytics` because observability depends on infrastructure provisioning. The user configures contexts per origin.

- `proxy-must-not-modify-www-authenticate` — stays `analytics`
  **Why**: Same reasoning as above — infrastructure-observable proxy behavior.

- `proxy-must-not-modify-authentication-info` — stays `informational`
  **Why**: Proxy modification detection requires comparing traffic at two points in the chain. Unlike the above two proxy rules, `Authentication-Info` modification is not practically detectable even with infrastructure access, because the field is less commonly logged/observed in proxy configurations.

- `authentication-scheme-must-accept-token-and-quoted-string` — stays `informational`
  **Why**: Internal implementation requirement — whether a scheme definition accepts both notations is not externally observable.

- `proxy-may-relay-credentials` — stays `informational`
  **Why**: Optional proxy behavior (`MAY`) with no specific condition to validate externally.

- `proxy-authenticate-applies-to-next-client` — stays `informational`
  **Why**: Scoping semantics of `Proxy-Authenticate` — not externally observable.

## Verification

- `nx run rules-rfc-9110:test` — 64/64 passing
- `nx run rules-rfc-9110:lint` — 0 errors