### PR TITLE
fix(core): make hash generation independant from source (location)

### DIFF
--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -131,6 +131,11 @@ export class ThymianFormat {
   readonly graph: ThymianGraph;
 
   static readonly ignoredNodeProperties: string[] = ['x', 'y'];
+  private static readonly ignoredHashProperties = [
+    'label',
+    'sourceLocation',
+    'sourceName',
+  ] as const;
 
   constructor(graph: ThymianGraph = new MultiDirectedGraph()) {
     this.graph = graph;
@@ -149,7 +154,7 @@ export class ThymianFormat {
       ...edge,
     };
 
-    const id = this.hash(source, target, this.hashObj(e));
+    const id = this.hash(source, target, this.semanticHashObj(e));
 
     if (this.graph.hasEdge(id)) {
       if (options.throwIfExists) {
@@ -215,7 +220,7 @@ export class ThymianFormat {
 
     // Generate unique ID by combining request ID with response hash
     // This ensures each request has its own response nodes, even if response content is identical
-    const responseNodeId = this.hash(requestId, this.hashObj(res));
+    const responseNodeId = this.hash(requestId, this.semanticHashObj(res));
 
     const resId = this.addResponse(res, responseNodeId);
 
@@ -289,7 +294,7 @@ export class ThymianFormat {
 
   addNode(
     node: ThymianNode,
-    id: string = this.hashObj(node),
+    id: string = this.semanticHashObj(node),
     options: {
       throwIfExists?: boolean;
     } = {},
@@ -688,13 +693,23 @@ export class ThymianFormat {
 
     this.graph
       .nodes()
+      .map((id) => this.semanticHashObj(this.graph.getNodeAttributes(id)))
       .sort()
-      .forEach((id) => hash.update(id));
+      .forEach((nodeHash) => hash.update(nodeHash));
 
     this.graph
       .edges()
+      .map((id) => {
+        const [source, target] = this.graph.extremities(id);
+
+        return this.hash(
+          this.semanticHashObj(this.graph.getNodeAttributes(source)),
+          this.semanticHashObj(this.graph.getNodeAttributes(target)),
+          this.semanticHashObj(this.graph.getEdgeAttributes(id)),
+        );
+      })
       .sort()
-      .forEach((id) => hash.update(id));
+      .forEach((edgeHash) => hash.update(edgeHash));
 
     return hash.digest('hex');
   }
@@ -834,5 +849,39 @@ export class ThymianFormat {
     }
 
     return createHash('sha1').update(stringify(obj)).digest('hex');
+  }
+
+  private semanticHashObj(obj: unknown): string {
+    if (typeof obj === 'undefined') {
+      return '';
+    }
+
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+      return this.hashObj(obj);
+    }
+
+    return this.hashObj(this.removeIgnoredHashProperties(obj));
+  }
+
+  private removeIgnoredHashProperties(obj: unknown): unknown {
+    if (!obj || typeof obj !== 'object') {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map((value) => this.removeIgnoredHashProperties(value));
+    }
+
+    const attributes = { ...(obj as Record<string, unknown>) };
+
+    ThymianFormat.ignoredHashProperties.forEach((property) => {
+      delete attributes[property];
+    });
+
+    Object.entries(attributes).forEach(([key, value]) => {
+      attributes[key] = this.removeIgnoredHashProperties(value);
+    });
+
+    return attributes;
   }
 }

--- a/packages/core/src/format/thymian-format.ts
+++ b/packages/core/src/format/thymian-format.ts
@@ -690,10 +690,19 @@ export class ThymianFormat {
 
   toHash(): string {
     const hash = createHash('sha1');
+    const nodeHashes = new Map(
+      this.graph
+        .nodes()
+        .map(
+          (id) =>
+            [
+              id,
+              this.semanticHashObj(this.graph.getNodeAttributes(id)),
+            ] as const,
+        ),
+    );
 
-    this.graph
-      .nodes()
-      .map((id) => this.semanticHashObj(this.graph.getNodeAttributes(id)))
+    [...nodeHashes.values()]
       .sort()
       .forEach((nodeHash) => hash.update(nodeHash));
 
@@ -703,8 +712,8 @@ export class ThymianFormat {
         const [source, target] = this.graph.extremities(id);
 
         return this.hash(
-          this.semanticHashObj(this.graph.getNodeAttributes(source)),
-          this.semanticHashObj(this.graph.getNodeAttributes(target)),
+          nodeHashes.get(source) ?? '',
+          nodeHashes.get(target) ?? '',
           this.semanticHashObj(this.graph.getEdgeAttributes(id)),
         );
       })
@@ -856,7 +865,7 @@ export class ThymianFormat {
       return '';
     }
 
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    if (!obj || typeof obj !== 'object') {
       return this.hashObj(obj);
     }
 

--- a/packages/core/test/format/thymian-format.test.ts
+++ b/packages/core/test/format/thymian-format.test.ts
@@ -794,6 +794,239 @@ describe('ThymianFormat', () => {
 
       expect(format1.toHash()).not.toBe(format2.toHash());
     });
+
+    it('should ignore labels, source names, and source locations', () => {
+      const format1 = new ThymianFormat();
+      const [reqId1, resId1, transactionId1] = format1.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        '/Users/alice/project/openapi.yaml',
+      );
+
+      format1.graph.setNodeAttribute(reqId1, 'label', 'Alice request label');
+      format1.graph.setNodeAttribute(resId1, 'label', 'Alice response label');
+      format1.graph.setNodeAttribute(reqId1, 'sourceLocation', {
+        path: '/Users/alice/project/openapi.yaml',
+        position: { line: 1, column: 2, offset: 3 },
+      });
+      format1.graph.setNodeAttribute(resId1, 'sourceLocation', {
+        path: '/Users/alice/project/openapi.yaml',
+        position: { line: 4, column: 5, offset: 6 },
+      });
+      format1.graph.setEdgeAttribute(
+        transactionId1,
+        'label',
+        'Alice transaction label',
+      );
+      format1.graph.setEdgeAttribute(transactionId1, 'sourceLocation', {
+        path: '/Users/alice/project/openapi.yaml',
+        position: { line: 7, column: 8, offset: 9 },
+      });
+
+      const format2 = new ThymianFormat();
+      const [reqId2, resId2, transactionId2] = format2.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        'C:\\Users\\bob\\project\\openapi.yaml',
+      );
+
+      format2.graph.setNodeAttribute(reqId2, 'label', 'Bob request label');
+      format2.graph.setNodeAttribute(resId2, 'label', 'Bob response label');
+      format2.graph.setNodeAttribute(reqId2, 'sourceLocation', {
+        path: 'C:\\Users\\bob\\project\\openapi.yaml',
+        position: { line: 10, column: 11, offset: 12 },
+      });
+      format2.graph.setNodeAttribute(resId2, 'sourceLocation', {
+        path: 'C:\\Users\\bob\\project\\openapi.yaml',
+        position: { line: 13, column: 14, offset: 15 },
+      });
+      format2.graph.setEdgeAttribute(
+        transactionId2,
+        'label',
+        'Bob transaction label',
+      );
+      format2.graph.setEdgeAttribute(transactionId2, 'sourceLocation', {
+        path: 'C:\\Users\\bob\\project\\openapi.yaml',
+        position: { line: 16, column: 17, offset: 18 },
+      });
+
+      expect(format1.toHash()).toBe(format2.toHash());
+      expect(format1.export().attributes.hash).toBe(
+        format2.export().attributes.hash,
+      );
+    });
+
+    it('should generate stable IDs for labels, source names, and source locations', () => {
+      const format1 = new ThymianFormat();
+      const ids1 = format1.addHttpTransaction(
+        {
+          ...transactions[0][0],
+          label: 'Request label A',
+          sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+        },
+        {
+          ...transactions[0][1],
+          label: 'Response label A',
+          sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+        },
+        '/Users/alice/project/openapi.yaml',
+      );
+
+      const format2 = new ThymianFormat();
+      const ids2 = format2.addHttpTransaction(
+        {
+          ...transactions[0][0],
+          label: 'Request label B',
+          sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+        },
+        {
+          ...transactions[0][1],
+          label: 'Response label B',
+          sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+        },
+        'C:\\Users\\bob\\project\\openapi.yaml',
+      );
+
+      expect(ids1).toStrictEqual(ids2);
+    });
+
+    it('should recursively ignore labels, source names, and source locations', () => {
+      const format1 = new ThymianFormat();
+      format1.addRequest({
+        ...transactions[0][0],
+        sourceName: 'source1',
+        extensions: {
+          metadata: {
+            sourceName: '/Users/alice/project/openapi.yaml',
+            sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+            label: 'Alice metadata label',
+          },
+        },
+      });
+
+      const format2 = new ThymianFormat();
+      format2.addRequest({
+        ...transactions[0][0],
+        sourceName: 'source2',
+        extensions: {
+          metadata: {
+            sourceName: 'C:\\Users\\bob\\project\\openapi.yaml',
+            sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+            label: 'Bob metadata label',
+          },
+        },
+      });
+
+      expect(format1.toHash()).toBe(format2.toHash());
+    });
+
+    it('should ignore source attribution on imported formats', () => {
+      const format = new ThymianFormat();
+      format.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        '/Users/alice/project/openapi.yaml',
+      );
+
+      const exported1 = format.export();
+      const exported2 = structuredClone(exported1);
+
+      exported1.nodes.forEach((node) => {
+        node.attributes.sourceName = '/Users/alice/project/openapi.yaml';
+        node.attributes.sourceLocation = {
+          path: '/Users/alice/project/openapi.yaml',
+        };
+      });
+      exported1.edges.forEach((edge) => {
+        edge.attributes.sourceName = '/Users/alice/project/openapi.yaml';
+        edge.attributes.sourceLocation = {
+          path: '/Users/alice/project/openapi.yaml',
+        };
+      });
+
+      exported2.nodes.forEach((node) => {
+        node.attributes.sourceName = 'C:\\Users\\bob\\project\\openapi.yaml';
+        node.attributes.sourceLocation = {
+          path: 'C:\\Users\\bob\\project\\openapi.yaml',
+        };
+      });
+      exported2.edges.forEach((edge) => {
+        edge.attributes.sourceName = 'C:\\Users\\bob\\project\\openapi.yaml';
+        edge.attributes.sourceLocation = {
+          path: 'C:\\Users\\bob\\project\\openapi.yaml',
+        };
+      });
+
+      expect(ThymianFormat.import(exported1).toHash()).toBe(
+        ThymianFormat.import(exported2).toHash(),
+      );
+    });
+
+    it('should include security schemes and HTTP links in semantic hashes', () => {
+      const format1 = new ThymianFormat();
+      const [reqId1, resId1] = format1.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        '/Users/alice/project/openapi.yaml',
+      );
+      const securityId1 = format1.addSecurityScheme({
+        scheme: 'api-key',
+        in: 'header',
+        sourceName: '/Users/alice/project/openapi.yaml',
+        sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+      });
+      format1.addEdge(reqId1, securityId1, {
+        type: 'is-secured',
+        sourceName: '/Users/alice/project/openapi.yaml',
+        sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+      });
+      format1.addHttpLink(resId1, reqId1, {
+        sourceName: '/Users/alice/project/openapi.yaml',
+        sourceLocation: { path: '/Users/alice/project/openapi.yaml' },
+      });
+
+      const format2 = new ThymianFormat();
+      const [reqId2, resId2] = format2.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        'C:\\Users\\bob\\project\\openapi.yaml',
+      );
+      const securityId2 = format2.addSecurityScheme({
+        scheme: 'api-key',
+        in: 'header',
+        sourceName: 'C:\\Users\\bob\\project\\openapi.yaml',
+        sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+      });
+      format2.addEdge(reqId2, securityId2, {
+        type: 'is-secured',
+        sourceName: 'C:\\Users\\bob\\project\\openapi.yaml',
+        sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+      });
+      format2.addHttpLink(resId2, reqId2, {
+        sourceName: 'C:\\Users\\bob\\project\\openapi.yaml',
+        sourceLocation: { path: 'C:\\Users\\bob\\project\\openapi.yaml' },
+      });
+
+      expect(format1.toHash()).toBe(format2.toHash());
+
+      const format3 = new ThymianFormat();
+      const [reqId3] = format3.addHttpTransaction(
+        transactions[0][0],
+        transactions[0][1],
+        '/Users/alice/project/openapi.yaml',
+      );
+      const securityId3 = format3.addSecurityScheme({
+        scheme: 'api-key',
+        in: 'query',
+        sourceName: '/Users/alice/project/openapi.yaml',
+      });
+      format3.addEdge(reqId3, securityId3, {
+        type: 'is-secured',
+        sourceName: '/Users/alice/project/openapi.yaml',
+      });
+
+      expect(format1.toHash()).not.toBe(format3.toHash());
+    });
   });
 
   describe('import with sourceName', () => {


### PR DESCRIPTION
# Summary

 This PR makes Thymian format hashing deterministic across machines by excluding non-semantic attribution fields from hash calculation.

 The format hash now ignores:

 - label
 - sourceLocation
 - sourceName

 These fields can vary depending on where or how the format was generated, for example due to absolute file paths or machine-specific source names. They should not affect
 whether the actual Thymian graph changed.

 ## Why this is necessary

 Previously, the hash of a Thymian format could change depending on the physical machine where it was calculated. This happened because source attribution metadata was included
 in the node/edge hashing inputs.

 That meant two semantically identical formats could produce different hashes if, for example:

 - the OpenAPI source file lived under different absolute paths
 - source names differed between environments
 - generated labels differed while request/response/security graph semantics stayed the same

 This made the hash unreliable as a signal for actual format changes.

 The hash should only change when semantic graph content changes, such as request, response, security, sample, or edge data.

 ## Changes

 - Introduced semantic hashing for ThymianFormat
 - Excluded label, sourceLocation, and sourceName from hash inputs
 - Applied semantic hashing to generated node and edge IDs
 - Added recursive stripping of ignored attribution fields
 - Preserved topology in format hashing by including semantic source/target node hashes for edges
 - Added regression tests covering:
     - different machine-specific source paths
     - stable IDs
     - exported hash values
     - imported formats
     - nested metadata
     - security schemes and HTTP links