### PR TITLE
fix(rules-rfc-9110): reclassify conditional-requests rule execution contexts

### DIFF
--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/non-origin-server-must-not-evaluate-conditional-headers.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/non-origin-server-must-not-evaluate-conditional-headers.rule.ts
@@ -4,7 +4,7 @@ export default httpRule(
   'rfc9110/non-origin-server-must-not-evaluate-conditional-headers',
 )
   .severity('error')
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1')
   .description(
     'A server that is not the origin server for the target resource and cannot act as a cache for requests on the target resource MUST NOT evaluate the conditional request header fields defined by this specification, and it MUST forward them if the request is forwarded, since the generating client intends that they be evaluated by a server that can provide a current representation.',
@@ -14,4 +14,8 @@ export default httpRule(
   )
   .appliesTo('intermediary', 'proxy')
   .tags('conditional-requests', 'evaluation', 'forwarding')
+  // TODO: Implement analytics rule to detect intermediaries that evaluate conditional headers
+  // instead of forwarding them. In recorded traffic, this could be detected by comparing
+  // conditional request headers sent by clients against responses from intermediaries that
+  // return 304/412 when the origin server would not have.
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/non-origin-server-must-not-evaluate-conditional-headers.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/non-origin-server-must-not-evaluate-conditional-headers.rule.ts
@@ -14,8 +14,11 @@ export default httpRule(
   )
   .appliesTo('intermediary', 'proxy')
   .tags('conditional-requests', 'evaluation', 'forwarding')
-  // TODO: Implement analytics rule to detect intermediaries that evaluate conditional headers
-  // instead of forwarding them. In recorded traffic, this could be detected by comparing
-  // conditional request headers sent by clients against responses from intermediaries that
-  // return 304/412 when the origin server would not have.
+  // No automated rule is registered. This is an infrastructure (intermediary/proxy)
+  // rule: reliably distinguishing an intermediary from an origin server, and knowing
+  // what the origin's counterfactual response would have been, is not observable in
+  // generic recorded traffic. Per the infrastructure exception in issue #327's
+  // Acceptance Criteria, the rule remains analytics-classified because it COULD be
+  // validated in specific proxy deployments where the intermediary's identity and the
+  // origin's response are both captured.
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-conditionals-for-connect-options-trace.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-conditionals-for-connect-options-trace.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
   'rfc9110/server-must-ignore-conditionals-for-connect-options-trace',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1')
   .description(
     'A server MUST ignore the conditional request header fields defined by this specification when received with a request method that does not involve the selection or modification of a selected representation, such as CONNECT, OPTIONS, or TRACE.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
@@ -12,7 +12,7 @@ export default httpRule(
   'rfc9110/server-must-ignore-preconditions-for-non-2xx-412-responses',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1')
   .description(
     'A server MUST ignore all received preconditions if its response to the same request without those conditions, prior to processing the request content, would have been a status code other than a 2xx (Successful) or 412 (Precondition Failed). In other words, redirects and failures that can be detected before significant processing occurs take precedence over the evaluation of preconditions.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
@@ -12,7 +12,11 @@ export default httpRule(
   'rfc9110/server-must-ignore-preconditions-for-non-2xx-412-responses',
 )
   .severity('error')
-  .type('static', 'test', 'analytics')
+  // TODO: A `test` context for this rule needs a paired-request probe: send the request
+  // without preconditions to learn the natural status, then with preconditions to verify it
+  // is unchanged when the natural status is non-2xx/412. A single conditional request cannot
+  // establish what the response "would have been", so `test` is intentionally omitted here.
+  .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1')
   .description(
     'A server MUST ignore all received preconditions if its response to the same request without those conditions, prior to processing the request content, would have been a status code other than a 2xx (Successful) or 412 (Precondition Failed). In other words, redirects and failures that can be detected before significant processing occurs take precedence over the evaluation of preconditions.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
@@ -1,22 +1,19 @@
 import {
   and,
+  constant,
   not,
   or,
   requestHeader,
   statusCode,
   statusCodeRange,
 } from '@thymian/core';
-import { httpRule } from '@thymian/core';
+import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/server-must-ignore-preconditions-for-non-2xx-412-responses',
 )
   .severity('error')
-  // TODO: A `test` context for this rule needs a paired-request probe: send the request
-  // without preconditions to learn the natural status, then with preconditions to verify it
-  // is unchanged when the natural status is non-2xx/412. A single conditional request cannot
-  // establish what the response "would have been", so `test` is intentionally omitted here.
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1')
   .description(
     'A server MUST ignore all received preconditions if its response to the same request without those conditions, prior to processing the request content, would have been a status code other than a 2xx (Successful) or 412 (Precondition Failed). In other words, redirects and failures that can be detected before significant processing occurs take precedence over the evaluation of preconditions.',
@@ -36,6 +33,41 @@ export default httpRule(
         ),
         not(or(statusCodeRange(200, 299), statusCode(412))),
       ),
+    ),
+  )
+  .overrideTest((ctx) =>
+    ctx.httpTest(
+      singleTestCase()
+        .forTransactionsWith(
+          not(or(statusCodeRange(200, 299), statusCode(412))),
+        )
+        .run()
+        .replayStep((step) =>
+          step
+            .set(requestHeader('if-match'), constant('"qupaya"'))
+            .run()
+            .done(),
+        )
+        .transactions(([baseline, withPrecondition]) => {
+          if (
+            withPrecondition.response.statusCode !==
+            baseline.response.statusCode
+          ) {
+            ctx.reportViolation({
+              location: {
+                elementType: 'edge',
+                elementId: withPrecondition.source.transactionId,
+              },
+              message:
+                'Server did not ignore preconditions for a request whose unconditional response is non-2xx/412: status changed from ' +
+                baseline.response.statusCode +
+                ' to ' +
+                withPrecondition.response.statusCode +
+                ' when an If-Match precondition was added.',
+            });
+          }
+        })
+        .done(),
     ),
   )
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-412-response-to-conditional-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-412-response-to-conditional-request.rule.ts
@@ -11,7 +11,7 @@ export default httpRule(
   'rfc9110/origin-server-may-respond-with-412-response-to-conditional-request',
 )
   .severity('hint')
-  .type('static', 'test')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1')
   .description(
     'An origin server that evaluates an If-Match condition MUST NOT perform the requested method if the condition evaluates to false. Instead, the origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
@@ -1,10 +1,4 @@
-import {
-  and,
-  constant,
-  not,
-  requestHeader,
-  statusCodeRange,
-} from '@thymian/core';
+import { constant, requestHeader, statusCodeRange } from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
@@ -21,11 +15,11 @@ export default httpRule(
   )
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-match', '412', 'precondition-failed')
-  .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(
-      and(requestHeader('if-match'), not(statusCodeRange(400, 499))),
-    ),
-  )
+  // TODO: Implement analytics-specific validation. Detecting a violation in recorded
+  // traffic requires correlating each If-Match value against the resource's prior known
+  // ETag to infer an actual condition *failure*. validateCommonHttpTransactions is
+  // per-transaction and would false-positive on compliant 2xx responses to matching
+  // If-Match requests, so no analytics rule is registered until that correlation exists.
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
   'rfc9110/origin-server-must-not-perform-method-when-if-match-fails',
 )
   .severity('error')
-  .type('test', 'analytics')
+  .type('test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1')
   .description(
     'An origin server that evaluates an If-Match condition MUST NOT perform the requested method if the condition evaluates to false.',
@@ -15,11 +15,10 @@ export default httpRule(
   )
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-match', '412', 'precondition-failed')
-  // TODO: Implement analytics-specific validation. Detecting a violation in recorded
-  // traffic requires correlating each If-Match value against the resource's prior known
-  // ETag to infer an actual condition *failure*. validateCommonHttpTransactions is
-  // per-transaction and would false-positive on compliant 2xx responses to matching
-  // If-Match requests, so no analytics rule is registered until that correlation exists.
+  // Analytics is intentionally omitted: the precondition's reference validator
+  // is the resource state BEFORE the operation, which is not reconstructable
+  // from recorded traffic for state-changing methods — the response carries
+  // the post-change validator.
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
@@ -1,11 +1,17 @@
-import { constant, requestHeader, statusCodeRange } from '@thymian/core';
+import {
+  and,
+  constant,
+  not,
+  requestHeader,
+  statusCodeRange,
+} from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/origin-server-must-not-perform-method-when-if-match-fails',
 )
   .severity('error')
-  .type('test')
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1')
   .description(
     'An origin server that evaluates an If-Match condition MUST NOT perform the requested method if the condition evaluates to false.',
@@ -16,6 +22,11 @@ export default httpRule(
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-match', '412', 'precondition-failed')
   .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(
+      and(requestHeader('if-match'), not(statusCodeRange(400, 499))),
+    ),
+  )
+  .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()
         .forTransactionsWith(requestHeader('if-match'))

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/origin-server-should-respond-304-when-if-modified-since-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/origin-server-should-respond-304-when-if-modified-since-false.rule.ts
@@ -15,7 +15,7 @@ export default httpRule(
   'rfc9110/origin-server-should-respond-304-when-if-modified-since-false',
 )
   .severity('warn')
-  .type('static', 'test')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3')
   .description(
     'An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response, including only those metadata that are useful for identifying or updating a previously cached response.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-for-non-get-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-for-non-get-head.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
   'rfc9110/recipient-must-ignore-if-modified-since-for-non-get-head',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3')
   .description(
     'A recipient MUST ignore the If-Modified-Since header field if the request method is neither GET nor HEAD.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-when-if-none-match-present.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-when-if-none-match-present.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
   'rfc9110/recipient-must-ignore-if-modified-since-when-if-none-match-present',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3')
   .description(
     'A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field; the condition in If-None-Match is considered to be a more accurate replacement for the condition in If-Modified-Since, and the two are only combined for the sake of interoperating with older intermediaries that might not implement If-None-Match.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
@@ -28,10 +28,18 @@ export default httpRule(
           return undefined;
         }
 
-        const getWithout = txns.find(
-          ([req]) =>
-            req.method === 'GET' &&
-            !req.headers.some((h) => h === 'if-none-match'),
+        const getRequests = txns.filter(([req]) => req.method === 'GET');
+
+        // Only a *re-fetch* pattern is a missed optimization: the first
+        // retrieval has no stored representation yet, so omitting If-None-Match
+        // is correct. Require at least two GETs to the same resource before
+        // flagging, to avoid false positives on initial fetches.
+        if (getRequests.length < 2) {
+          return undefined;
+        }
+
+        const getWithout = getRequests.find(
+          ([req]) => !req.headers.some((h) => h === 'if-none-match'),
         );
 
         if (!getWithout) {

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
@@ -4,7 +4,7 @@ export default httpRule(
   'rfc9110/client-should-generate-if-none-match-for-cache-updates',
 )
   .severity('warn')
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2')
   .description(
     'If-None-Match is primarily used in conditional GET requests to enable efficient updates of cached information with a minimum amount of transaction overhead. When a client desires to update one or more stored responses that have entity tags, the client SHOULD generate an If-None-Match header field containing a list of those entity tags when making a GET request; this allows recipient servers to send a 304 (Not Modified) response to indicate when one of those stored responses matches the selected representation.',
@@ -14,4 +14,7 @@ export default httpRule(
   )
   .appliesTo('client')
   .tags('conditional-requests', 'if-none-match', 'cache', 'optimization')
+  // TODO: Implement analytics rule to detect GET requests in recorded traffic that lack
+  // If-None-Match headers when prior responses for the same resource included ETag headers,
+  // indicating missed cache optimization opportunities.
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/client-should-generate-if-none-match-for-cache-updates.rule.ts
@@ -1,3 +1,4 @@
+import { and, constant, origin, path } from '@thymian/core';
 import { httpRule } from '@thymian/core';
 
 export default httpRule(
@@ -14,7 +15,37 @@ export default httpRule(
   )
   .appliesTo('client')
   .tags('conditional-requests', 'if-none-match', 'cache', 'optimization')
-  // TODO: Implement analytics rule to detect GET requests in recorded traffic that lack
-  // If-None-Match headers when prior responses for the same resource included ETag headers,
-  // indicating missed cache optimization opportunities.
+  .rule((ctx) =>
+    ctx.validateGroupedCommonHttpTransactions(
+      constant(),
+      and(origin(), path()),
+      (_key, txns) => {
+        const groupHasEtagResponse = txns.some(([, res]) =>
+          res.headers.some((h) => h === 'etag'),
+        );
+
+        if (!groupHasEtagResponse) {
+          return undefined;
+        }
+
+        const getWithout = txns.find(
+          ([req]) =>
+            req.method === 'GET' &&
+            !req.headers.some((h) => h === 'if-none-match'),
+        );
+
+        if (!getWithout) {
+          return undefined;
+        }
+
+        const [, , location] = getWithout;
+
+        return {
+          location,
+          message:
+            'A prior response for this resource included an ETag, but a GET request omitted If-None-Match — a missed conditional-request (cache update) optimization opportunity.',
+        };
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/origin-server-must-respond-304-or-412-when-if-none-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/origin-server-must-respond-304-or-412-when-if-none-match-fails.rule.ts
@@ -17,7 +17,7 @@ export default httpRule(
   'rfc9110/origin-server-must-respond-304-or-412-when-if-none-match-fails',
 )
   .severity('error')
-  .type('static', 'test')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2')
   .description(
     'An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
@@ -1,5 +1,14 @@
-import { constant, not, requestHeader, statusCode } from '@thymian/core';
+import {
+  and,
+  constant,
+  getHeader,
+  not,
+  requestHeader,
+  statusCode,
+} from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
+
+import { ifRangeMatchesRepresentation } from '../../utils.js';
 
 export default httpRule(
   'rfc9110/recipient-must-ignore-range-when-if-range-false',
@@ -15,11 +24,39 @@ export default httpRule(
   )
   .appliesTo('server')
   .tags('conditional-requests', 'if-range', 'range', '206')
-  // TODO: Implement analytics-specific validation. A 206 response to an If-Range + Range
-  // request is the *expected* outcome when If-Range matches; it is only a violation when
-  // If-Range does NOT match the selected representation. Detecting that in recorded traffic
-  // requires comparing the If-Range value against the response's ETag/Last-Modified, which
-  // validateCommonHttpTransactions cannot express, so no analytics rule is registered yet.
+  .overrideAnalyticsRule((ctx) =>
+    ctx.validateHttpTransactions(
+      and(requestHeader('if-range'), requestHeader('range'), statusCode(206)),
+      (req, res) => {
+        const ifRangeRaw = getHeader(req.headers, 'if-range');
+        const ifRange = Array.isArray(ifRangeRaw) ? ifRangeRaw[0] : ifRangeRaw;
+        if (!ifRange) {
+          return false;
+        }
+
+        const etagRaw = getHeader(res.headers, 'etag');
+        const etag = Array.isArray(etagRaw) ? etagRaw[0] : etagRaw;
+
+        const lastModifiedRaw = getHeader(res.headers, 'last-modified');
+        const lastModified = Array.isArray(lastModifiedRaw)
+          ? lastModifiedRaw[0]
+          : lastModifiedRaw;
+
+        const matches = ifRangeMatchesRepresentation(
+          ifRange,
+          etag,
+          lastModified,
+        );
+
+        return matches === false
+          ? {
+              message:
+                'Server responded 206 to a Range request whose If-Range condition is false (If-Range does not match the selected representation); it MUST ignore Range and respond 200.',
+            }
+          : false;
+      },
+    ),
+  )
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
@@ -1,11 +1,11 @@
-import { constant, not, requestHeader, statusCode } from '@thymian/core';
+import { and, constant, not, requestHeader, statusCode } from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/recipient-must-ignore-range-when-if-range-false',
 )
   .severity('error')
-  .type('test')
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5')
   .description(
     'A recipient of an If-Range header field MUST ignore the Range header field if the If-Range condition evaluates to false. Otherwise, the recipient SHOULD process the Range header field as requested.',
@@ -16,6 +16,11 @@ export default httpRule(
   .appliesTo('server')
   .tags('conditional-requests', 'if-range', 'range', '206')
   .rule((ctx) =>
+    ctx.validateCommonHttpTransactions(
+      and(requestHeader('if-range'), requestHeader('range'), statusCode(206)),
+    ),
+  )
+  .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()
         .forTransactionsWith(requestHeader('if-match'))

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
@@ -1,4 +1,4 @@
-import { and, constant, not, requestHeader, statusCode } from '@thymian/core';
+import { constant, not, requestHeader, statusCode } from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
@@ -15,11 +15,11 @@ export default httpRule(
   )
   .appliesTo('server')
   .tags('conditional-requests', 'if-range', 'range', '206')
-  .rule((ctx) =>
-    ctx.validateCommonHttpTransactions(
-      and(requestHeader('if-range'), requestHeader('range'), statusCode(206)),
-    ),
-  )
+  // TODO: Implement analytics-specific validation. A 206 response to an If-Range + Range
+  // request is the *expected* outcome when If-Range matches; it is only a violation when
+  // If-Range does NOT match the selected representation. Detecting that in recorded traffic
+  // requires comparing the If-Range value against the response's ETag/Last-Modified, which
+  // validateCommonHttpTransactions cannot express, so no analytics rule is registered yet.
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-should-process-range-header-if-if-range-matches.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-should-process-range-header-if-if-range-matches.rule.ts
@@ -1,4 +1,17 @@
-import { httpRule } from '@thymian/core';
+import {
+  and,
+  constant,
+  getHeader,
+  method,
+  not,
+  or,
+  requestHeader,
+  responseHeader,
+  statusCode,
+} from '@thymian/core';
+import { httpRule, singleTestCase } from '@thymian/core';
+
+import { ifRangeMatchesRepresentation } from '../../utils.js';
 
 export default httpRule(
   'rfc9110/recipient-should-process-range-header-if-if-range-matches',
@@ -11,8 +24,59 @@ export default httpRule(
   )
   .appliesTo('server')
   .tags('conditional-requests', 'if-range', 'evaluation')
-  // TODO: Implement test rule that sends a Range request with a matching If-Range ETag
-  // (from a prior response) and verifies the server returns 206 Partial Content.
-  // TODO: Implement analytics rule that checks recorded traffic for transactions where
-  // a matching If-Range was sent with a Range header but the server did not respond with 206.
+  .overrideAnalyticsRule((ctx) =>
+    ctx.validateHttpTransactions(
+      and(requestHeader('if-range'), requestHeader('range'), statusCode(200)),
+      (req, res) => {
+        const ifRangeRaw = getHeader(req.headers, 'if-range');
+        const ifRange = Array.isArray(ifRangeRaw) ? ifRangeRaw[0] : ifRangeRaw;
+        if (!ifRange) {
+          return false;
+        }
+
+        const etagRaw = getHeader(res.headers, 'etag');
+        const etag = Array.isArray(etagRaw) ? etagRaw[0] : etagRaw;
+
+        const lastModifiedRaw = getHeader(res.headers, 'last-modified');
+        const lastModified = Array.isArray(lastModifiedRaw)
+          ? lastModifiedRaw[0]
+          : lastModifiedRaw;
+
+        const matches = ifRangeMatchesRepresentation(
+          ifRange,
+          etag,
+          lastModified,
+        );
+
+        return matches === true
+          ? {
+              message:
+                'If-Range condition matched the selected representation but the server returned 200 instead of 206; it SHOULD process the Range header.',
+            }
+          : false;
+      },
+    ),
+  )
+  .overrideTest((ctx) =>
+    ctx.httpTest(
+      singleTestCase()
+        .forTransactionsWith(
+          and(or(method('GET'), method('HEAD')), statusCode(200)),
+        )
+        .run()
+        .skipIf(
+          or(not(responseHeader('etag')), not(responseHeader('accept-ranges'))),
+          'No ETag or server does not advertise range support',
+        )
+        .replayStep((step) =>
+          step
+            .set(requestHeader('range'), constant('bytes=0-0'))
+            .set(requestHeader('if-range'), responseHeader('etag'))
+            .run()
+            .done(),
+        )
+        .expectForTransactions(statusCode(206))
+        .done(),
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-should-process-range-header-if-if-range-matches.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-should-process-range-header-if-if-range-matches.rule.ts
@@ -4,10 +4,15 @@ export default httpRule(
   'rfc9110/recipient-should-process-range-header-if-if-range-matches',
 )
   .severity('warn')
-  .type('informational')
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5')
   .description(
     'A recipient of an If-Range header field MUST ignore the Range header field if the If-Range condition evaluates to false. Otherwise, the recipient SHOULD process the Range header field as requested.',
   )
+  .appliesTo('server')
   .tags('conditional-requests', 'if-range', 'evaluation')
+  // TODO: Implement test rule that sends a Range request with a matching If-Range ETag
+  // (from a prior response) and verifies the server returns 206 Partial Content.
+  // TODO: Implement analytics rule that checks recorded traffic for transactions where
+  // a matching If-Range was sent with a Range header but the server did not respond with 206.
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-may-respond-with-412-response-to-unmodified-since.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-may-respond-with-412-response-to-unmodified-since.rule.ts
@@ -19,7 +19,7 @@ export default httpRule(
   'rfc9110/origin-server-may-respond-with-412-response-to-unmodified-since',
 )
   .severity('hint')
-  .type('static', 'test')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4')
   .description(
     'An origin server that evaluates an If-Unmodified-Since condition MUST NOT perform the requested method if the condition evaluates to false. Instead, the origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
@@ -14,7 +14,7 @@ export default httpRule(
   'rfc9110/origin-server-must-not-perform-method-when-if-unmodified-since-fails',
 )
   .severity('error')
-  .type('test')
+  .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4')
   .description(
     'An origin server that evaluates an If-Unmodified-Since condition MUST NOT perform the requested method if the condition evaluates to false. Instead, the origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code. Alternatively, if the request is a state-changing operation that appears to have already been applied to the selected representation, the origin server MAY respond with a 2xx (Successful) status code.',
@@ -25,6 +25,19 @@ export default httpRule(
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-unmodified-since', '412')
   .rule((ctx) =>
+    // TODO: Implement analytics-specific validation for If-Unmodified-Since failure detection.
+    // In analytics mode, this should check recorded traffic for transactions where
+    // If-Unmodified-Since was sent without If-Match, and the server responded with
+    // a success status when it should have responded 412 (based on Last-Modified comparison).
+    ctx.validateCommonHttpTransactions(
+      and(
+        requestHeader('if-unmodified-since'),
+        not(requestHeader('if-match')),
+        not(statusCodeRange(400, 499)),
+      ),
+    ),
+  )
+  .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()
         .forTransactionsWith(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
@@ -14,7 +14,7 @@ export default httpRule(
   'rfc9110/origin-server-must-not-perform-method-when-if-unmodified-since-fails',
 )
   .severity('error')
-  .type('test', 'analytics')
+  .type('test')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4')
   .description(
     'An origin server that evaluates an If-Unmodified-Since condition MUST NOT perform the requested method if the condition evaluates to false. Instead, the origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code. Alternatively, if the request is a state-changing operation that appears to have already been applied to the selected representation, the origin server MAY respond with a 2xx (Successful) status code.',
@@ -24,13 +24,10 @@ export default httpRule(
   )
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-unmodified-since', '412')
-  // TODO: Implement analytics-specific validation for If-Unmodified-Since failure detection.
-  // In analytics mode, this should check recorded traffic for transactions where
-  // If-Unmodified-Since was sent without If-Match, and the server responded with a success
-  // status when it should have responded 412 (by comparing If-Unmodified-Since against the
-  // resource's observed Last-Modified / known state). validateCommonHttpTransactions is
-  // per-transaction and would false-positive on compliant 2xx responses, so no analytics
-  // rule is registered until that correlation exists.
+  // Analytics is intentionally omitted: the precondition's reference validator
+  // is the resource state BEFORE the operation, which is not reconstructable
+  // from recorded traffic for state-changing methods — the response carries
+  // the post-change validator.
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
@@ -24,19 +24,13 @@ export default httpRule(
   )
   .appliesTo('origin server')
   .tags('conditional-requests', 'if-unmodified-since', '412')
-  .rule((ctx) =>
-    // TODO: Implement analytics-specific validation for If-Unmodified-Since failure detection.
-    // In analytics mode, this should check recorded traffic for transactions where
-    // If-Unmodified-Since was sent without If-Match, and the server responded with
-    // a success status when it should have responded 412 (based on Last-Modified comparison).
-    ctx.validateCommonHttpTransactions(
-      and(
-        requestHeader('if-unmodified-since'),
-        not(requestHeader('if-match')),
-        not(statusCodeRange(400, 499)),
-      ),
-    ),
-  )
+  // TODO: Implement analytics-specific validation for If-Unmodified-Since failure detection.
+  // In analytics mode, this should check recorded traffic for transactions where
+  // If-Unmodified-Since was sent without If-Match, and the server responded with a success
+  // status when it should have responded 412 (by comparing If-Unmodified-Since against the
+  // resource's observed Last-Modified / known state). validateCommonHttpTransactions is
+  // per-transaction and would false-positive on compliant 2xx responses, so no analytics
+  // rule is registered until that correlation exists.
   .overrideTest((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/recipient-must-ignore-if-unmodified-since-when-if-match-present.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/recipient-must-ignore-if-unmodified-since-when-if-match-present.rule.ts
@@ -5,7 +5,7 @@ export default httpRule(
   'rfc9110/recipient-must-ignore-if-unmodified-since-when-if-match-present',
 )
   .severity('error')
-  .type('static', 'analytics')
+  .type('static', 'test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4')
   .description(
     'A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field; the condition in If-Match is considered to be a more accurate replacement for the condition in If-Unmodified-Since, and the two are only combined for the sake of interoperating with older intermediaries that might not implement If-Match.',

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/utils.test.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/utils.test.ts
@@ -4,6 +4,7 @@ import {
   compareETags,
   compareHttpDates,
   hasInvalidConditionalETagSyntax,
+  ifRangeMatchesRepresentation,
   isStrongETag,
   isValidHttpDate,
   isWeakETag,
@@ -312,5 +313,65 @@ describe('compareHttpDates', () => {
         'Sun, 06 Nov 1994 08:49:38 GMT',
       ),
     ).toBe(-1);
+  });
+});
+
+describe('ifRangeMatchesRepresentation', () => {
+  const date = 'Sun, 06 Nov 1994 08:49:37 GMT';
+  const otherDate = 'Mon, 07 Nov 1994 08:49:37 GMT';
+
+  describe('date validator', () => {
+    it('returns true when If-Range date matches Last-Modified exactly', () => {
+      expect(ifRangeMatchesRepresentation(date, undefined, date)).toBe(true);
+    });
+
+    it('returns false when If-Range date does not match Last-Modified', () => {
+      expect(ifRangeMatchesRepresentation(date, undefined, otherDate)).toBe(
+        false,
+      );
+    });
+
+    it('returns null when Last-Modified is absent', () => {
+      expect(ifRangeMatchesRepresentation(date, undefined, undefined)).toBe(
+        null,
+      );
+    });
+
+    it('ignores ETag when If-Range is a valid HTTP-date', () => {
+      expect(ifRangeMatchesRepresentation(date, '"abc"', date)).toBe(true);
+    });
+  });
+
+  describe('entity-tag validator (strong comparison)', () => {
+    it('returns true when If-Range strong ETag matches response ETag', () => {
+      expect(ifRangeMatchesRepresentation('"abc"', '"abc"', undefined)).toBe(
+        true,
+      );
+    });
+
+    it('returns false when If-Range ETag does not match response ETag', () => {
+      expect(ifRangeMatchesRepresentation('"abc"', '"xyz"', undefined)).toBe(
+        false,
+      );
+    });
+
+    it('returns false when If-Range is a weak ETag (strong comparison fails)', () => {
+      // RFC 9110 §13.1.5: If-Range uses strong comparison; weak ETags MUST NOT match
+      expect(ifRangeMatchesRepresentation('W/"abc"', '"abc"', undefined)).toBe(
+        false,
+      );
+    });
+
+    it('returns null when ETag is absent', () => {
+      expect(ifRangeMatchesRepresentation('"abc"', undefined, undefined)).toBe(
+        null,
+      );
+    });
+
+    it('ignores Last-Modified when If-Range is an entity-tag', () => {
+      expect(ifRangeMatchesRepresentation('"abc"', '"abc"', otherDate)).toBe(
+        true,
+      );
+    });
   });
 });

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/utils.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/utils.ts
@@ -139,6 +139,48 @@ export function hasInvalidConditionalETagSyntax(headerValue: string): boolean {
 }
 
 /**
+ * Determines whether an If-Range header value matches the current selected
+ * representation, following RFC 9110 §13.1.5.
+ *
+ * If the If-Range value is a valid HTTP-date it is compared (as a date
+ * validator) against the response's Last-Modified value; otherwise it is
+ * treated as an entity-tag and compared against the response's ETag using
+ * **strong comparison** (RFC 9110 §13.1.5 requires strong comparison for
+ * If-Range).
+ *
+ * @param ifRange The trimmed value of the If-Range request header.
+ * @param etag The ETag value from the selected representation's response,
+ *   or `undefined` when not present.
+ * @param lastModified The Last-Modified value from the selected
+ *   representation's response, or `undefined` when not present.
+ * @returns `true` if the condition matches, `false` if it does not match,
+ *   or `null` when the necessary representation validator is absent and the
+ *   outcome cannot be determined. Callers should treat `null` as "unknown"
+ *   and refrain from reporting a violation.
+ */
+export function ifRangeMatchesRepresentation(
+  ifRange: string,
+  etag: string | undefined,
+  lastModified: string | undefined,
+): boolean | null {
+  const trimmed = ifRange.trim();
+
+  if (isValidHttpDate(trimmed)) {
+    // Date validator: compare against Last-Modified using exact equality
+    if (!lastModified) {
+      return null;
+    }
+    return compareHttpDates(trimmed, lastModified) === 0;
+  }
+
+  // Entity-tag validator: If-Range requires strong comparison (RFC 9110 §13.1.5)
+  if (!etag) {
+    return null;
+  }
+  return compareETags(trimmed, etag, false);
+}
+
+/**
  * Compares two HTTP dates
  * @param date1 First date string
  * @param date2 Second date string


### PR DESCRIPTION
## Summary

Reviewed and updated execution context assignments for the conditional-requests rules in
`@thymian/rules-rfc-9110`, **and implemented the rule logic** required to support the newly
declared contexts (per the updated guidance in thymianofficial/thymian-internal#327: reclassify
and implement together rather than deferring with TODOs).

Closes part of thymianofficial/thymian-internal#327

## Rationale

- **`lint` (static)**: design-time validation of the API description.
- **`test`**: validation of **server/response-side** behavior by sending real requests. Request-side
  rules don't belong here (Thymian generates the requests).
- **`analytics`**: validation of recorded request+response traffic. Both request- and response-side
  rules apply. A declared context must actually be validatable — we do **not** declare a context we
  can't implement.

### Framework note on analytics
`validateCommonHttpTransactions(filter)` treats every matching transaction as a violation. For
richer checks we use:
- `validateHttpTransactions(filter, (req,res)=>…)` — single transaction, full header **values**
  (compare a request header against the same response's validators).
- `validateGroupedCommonHttpTransactions(filter, groupBy, …)` — transactions grouped by resource
  (header names only).

## Implemented in this PR

### `test` added + implemented
- **`server-must-ignore-preconditions-for-non-2xx-412-responses`** — `static, analytics` →
  `static, test, analytics`. New `overrideTest` paired-baseline probe: send the request unconditionally
  to learn the natural status, replay with an added `If-Match` precondition, and report a violation
  only if the status changed (i.e. the precondition was not ignored when the natural response is
  non-2xx/412). This is the correct way to test a "what the response would have been" requirement.

### `analytics` added/implemented (response-side, single-transaction)
The If-Range condition is evaluated against the **current selected representation**, whose
`ETag`/`Last-Modified` are present in the same response, so both halves are decidable per-transaction.
A shared helper `ifRangeMatchesRepresentation(ifRange, etag, lastModified)` (strong ETag comparison
per RFC 9110 §13.1.5, or exact date match) was added to `conditional-requests/utils.ts` with unit tests.

- **`recipient-must-ignore-range-when-if-range-false`** (`test, analytics`) — analytics flags a `206`
  whose If-Range does **not** match the representation (server should have ignored Range → `200`).
- **`recipient-should-process-range-header-if-if-range-matches`** (`informational` → `test, analytics`)
  — analytics flags a `200` where If-Range **does** match (server should have returned `206`); test
  GETs a `200`, then replays `Range` + `If-Range: <ETag>` and expects `206` (skips when the server
  doesn't advertise `Accept-Ranges` or lacks an `ETag`).

### `analytics` added/implemented (grouped, request-side hint)
- **`client-should-generate-if-none-match-for-cache-updates`** (`informational` → `analytics`) —
  grouped by `origin`+`path`; flags a GET that omits `If-None-Match` when the resource was fetched
  repeatedly (≥2 GETs) and a response carried an `ETag` — a missed cache-update optimization. The
  ≥2-GET guard avoids false-positiving the initial fetch (where the client has no stored ETag yet).

### Other working analytics (already supported by the shared `.rule()`)
`origin-server-may-respond-with-412-response-to-conditional-request`,
`origin-server-must-respond-304-or-412-when-if-none-match-fails`,
`origin-server-may-respond-with-412-response-to-unmodified-since`,
`origin-server-should-respond-304-when-if-modified-since-false` — all `static, test` →
`static, test, analytics`, validated via the existing `validateCommonHttpTransactions` rule.

### `test` added (response-side, already implemented)
`server-must-ignore-conditionals-for-connect-options-trace`,
`recipient-must-ignore-if-unmodified-since-when-if-match-present`,
`recipient-must-ignore-if-modified-since-for-non-get-head`,
`recipient-must-ignore-if-modified-since-when-if-none-match-present` — `static, analytics` →
`static, test, analytics`.

## Reclassified to `test`-only (analytics not reliably possible)
- **`origin-server-must-not-perform-method-when-if-match-fails`** — `test, analytics` → `test`.
- **`origin-server-must-not-perform-method-when-if-unmodified-since-fails`** — `test, analytics` → `test`.

The precondition's reference validator is the resource state **before** the operation, which is not
reconstructable from recorded traffic for state-changing methods (the response carries the
post-change validator). Rather than ship a false-positive-prone heuristic, analytics is dropped and
the working active `test` is kept, with the reason documented in each file.

## Infrastructure rule kept classified (documented, no implementation)
- **`non-origin-server-must-not-evaluate-conditional-headers`** — stays `analytics`. Distinguishing an
  intermediary from an origin and knowing the origin's counterfactual response is not reliably
  observable in generic recorded traffic. Per issue #327's infrastructure exception, it remains
  analytics-classified (it *could* be validated in specific proxy deployments). The previous
  "implement later" TODO was replaced with a permanent rationale comment.

## Remaining `informational` / `request-side` rules
Unchanged: rules covering internal evaluation order, clock interpretation, comparison-algorithm
choice (genuinely unobservable) stay `informational`; request-side `client-*` / `If-Range`-generation
rules stay `analytics`/`static` as appropriate.

## Verification
- `nx run rules-rfc-9110:lint` — 0 errors.
- `nx run rules-rfc-9110:test` — 73 passing (existing 64 + new `ifRangeMatchesRepresentation` tests).

> Note: `rules-rfc-9110` has no per-rule execution tests by convention — rule execution is covered at
> the plugin-framework level; shared helpers are unit-tested. `nx run rules-rfc-9110:build` currently
> fails only at the `core` dependency due to a pre-existing missing `@types/type-is` (unrelated).
