### PR TITLE
feat(core): strictPayloads mode with serializability probe and schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ vitest.config.*.timestamp*
 .thymian
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+# Other AI files
+.mcp.json
+
+# Claude memory
+memory

--- a/packages/core/src/core-plugin.ts
+++ b/packages/core/src/core-plugin.ts
@@ -73,8 +73,7 @@ export const corePlugin: ThymianPlugin = {
   },
   events: {
     provides: {
-      'core.register':
-        RegisterPluginEventSchema as unknown as JSONSchemaType<unknown>,
+      'core.register': RegisterPluginEventSchema,
       'core.report': thymianReportSchema as unknown as JSONSchemaType<unknown>,
     },
   },

--- a/packages/core/src/emitter/index.ts
+++ b/packages/core/src/emitter/index.ts
@@ -1,5 +1,7 @@
 export * from './action-event.js';
 export * from './error-event.js';
 export * from './events.js';
+export * from './schema-registry.js';
+export * from './serializability-probe.js';
 export * from './thymian-emitter.js';
 export * from './utils.js';

--- a/packages/core/src/emitter/schema-registry.ts
+++ b/packages/core/src/emitter/schema-registry.ts
@@ -1,0 +1,87 @@
+import { ajv, type JSONSchemaType, validate } from '../ajv.js';
+import type { ThymianPlugin } from '../thymian-plugin.js';
+import {
+  probe,
+  type SerializabilityViolation,
+} from './serializability-probe.js';
+
+export type PayloadCheck =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: 'not-serializable';
+      violations: SerializabilityViolation[];
+    }
+  | { ok: false; reason: 'schema-mismatch'; details: string };
+
+export type PayloadKind = 'event' | 'action.event' | 'action.response';
+
+export class SchemaRegistry {
+  readonly #event = new Map<string, JSONSchemaType<unknown>>();
+  readonly #actionEvent = new Map<string, JSONSchemaType<unknown>>();
+  readonly #actionResponse = new Map<string, JSONSchemaType<unknown>>();
+
+  register<T extends Record<PropertyKey, unknown>>(
+    plugin: ThymianPlugin<T>,
+  ): void {
+    const events = plugin.events?.provides ?? {};
+    for (const [name, schema] of Object.entries(events)) {
+      if (schema) {
+        this.#event.set(name, schema as JSONSchemaType<unknown>);
+      }
+    }
+
+    const actions = plugin.actions?.provides ?? {};
+    for (const [name, schemas] of Object.entries(actions)) {
+      if (!schemas) {
+        continue;
+      }
+      this.#actionEvent.set(name, schemas.event as JSONSchemaType<unknown>);
+      this.#actionResponse.set(
+        name,
+        schemas.response as JSONSchemaType<unknown>,
+      );
+    }
+  }
+
+  has(name: string, kind: PayloadKind): boolean {
+    return this.#map(kind).has(name);
+  }
+
+  check(name: string, kind: PayloadKind, payload: unknown): PayloadCheck {
+    const serial = probe(payload);
+    if (!serial.ok) {
+      return {
+        ok: false,
+        reason: 'not-serializable',
+        violations: serial.violations,
+      };
+    }
+
+    const schema = this.#map(kind).get(name);
+    if (!schema) {
+      return { ok: true };
+    }
+
+    if (!validate(schema, payload)) {
+      return {
+        ok: false,
+        reason: 'schema-mismatch',
+        details: `payload does not match ${kind} schema for "${name}": ${ajv.errorsText(ajv.errors)}`,
+      };
+    }
+
+    return { ok: true };
+  }
+
+  #map(kind: PayloadKind): Map<string, JSONSchemaType<unknown>> {
+    switch (kind) {
+      case 'event':
+        return this.#event;
+      case 'action.event':
+        return this.#actionEvent;
+      case 'action.response':
+        return this.#actionResponse;
+    }
+  }
+}

--- a/packages/core/src/emitter/serializability-probe.ts
+++ b/packages/core/src/emitter/serializability-probe.ts
@@ -1,0 +1,160 @@
+export type SerializabilityViolation = {
+  path: string;
+  reason: string;
+  kind:
+    | 'function'
+    | 'class-instance'
+    | 'builtin'
+    | 'symbol'
+    | 'bigint'
+    | 'cycle';
+};
+
+export type ProbeResult =
+  | { ok: true }
+  | { ok: false; violations: SerializabilityViolation[] };
+
+const BUILTIN_TAGS = new Set([
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'Date',
+  'RegExp',
+  'Promise',
+  'Error',
+  'ArrayBuffer',
+  'DataView',
+  'Int8Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'BigInt64Array',
+  'BigUint64Array',
+]);
+
+export function probe(value: unknown): ProbeResult {
+  const violations: SerializabilityViolation[] = [];
+  walk(value, '$', new WeakSet(), violations);
+  return violations.length === 0 ? { ok: true } : { ok: false, violations };
+}
+
+function walk(
+  value: unknown,
+  path: string,
+  seen: WeakSet<object>,
+  out: SerializabilityViolation[],
+): void {
+  if (value === null) {
+    return;
+  }
+
+  const type = typeof value;
+
+  if (type === 'string' || type === 'number' || type === 'boolean') {
+    return;
+  }
+
+  if (type === 'undefined') {
+    // undefined is dropped by JSON.stringify; treat it as serializable.
+    return;
+  }
+
+  if (type === 'function') {
+    out.push({
+      path,
+      kind: 'function',
+      reason: 'functions are not serializable',
+    });
+    return;
+  }
+
+  if (type === 'symbol') {
+    out.push({
+      path,
+      kind: 'symbol',
+      reason: 'symbol values are not serializable',
+    });
+    return;
+  }
+
+  if (type === 'bigint') {
+    out.push({
+      path,
+      kind: 'bigint',
+      reason: 'bigint values are not serializable as JSON',
+    });
+    return;
+  }
+
+  if (type !== 'object') {
+    return;
+  }
+
+  const obj = value as object;
+
+  if (seen.has(obj)) {
+    out.push({
+      path,
+      kind: 'cycle',
+      reason: 'cyclic reference is not JSON-serializable',
+    });
+    return;
+  }
+  seen.add(obj);
+
+  try {
+    const tag = builtinTag(obj);
+    if (tag) {
+      out.push({
+        path,
+        kind: 'builtin',
+        reason: `${tag} is not a JSON-serializable value`,
+      });
+      return;
+    }
+
+    if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        walk(obj[i], `${path}[${i}]`, seen, out);
+      }
+      return;
+    }
+
+    // Plain objects only. Anything with a non-Object prototype is a class instance
+    // and not safe to pass over a wire (methods, accessors, non-enumerable state).
+    const proto = Object.getPrototypeOf(obj);
+    if (proto !== Object.prototype && proto !== null) {
+      out.push({
+        path,
+        kind: 'class-instance',
+        reason: `value is an instance of ${proto?.constructor?.name ?? 'unknown class'}`,
+      });
+      return;
+    }
+
+    for (const key of Reflect.ownKeys(obj)) {
+      if (typeof key === 'symbol') {
+        out.push({
+          path: `${path}.${String(key)}`,
+          kind: 'symbol',
+          reason: 'symbol-keyed property is not serializable',
+        });
+        continue;
+      }
+      walk((obj as Record<string, unknown>)[key], `${path}.${key}`, seen, out);
+    }
+  } finally {
+    seen.delete(obj);
+  }
+}
+
+function builtinTag(obj: object): string | undefined {
+  const tag = Object.prototype.toString.call(obj).slice(8, -1);
+  return BUILTIN_TAGS.has(tag) ? tag : undefined;
+}

--- a/packages/core/src/emitter/thymian-emitter.ts
+++ b/packages/core/src/emitter/thymian-emitter.ts
@@ -36,6 +36,11 @@ import type {
 import type { ErrorName, ThymianErrorEvent } from './error-event.js';
 import type { EventPayload, ThymianEvent } from './events.js';
 import {
+  type PayloadCheck,
+  type PayloadKind,
+  SchemaRegistry,
+} from './schema-registry.js';
+import {
   isActionEventWithName,
   isEventWithName,
   isResponseOf,
@@ -57,9 +62,13 @@ export type ActionHandler<Name extends ThymianActionName> = (
   ctx: ActionContext<Name>,
 ) => Promise<void> | void;
 
+export type StrictPayloadsMode = 'off' | 'warn' | 'throw';
+
 export type ThymianEmitterOptions = {
   timeout: number;
   traceEvents: boolean;
+  strictPayloads: StrictPayloadsMode;
+  schemaRegistry: SchemaRegistry;
 };
 
 export type EmitActionOptions = {
@@ -126,6 +135,8 @@ export class ThymianEmitter {
     this.options = {
       timeout: 1000,
       traceEvents: false,
+      strictPayloads: 'off',
+      schemaRegistry: new SchemaRegistry(),
       ...options,
     };
 
@@ -249,6 +260,7 @@ export class ThymianEmitter {
     name: Name,
     payload: EventPayload<Name>,
   ): void {
+    this.checkPayload(name, 'event', payload);
     this.#events.next({
       id: randomUUID(),
       name,
@@ -377,6 +389,8 @@ export class ThymianEmitter {
       return undefined as EmitActionReturnType<Name, Options>;
     }
 
+    this.checkPayload(name, 'action.event', payload);
+
     const start = performance.now();
     const event: ThymianActionEvent<Name> = {
       id: randomUUID(),
@@ -498,6 +512,52 @@ export class ThymianEmitter {
     );
   }
 
+  private checkPayload(
+    name: string,
+    kind: PayloadKind,
+    payload: unknown,
+  ): void {
+    if (this.options.strictPayloads === 'off') {
+      return;
+    }
+
+    const result = this.options.schemaRegistry.check(name, kind, payload);
+    if (result.ok) {
+      return;
+    }
+
+    this.reportPayloadViolation(name, kind, result);
+  }
+
+  private reportPayloadViolation(
+    name: string,
+    kind: PayloadKind,
+    result: Exclude<PayloadCheck, { ok: true }>,
+  ): void {
+    const header = `[strict-payloads] ${kind} "${name}" from "${this.source}"`;
+    const detail =
+      result.reason === 'not-serializable'
+        ? result.violations
+            .map((v) => `  - ${v.path}: ${v.reason} (${v.kind})`)
+            .join('\n')
+        : `  - ${result.details}`;
+    const message = `${header} failed payload check:\n${detail}`;
+
+    if (this.options.strictPayloads === 'throw') {
+      const isSerialError = result.reason === 'not-serializable';
+      throw new ThymianBaseError(message, {
+        name: isSerialError
+          ? 'NonSerializablePayloadError'
+          : 'SchemaValidationError',
+        ref: isSerialError
+          ? 'https://thymian.dev/references/errors/non-serializable-payload-error/'
+          : 'https://thymian.dev/references/errors/schema-validation-error/',
+      });
+    }
+
+    this.logger.warn(message);
+  }
+
   private createActionContext<Name extends ThymianActionName>(
     name: Name,
     correlationId: string,
@@ -546,6 +606,7 @@ export class ThymianEmitter {
         }
       },
       reply: (payload) => {
+        this.checkPayload(name, 'action.response', payload);
         this.#responses.next({
           correlationId,
           name,

--- a/packages/core/src/events/register-plugin.event.ts
+++ b/packages/core/src/events/register-plugin.event.ts
@@ -1,35 +1,31 @@
+import type { JSONSchemaType } from 'ajv/dist/2020.js';
+
 import type { ThymianPluginEvents } from '../thymian-plugin.js';
 
 export type RegisterPluginEvent = {
   name: string;
-  options: unknown;
+  options: Record<string, unknown>;
   events: ThymianPluginEvents;
 };
 
-export const RegisterPluginEventSchema = {
+export const RegisterPluginEventSchema: JSONSchemaType<RegisterPluginEvent> = {
   type: 'object',
-  required: ['name', 'options', 'events', 'hooks'],
+  required: ['name', 'options', 'events'],
   properties: {
     name: { type: 'string' },
-    options: {},
+    options: { type: 'object', additionalProperties: true },
     events: {
       type: 'object',
       properties: {
-        emits: { type: 'object', additionalProperties: true },
-        listens: { type: 'array', items: { type: 'string' } },
+        provides: {
+          type: 'object',
+          additionalProperties: true,
+          nullable: true,
+        },
+        emits: { type: 'array', items: { type: 'string' }, nullable: true },
+        listensOn: { type: 'array', items: { type: 'string' }, nullable: true },
       },
       additionalProperties: false,
-    },
-    hooks: {
-      type: 'object',
-      additionalProperties: {
-        type: 'object',
-        properties: {
-          input: { type: 'object', additionalProperties: true },
-          output: { type: 'object', additionalProperties: true },
-        },
-        additionalProperties: false,
-      },
     },
   },
   additionalProperties: false,

--- a/packages/core/src/events/report.event.ts
+++ b/packages/core/src/events/report.event.ts
@@ -211,4 +211,4 @@ export const thymianReportSchema: JSONSchemaType<ReportEvent> = {
       additionalProperties: true,
     },
   },
-} as unknown as JSONSchemaType<ReportEvent>;
+};

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -16,7 +16,11 @@ import type {
 } from './actions/index.js';
 import { validate } from './ajv.js';
 import { corePlugin } from './core-plugin.js';
-import { ThymianEmitter } from './emitter/index.js';
+import {
+  SchemaRegistry,
+  type StrictPayloadsMode,
+  ThymianEmitter,
+} from './emitter/index.js';
 import type {
   ThymianReport,
   ThymianReportItem,
@@ -93,6 +97,7 @@ export type ThymianOptions = {
   logAllErrors: boolean;
   logLevel?: LogLevel;
   sortReportsBy?: ReportSortMode;
+  strictPayloads: StrictPayloadsMode;
 };
 
 export class Thymian {
@@ -101,6 +106,8 @@ export class Thymian {
   readonly emitter: ThymianEmitter;
 
   readonly options: ThymianOptions;
+
+  readonly #schemaRegistry = new SchemaRegistry();
 
   #ready = false;
 
@@ -127,9 +134,12 @@ export class Thymian {
       cwd: process.cwd(),
       logAllErrors: false,
       logLevel,
+      strictPayloads: 'off',
       ...options,
       traceEvents,
     };
+
+    this.#schemaRegistry.register(corePlugin);
 
     const emitterLogger = logger.child('@thymian/core');
     this.emitter = new ThymianEmitter(
@@ -138,6 +148,8 @@ export class Thymian {
       {
         traceEvents: this.options.traceEvents,
         timeout: this.options.timeout,
+        strictPayloads: this.options.strictPayloads,
+        schemaRegistry: this.#schemaRegistry,
       },
     );
   }
@@ -173,6 +185,8 @@ export class Thymian {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     this.plugins.push({ plugin: plugin, options: options ?? {} });
+
+    this.#schemaRegistry.register(plugin);
 
     return this;
   }

--- a/packages/core/test/emitter-strict-payloads.test.ts
+++ b/packages/core/test/emitter-strict-payloads.test.ts
@@ -1,0 +1,108 @@
+import { Subject } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+
+import { corePlugin } from '../src/core-plugin.js';
+import { SchemaRegistry } from '../src/emitter/schema-registry.js';
+import { ThymianEmitter } from '../src/emitter/thymian-emitter.js';
+import { NoopLogger } from '../src/logger/noop.logger.js';
+import { ThymianBaseError } from '../src/thymian.error.js';
+
+function buildEmitter(
+  mode: 'off' | 'warn' | 'throw',
+  registry = new SchemaRegistry(),
+  { registerCore = true } = {},
+) {
+  if (registerCore) {
+    registry.register(corePlugin);
+  }
+
+  const warnings: string[] = [];
+  const logger = Object.assign(new NoopLogger(), {
+    warn: (msg: string) => warnings.push(msg),
+  });
+
+  const emitter = new ThymianEmitter(
+    logger,
+    {
+      completed: new Set(),
+      errors: new Subject(),
+      events: new Subject(),
+      listeners: new Map(),
+      responses: new Subject(),
+      source: '@thymian/core',
+    },
+    {
+      strictPayloads: mode,
+      schemaRegistry: registry,
+    },
+  );
+
+  return { emitter, warnings };
+}
+
+describe('ThymianEmitter strictPayloads', () => {
+  it('warns when an emitted event payload contains a class instance', () => {
+    const { emitter, warnings } = buildEmitter('warn');
+
+    // `core.register` is declared in core-plugin's events.provides.
+    // Embedding a class instance in the payload should be caught.
+    emitter.emit('core.register', {
+      name: 'demo',
+      options: { err: new ThymianBaseError('boom') },
+      events: {},
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/event "core\.register"/);
+    expect(warnings[0]).toMatch(/class-instance|builtin|Error/);
+  });
+
+  it('throws in throw mode when an emitted payload fails the probe', () => {
+    const { emitter } = buildEmitter('throw');
+
+    expect(() =>
+      emitter.emit('core.register', {
+        name: 'demo',
+        options: { err: new ThymianBaseError('boom') },
+        events: {},
+      }),
+    ).toThrow(/strict-payloads/);
+  });
+
+  it('does nothing in off mode', () => {
+    const { emitter, warnings } = buildEmitter('off');
+
+    emitter.emit('core.register', {
+      name: 'demo',
+      options: { err: new ThymianBaseError('boom') },
+      events: {},
+    });
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('probes serializability even when no schema is declared for the payload', () => {
+    const { emitter, warnings } = buildEmitter('warn', new SchemaRegistry(), {
+      registerCore: false,
+    });
+
+    emitter.emit('core.report', {
+      sections: [{ bad: () => 'fn' }],
+    } as unknown as never);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/not-serializable|function/);
+  });
+
+  it('passes through serializable payloads matching the schema', () => {
+    const { emitter, warnings } = buildEmitter('warn');
+
+    emitter.emit('core.report', {
+      source: 'test',
+      message: 'all good',
+      sections: [],
+    } as unknown as never);
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/core/test/serializability-probe.test.ts
+++ b/packages/core/test/serializability-probe.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { probe } from '../src/emitter/serializability-probe.js';
+
+describe('serializability probe', () => {
+  it('accepts plain JSON-shaped values', () => {
+    expect(probe({ a: 1, b: 'x', c: [1, 2, null, { d: true }] })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('rejects functions', () => {
+    const result = probe({ handler: () => 1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations[0]?.kind).toBe('function');
+      expect(result.violations[0]?.path).toBe('$.handler');
+    }
+  });
+
+  it('rejects class instances', () => {
+    class Box {
+      value = 1;
+    }
+    const result = probe({ box: new Box() });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations[0]?.kind).toBe('class-instance');
+      expect(result.violations[0]?.reason).toContain('Box');
+    }
+  });
+
+  it('rejects Error instances even though they look object-like', () => {
+    const result = probe({ err: new Error('boom') });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations[0]?.kind).toBe('builtin');
+      expect(result.violations[0]?.reason).toContain('Error');
+    }
+  });
+
+  it('rejects Maps/Sets/Dates/RegExps', () => {
+    const result = probe({
+      m: new Map(),
+      s: new Set(),
+      d: new Date(),
+      r: /x/,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations.map((v) => v.kind)).toEqual([
+        'builtin',
+        'builtin',
+        'builtin',
+        'builtin',
+      ]);
+    }
+  });
+
+  it('rejects bigint and symbol values', () => {
+    const result = probe({ big: 1n, sym: Symbol('x') });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const kinds = result.violations.map((v) => v.kind).sort();
+      expect(kinds).toEqual(['bigint', 'symbol']);
+    }
+  });
+
+  it('detects cycles', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    const result = probe(obj);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations[0]?.kind).toBe('cycle');
+    }
+  });
+
+  it('accepts shared (diamond) references without false-positive cycle reports', () => {
+    const shared = { x: 1 };
+    expect(probe({ a: shared, b: shared })).toEqual({ ok: true });
+    expect(probe([shared, shared])).toEqual({ ok: true });
+  });
+
+  it('walks into arrays of plain objects', () => {
+    const result = probe([{ ok: 1 }, { bad: () => 1 }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.violations[0]?.path).toBe('$[1].bad');
+    }
+  });
+});

--- a/packages/core/test/strict-payloads-live.test.ts
+++ b/packages/core/test/strict-payloads-live.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { ThymianFormat } from '../src/format/index.js';
+import { NoopLogger } from '../src/logger/noop.logger.js';
+import { Thymian } from '../src/thymian.js';
+
+class CapturingLogger extends NoopLogger {
+  warnings: string[] = [];
+  override warn(msg: unknown): void {
+    this.warnings.push(String(msg));
+  }
+}
+
+describe('strictPayloads against a live core flow', () => {
+  it(
+    'emits no probe warnings during a vanilla core.lint round-trip',
+    { timeout: 30_000 },
+    async () => {
+      const logger = new CapturingLogger();
+
+      const thymian = new Thymian(logger, { strictPayloads: 'warn' });
+
+      thymian.register({
+        name: 'demo',
+        version: '0.x',
+        plugin: async (emitter) => {
+          emitter.onAction('core.lint', (_payload, ctx) => {
+            ctx.reply({
+              source: 'demo',
+              status: 'success',
+              violations: [],
+            });
+          });
+        },
+      });
+
+      await thymian.run(async () => {
+        await thymian.emitter.emitAction('core.lint', {
+          format: new ThymianFormat().export(),
+          rules: [],
+          rulesConfig: {},
+        });
+      });
+
+      const probeWarnings = logger.warnings.filter((w) =>
+        w.includes('[strict-payloads]'),
+      );
+
+      expect(probeWarnings).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Adds a `strictPayloads: 'off' | 'warn' | 'throw'` option to `ThymianEmitter`, threaded via `child()` so all plugin emitters inherit it
- Introduces `serializability-probe.ts` — a deep-walker that flags functions, class instances, built-ins (`Map`/`Set`/`Date`/etc.), `Symbol`, `BigInt`, and cycles, returning dot-notation paths like `$.foo[3].bar`
- Introduces `SchemaRegistry` — populated from each plugin's `provides` at startup; runs the probe first, then AJV validation when a schema is declared
- The probe now fires on **all** payloads (events, action events, action responses) regardless of whether the plugin declared a `provides` schema — previously undeclared payloads were silently skipped
- Fixes `RegisterPluginEventSchema` to match the actual `RegisterPluginEvent` type (removed stale `hooks` field, corrected `events` sub-schema)

## Test plan

- [ ] `packages/core/test/serializability-probe.test.ts` — 8 unit tests for the probe (functions, class instances, built-ins, bigint/symbol, cycles, arrays)
- [ ] `packages/core/test/emitter-strict-payloads.test.ts` — 5 tests covering warn/throw/off modes and the new behaviour for undeclared payloads
- [ ] `packages/core/test/strict-payloads-live.test.ts` — smoke test against a real `core.lint` round-trip with strict mode on
- [ ] Build and run all core tests: `npx nx build core && npx nx test core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)