### PR TITLE
feat(rules-rfc-9110): align identifiers rule execution contexts (#327)

### DIFF
--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
@@ -4,6 +4,12 @@ export default httpRule(
   'rfc9110/automated-client-must-log-error-to-audit-log-for-bad-certificate',
 )
   .severity('error')
+  // Informational (outcome 2): this MUST governs an automated client's internal
+  // side effect — writing to an audit log when certificate verification fails.
+  // Whether a client logged the error is not observable from any HTTP request or
+  // response, nor from recorded traffic (HAR). No transaction-level condition
+  // signals conformance or violation, so no lint/test/analyze function can
+  // meaningfully run. Kept as documentation of the requirement.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
@@ -4,9 +4,8 @@ export default httpRule(
   'rfc9110/automated-client-must-log-error-to-audit-log-for-bad-certificate',
 )
   .severity('error')
-  // Informational (#327): unobservable. Writing to a local audit log is a
-  // client-side side effect entirely outside the HTTP message exchange Thymian
-  // records.
+  // Writing to a local audit log is a client-side side effect entirely outside
+  // the HTTP message exchange Thymian records.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
@@ -4,6 +4,9 @@ export default httpRule(
   'rfc9110/automated-client-must-log-error-to-audit-log-for-bad-certificate',
 )
   .severity('error')
+  // Informational (#327): unobservable. Writing to a local audit log is a
+  // client-side side effect entirely outside the HTTP message exchange Thymian
+  // records.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate.rule.ts
@@ -4,12 +4,6 @@ export default httpRule(
   'rfc9110/automated-client-must-log-error-to-audit-log-for-bad-certificate',
 )
   .severity('error')
-  // Informational (outcome 2): this MUST governs an automated client's internal
-  // side effect — writing to an audit log when certificate verification fails.
-  // Whether a client logged the error is not observable from any HTTP request or
-  // response, nor from recorded traffic (HAR). No transaction-level condition
-  // signals conformance or violation, so no lint/test/analyze function can
-  // meaningfully run. Kept as documentation of the requirement.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -4,12 +4,6 @@ export default httpRule(
   'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
 )
   .severity('warn')
-  // Informational (outcome 2): this SHOULD concerns an automated client's
-  // connection-handling decision on TLS certificate verification failure — an
-  // internal client behavior at the transport layer. It is not observable from
-  // HTTP messages or recorded traffic; a terminated connection produces no
-  // transaction to inspect. No lint/test/analyze function can apply. Kept as
-  // documentation of the requirement.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -4,6 +4,9 @@ export default httpRule(
   'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
 )
   .severity('warn')
+  // Informational (#327): unobservable. Terminating the connection on failed
+  // certificate verification is a TLS-layer action; a torn-down handshake
+  // leaves no recorded HTTP transaction to inspect.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -4,9 +4,9 @@ export default httpRule(
   'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
 )
   .severity('warn')
-  // Informational (#327): unobservable. Terminating the connection on failed
-  // certificate verification is a TLS-layer action; a torn-down handshake
-  // leaves no recorded HTTP transaction to inspect.
+  // Terminating the connection on failed certificate verification is a
+  // TLS-layer action; a torn-down handshake leaves no recorded HTTP transaction
+  // to inspect.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-client-should-terminate-connection-for-bad-certificate.rule.ts
@@ -4,6 +4,12 @@ export default httpRule(
   'rfc9110/automated-client-should-terminate-connection-for-bad-certificate',
 )
   .severity('warn')
+  // Informational (outcome 2): this SHOULD concerns an automated client's
+  // connection-handling decision on TLS certificate verification failure — an
+  // internal client behavior at the transport layer. It is not observable from
+  // HTTP messages or recorded traffic; a terminated connection produces no
+  // transaction to inspect. No lint/test/analyze function can apply. Kept as
+  // documentation of the requirement.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
@@ -4,6 +4,8 @@ export default httpRule(
   'rfc9110/automated-clients-may-provide-setting-to-disable-certificate-check',
 )
   .severity('hint')
+  // Informational (#327): permissive MAY about a client configuration setting —
+  // no observable failure mode and not detectable from recorded HTTP traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
@@ -4,8 +4,8 @@ export default httpRule(
   'rfc9110/automated-clients-may-provide-setting-to-disable-certificate-check',
 )
   .severity('hint')
-  // Informational (#327): permissive MAY about a client configuration setting —
-  // no observable failure mode and not detectable from recorded HTTP traffic.
+  // Permissive MAY about a client configuration setting — no observable failure
+  // mode and not detectable from recorded HTTP traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
@@ -4,11 +4,6 @@ export default httpRule(
   'rfc9110/automated-clients-may-provide-setting-to-disable-certificate-check',
 )
   .severity('hint')
-  // Informational (outcome 2): a permissive MAY about a client's configuration
-  // surface (offering a setting to disable certificate checking). It describes
-  // an allowed capability with no non-conformant condition to detect, and the
-  // setting's existence is a property of the client product, not of any HTTP
-  // transaction. Nothing to validate via lint/test/analyze. Kept as guidance.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check.rule.ts
@@ -4,6 +4,11 @@ export default httpRule(
   'rfc9110/automated-clients-may-provide-setting-to-disable-certificate-check',
 )
   .severity('hint')
+  // Informational (outcome 2): a permissive MAY about a client's configuration
+  // surface (offering a setting to disable certificate checking). It describes
+  // an allowed capability with no non-conformant condition to detect, and the
+  // setting's existence is a property of the client product, not of any HTTP
+  // transaction. Nothing to validate via lint/test/analyze. Kept as guidance.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
@@ -4,9 +4,8 @@ export default httpRule(
   'rfc9110/automated-clients-must-provide-setting-to-enable-certificate-check',
 )
   .severity('error')
-  // Informational (#327): unobservable. Presence of a client configuration
-  // setting is a product-capability requirement; it cannot be detected from
-  // recorded HTTP traffic.
+  // Presence of a client configuration setting is a product-capability
+  // requirement; it cannot be detected from recorded HTTP traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
@@ -4,6 +4,9 @@ export default httpRule(
   'rfc9110/automated-clients-must-provide-setting-to-enable-certificate-check',
 )
   .severity('error')
+  // Informational (#327): unobservable. Presence of a client configuration
+  // setting is a product-capability requirement; it cannot be detected from
+  // recorded HTTP traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
@@ -4,6 +4,11 @@ export default httpRule(
   'rfc9110/automated-clients-must-provide-setting-to-enable-certificate-check',
 )
   .severity('error')
+  // Informational (outcome 2): this MUST is about a client's configuration
+  // surface (it must offer a setting that enables certificate checking). The
+  // presence of such a setting is a property of the client product, not of any
+  // HTTP transaction, and is not observable from messages or recorded traffic.
+  // No lint/test/analyze function can apply. Kept as documentation.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check.rule.ts
@@ -4,11 +4,6 @@ export default httpRule(
   'rfc9110/automated-clients-must-provide-setting-to-enable-certificate-check',
 )
   .severity('error')
-  // Informational (outcome 2): this MUST is about a client's configuration
-  // surface (it must offer a setting that enables certificate checking). The
-  // presence of such a setting is a property of the client product, not of any
-  // HTTP transaction, and is not observable from messages or recorded traffic.
-  // No lint/test/analyze function can apply. Kept as documentation.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -4,6 +4,11 @@ export default httpRule(
   'rfc9110/client-may-access-by-resolving-host-to-ip-address',
 )
   .severity('hint')
+  // Informational (outcome 2): a permissive MAY describing one allowed way a
+  // client may dereference an origin (DNS resolution + TCP connect). It states
+  // a capability with no non-conformant condition, and the underlying name
+  // resolution / connection establishment happens below HTTP and is not visible
+  // in any transaction or recorded traffic. Nothing to validate. Kept as guidance.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-origins')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -4,11 +4,6 @@ export default httpRule(
   'rfc9110/client-may-access-by-resolving-host-to-ip-address',
 )
   .severity('hint')
-  // Informational (outcome 2): a permissive MAY describing one allowed way a
-  // client may dereference an origin (DNS resolution + TCP connect). It states
-  // a capability with no non-conformant condition, and the underlying name
-  // resolution / connection establishment happens below HTTP and is not visible
-  // in any transaction or recorded traffic. Nothing to validate. Kept as guidance.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-origins')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -4,6 +4,9 @@ export default httpRule(
   'rfc9110/client-may-access-by-resolving-host-to-ip-address',
 )
   .severity('hint')
+  // Informational (#327): permissive MAY describing a client's DNS/TCP access
+  // procedure — no violation to detect, and the resolution/connection steps
+  // occur below the recorded HTTP layer.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-origins')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-may-access-by-resolving-host-to-ip-address.rule.ts
@@ -4,9 +4,9 @@ export default httpRule(
   'rfc9110/client-may-access-by-resolving-host-to-ip-address',
 )
   .severity('hint')
-  // Informational (#327): permissive MAY describing a client's DNS/TCP access
-  // procedure — no violation to detect, and the resolution/connection steps
-  // occur below the recorded HTTP layer.
+  // Permissive MAY describing a client's DNS/TCP access procedure — no
+  // violation to detect, and the resolution/connection steps occur below the
+  // recorded HTTP layer.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-origins')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -2,9 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-construct-reference-identity')
   .severity('error')
-  // Informational (#327): unobservable. How a client constructs its TLS
-  // reference identity (IP-ID vs DNS-ID) is internal certificate-verification
-  // logic at the transport layer; it leaves no trace in recorded HTTP messages.
+  // How a client constructs its TLS reference identity (IP-ID vs DNS-ID) is
+  // internal certificate-verification logic at the transport layer; it leaves
+  // no trace in recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/client-must-construct-reference-identity')
   // no trace in recorded HTTP messages.
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description(
     "A client MUST construct a reference identity from the service's host when verifying a secure HTTP connection: If the host is an IP address, use an IP-ID; if a registered name, use a DNS-ID.\n\nContext: This is required for proper service identity verification (RFC 6125), as specified in RFC 9110 section 4.3.4.",

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -2,6 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-construct-reference-identity')
   .severity('error')
+  // Informational (outcome 2): this MUST governs an internal step of the client's
+  // TLS identity-verification algorithm (deriving an IP-ID vs DNS-ID reference
+  // identity from the target host, per RFC 6125). It is purely client-side
+  // verification logic that leaves no signal in any HTTP request, response, or
+  // recorded traffic. No lint/test/analyze function can observe it. Kept as
+  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-construct-reference-identity')
   .severity('error')
+  // Informational (#327): unobservable. How a client constructs its TLS
+  // reference identity (IP-ID vs DNS-ID) is internal certificate-verification
+  // logic at the transport layer; it leaves no trace in recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-construct-reference-identity.rule.ts
@@ -2,12 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-construct-reference-identity')
   .severity('error')
-  // Informational (outcome 2): this MUST governs an internal step of the client's
-  // TLS identity-verification algorithm (deriving an IP-ID vs DNS-ID reference
-  // identity from the target host, per RFC 6125). It is purely client-side
-  // verification logic that leaves no signal in any HTTP request, response, or
-  // recorded traffic. No lint/test/analyze function can observe it. Kept as
-  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -2,11 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
   .severity('error')
-  // Informational (outcome 2): this MUST NOT forbids a choice inside the client's
-  // TLS identity-verification logic (using a CN-ID reference identity). It is an
-  // internal client decision with no observable footprint in HTTP messages or
-  // recorded traffic. No lint/test/analyze function can detect it. Kept as
-  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -2,9 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
   .severity('error')
-  // Informational (#327): unobservable. Which reference-identity type a client
-  // uses (rejecting CN-ID) is internal TLS certificate-verification logic; it
-  // leaves no trace in recorded HTTP messages.
+  // Which reference-identity type a client uses (rejecting CN-ID) is internal
+  // TLS certificate-verification logic; it leaves no trace in recorded HTTP
+  // messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
   .severity('error')
+  // Informational (#327): unobservable. Which reference-identity type a client
+  // uses (rejecting CN-ID) is internal TLS certificate-verification logic; it
+  // leaves no trace in recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
   // messages.
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description('A client MUST NOT use a reference identity of type CN-ID.')
   .appliesTo('client')

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-not-use-cn-id-reference-identity.rule.ts
@@ -2,6 +2,11 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-not-use-cn-id-reference-identity')
   .severity('error')
+  // Informational (outcome 2): this MUST NOT forbids a choice inside the client's
+  // TLS identity-verification logic (using a CN-ID reference identity). It is an
+  // internal client decision with no observable footprint in HTTP messages or
+  // recorded traffic. No lint/test/analyze function can detect it. Kept as
+  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -2,9 +2,8 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-use-rfc6125-verification')
   .severity('error')
-  // Informational (#327): unobservable. RFC 6125 verification is TLS-handshake
-  // certificate logic below the recorded HTTP layer; it cannot be checked from
-  // recorded HTTP messages.
+  // RFC 6125 verification is TLS-handshake certificate logic below the recorded
+  // HTTP layer; it cannot be checked from recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -2,6 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-use-rfc6125-verification')
   .severity('error')
+  // Informational (outcome 2): this MUST requires the client to run the RFC 6125
+  // service-identity verification process during the TLS handshake. Whether the
+  // client performed that verification is an internal client behavior at the
+  // transport/security layer; it produces no signal in any HTTP request,
+  // response, or recorded traffic. No lint/test/analyze function can observe it.
+  // Kept as documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -2,12 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-use-rfc6125-verification')
   .severity('error')
-  // Informational (outcome 2): this MUST requires the client to run the RFC 6125
-  // service-identity verification process during the TLS handshake. Whether the
-  // client performed that verification is an internal client behavior at the
-  // transport/security layer; it produces no signal in any HTTP request,
-  // response, or recorded traffic. No lint/test/analyze function can observe it.
-  // Kept as documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-use-rfc6125-verification')
   .severity('error')
+  // Informational (#327): unobservable. RFC 6125 verification is TLS-handshake
+  // certificate logic below the recorded HTTP layer; it cannot be checked from
+  // recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-use-rfc6125-verification.rule.ts
@@ -6,7 +6,7 @@ export default httpRule('rfc9110/client-must-use-rfc6125-verification')
   // HTTP layer; it cannot be checked from recorded HTTP messages.
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description(
     'A client MUST verify the service identity using the verification process defined in Section 6 of RFC 6125 when establishing a secure HTTP connection.\n\nContext: This ensures that connections are only made to servers whose identities match the expected reference identity, preventing impersonation attacks as required in RFC 9110 section 4.3.4.',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -2,9 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-verify-service-identity')
   .severity('error')
-  // Informational (#327): unobservable. Service-identity verification happens
-  // during the TLS handshake, below the recorded HTTP layer; a successful or
-  // skipped check leaves no distinguishing trace in HTTP messages.
+  // Service-identity verification happens during the TLS handshake, below the
+  // recorded HTTP layer; a successful or skipped check leaves no distinguishing
+  // trace in HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -2,6 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-verify-service-identity')
   .severity('error')
+  // Informational (outcome 2): this MUST requires the client to confirm the
+  // service's identity matches the URI's origin server before using a secured
+  // connection. This is internal client-side verification performed during TLS
+  // establishment; conformance or violation leaves no trace in HTTP messages or
+  // recorded traffic. No lint/test/analyze function can observe it. Kept as
+  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/client-must-verify-service-identity')
   // trace in HTTP messages.
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description(
     "A client MUST verify that the service's identity is an acceptable match for the URI's origin server when establishing a secured connection to dereference a URI.\n\nContext: This verification ensures that an attacker cannot impersonate the server, supporting confidentiality and integrity for secure HTTP communication (HTTPS), as specified in RFC 9110 section 4.3.4.",

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-verify-service-identity')
   .severity('error')
+  // Informational (#327): unobservable. Service-identity verification happens
+  // during the TLS handshake, below the recorded HTTP layer; a successful or
+  // skipped check leaves no distinguishing trace in HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/client-must-verify-service-identity.rule.ts
@@ -2,12 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/client-must-verify-service-identity')
   .severity('error')
-  // Informational (outcome 2): this MUST requires the client to confirm the
-  // service's identity matches the URI's origin server before using a secured
-  // connection. This is internal client-side verification performed during TLS
-  // establishment; conformance or violation leaves no trace in HTTP messages or
-  // recorded traffic. No lint/test/analyze function can observe it. Kept as
-  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -2,12 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
   .severity('error')
-  // Informational (outcome 2): this MUST governs the user agent's interactive
-  // handling of an invalid certificate (prompt the user, or terminate with a bad
-  // certificate error). It is user-agent-internal UX/transport behavior; neither
-  // the user prompt nor the connection termination is visible in HTTP messages
-  // or recorded traffic. No lint/test/analyze function can observe it. Kept as
-  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
   .severity('error')
+  // Informational (#327): unobservable. The user-agent's response to an invalid
+  // certificate (prompt the user or terminate) happens at the TLS layer and in
+  // UI; it is not represented in recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -2,9 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
   .severity('error')
-  // Informational (#327): unobservable. The user-agent's response to an invalid
-  // certificate (prompt the user or terminate) happens at the TLS layer and in
-  // UI; it is not represented in recorded HTTP messages.
+  // The user-agent's response to an invalid certificate (prompt the user or
+  // terminate) happens at the TLS layer and in UI; it is not represented in
+  // recorded HTTP messages.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
   // recorded HTTP messages.
   .type('informational')
   .url(
-    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',
+    'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verificat',
   )
   .description(
     "If a certificate is not valid for the target URI's origin, a user agent MUST either obtain confirmation from the user before proceeding or terminate the connection with a bad certificate error.",

--- a/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/authoritative-access/user-agent-must-handle-bad-certificate.rule.ts
@@ -2,6 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/user-agent-must-handle-bad-certificate')
   .severity('error')
+  // Informational (outcome 2): this MUST governs the user agent's interactive
+  // handling of an invalid certificate (prompt the user, or terminate with a bad
+  // certificate error). It is user-agent-internal UX/transport behavior; neither
+  // the user prompt nor the connection termination is visible in HTTP messages
+  // or recorded traffic. No lint/test/analyze function can observe it. Kept as
+  // documentation; security-relevant (see PR security section).
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-certificate-verification',

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -2,12 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
-  // Informational (#327): unobservable. The check was gated on
-  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
-  // origin from `new URL(url).origin`, which always yields a non-empty host —
-  // an empty-host URI is unrepresentable after URL-based ingestion, so the
-  // predicate is vacuous (can never fire) and the response-status half never
-  // runs. Documenting the requirement is all that remains.
+  // HAR ingestion derives origin from `new URL(url).origin`, which always
+  // yields a non-empty host, so an empty-host URI is unrepresentable after
+  // URL-based ingestion and there is nothing to observe.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -1,14 +1,27 @@
-import { httpRule } from '@thymian/core';
+import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
-  // HAR ingestion derives origin from `new URL(url).origin`, which always
-  // yields a non-empty host, so an empty-host URI is unrepresentable after
-  // URL-based ingestion and there is nothing to observe.
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
   .appliesTo('origin server', 'server')
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(
+      protocol('http'),
+      (req, res, location: RuleViolationLocation) => {
+        try {
+          const isViolation =
+            new URL(req.path, req.origin).host === '' &&
+            !(res.statusCode >= 400 && res.statusCode < 500);
+          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -1,27 +1,17 @@
-import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
-  .type('analytics')
+  // Informational (#327): unobservable. The check was gated on
+  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
+  // origin from `new URL(url).origin`, which always yields a non-empty host —
+  // an empty-host URI is unrepresentable after URL-based ingestion, so the
+  // predicate is vacuous (can never fire) and the response-status half never
+  // runs. Documenting the requirement is all that remains.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
   .appliesTo('origin server', 'server')
-  .rule((ctx, opts, logger) =>
-    ctx.validateHttpTransactions(
-      protocol('http'),
-      (req, res, location: RuleViolationLocation) => {
-        try {
-          const isViolation =
-            new URL(req.path, req.origin).host === '' &&
-            !(res.statusCode >= 400 && res.statusCode < 500);
-          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -2,11 +2,20 @@ import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
+  // Response-/recipient-side rule (outcome 1, already implemented). A violation
+  // is an empty-host `http` request that the recipient (server) did NOT reject
+  // with a 4xx. This depends on the deployed recipient's behavior, so it is not
+  // meaningful in `test` (Thymian generates well-formed requests and the user
+  // cannot make it send an empty-host URI) nor in `lint`; it stays `analytics`
+  // over recorded traffic. appliesTo includes `origin server` so the analyze
+  // role filter matches HAR responses (HAR default response role = origin
+  // server); `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
+  .appliesTo('origin server', 'server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('http'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
-  .appliesTo('origin server', 'server')
+  .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('http'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -2,14 +2,6 @@ import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
-  // Response-/recipient-side rule (outcome 1, already implemented). A violation
-  // is an empty-host `http` request that the recipient (server) did NOT reject
-  // with a 4xx. This depends on the deployed recipient's behavior, so it is not
-  // meaningful in `test` (Thymian generates well-formed requests and the user
-  // cannot make it send an empty-host URI) nor in `lint`; it stays `analytics`
-  // over recorded traffic. appliesTo includes `origin server` so the analyze
-  // role filter matches HAR responses (HAR default response role = origin
-  // server); `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -1,5 +1,7 @@
 import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
+import { targetUriHasEmptyHost } from '../utils.js';
+
 export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .severity('error')
   .type('analytics')
@@ -13,9 +15,12 @@ export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
       protocol('http'),
       (req, res, location: RuleViolationLocation) => {
         try {
+          const hasEmptyHost =
+            req.target !== undefined
+              ? targetUriHasEmptyHost(req.target)
+              : new URL(req.path, req.origin).host === '';
           const isViolation =
-            new URL(req.path, req.origin).host === '' &&
-            !(res.statusCode >= 400 && res.statusCode < 500);
+            hasEmptyHost && !(res.statusCode >= 400 && res.statusCode < 500);
           return isViolation ? [{ location, violation: {}, findings: [] }] : [];
         } catch (e) {
           logger.error('Cannot run rule because of invalid URL:', e);

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -4,12 +4,6 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
   .severity('error')
-  // Request-side rule (outcome 1, already implemented): it constrains the target
-  // URI the *sender* generates. It is correctly NOT in `test` (Thymian is the
-  // sender there, so the user cannot control the generated URI) and stays
-  // `analytics`, where the request comes from a real recorded client. appliesTo
-  // is set to the request roles so the analyze role filter matches HAR requests
-  // (HAR default request role = user-agent).
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -9,7 +9,7 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
-  .appliesTo('client', 'user-agent')
+  .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('http'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -4,12 +4,9 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
   .severity('error')
-  // Informational (#327): unobservable. The check tested
-  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
-  // origin from `new URL(url).origin`, which always yields a non-empty host —
-  // an empty-host absolute URI is unrepresentable after URL-based ingestion, so
-  // the predicate is vacuous (can never fire). Documenting the requirement is
-  // all that remains.
+  // HAR ingestion derives origin from `new URL(url).origin`, which always
+  // yields a non-empty host, so an empty-host absolute URI is unrepresentable
+  // after URL-based ingestion and there is nothing to observe.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -1,16 +1,27 @@
-import { httpRule } from '@thymian/core';
+import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
   .severity('error')
-  // HAR ingestion derives origin from `new URL(url).origin`, which always
-  // yields a non-empty host, so an empty-host absolute URI is unrepresentable
-  // after URL-based ingestion and there is nothing to observe.
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
   .appliesTo('client', 'user-agent')
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(
+      protocol('http'),
+      (req, _res, location: RuleViolationLocation) => {
+        try {
+          const isViolation = new URL(req.path, req.origin).host === '';
+          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -1,27 +1,19 @@
-import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
   .severity('error')
-  .type('analytics')
+  // Informational (#327): unobservable. The check tested
+  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
+  // origin from `new URL(url).origin`, which always yields a non-empty host —
+  // an empty-host absolute URI is unrepresentable after URL-based ingestion, so
+  // the predicate is vacuous (can never fire). Documenting the requirement is
+  // all that remains.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
   .appliesTo('client', 'user-agent')
-  .rule((ctx, opts, logger) =>
-    ctx.validateHttpTransactions(
-      protocol('http'),
-      (req, _res, location: RuleViolationLocation) => {
-        try {
-          const isViolation = new URL(req.path, req.origin).host === '';
-          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -1,5 +1,7 @@
 import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
+import { targetUriHasEmptyHost } from '../utils.js';
+
 export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
@@ -15,7 +17,10 @@ export default httpRule(
       protocol('http'),
       (req, _res, location: RuleViolationLocation) => {
         try {
-          const isViolation = new URL(req.path, req.origin).host === '';
+          const isViolation =
+            req.target !== undefined
+              ? targetUriHasEmptyHost(req.target)
+              : new URL(req.path, req.origin).host === '';
           return isViolation ? [{ location, violation: {}, findings: [] }] : [];
         } catch (e) {
           logger.error('Cannot run rule because of invalid URL:', e);

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -4,11 +4,18 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-http-uri-with-empty-host',
 )
   .severity('error')
+  // Request-side rule (outcome 1, already implemented): it constrains the target
+  // URI the *sender* generates. It is correctly NOT in `test` (Thymian is the
+  // sender there, so the user cannot control the generated URI) and stays
+  // `analytics`, where the request comes from a real recorded client. appliesTo
+  // is set to the request roles so the analyze role filter matches HAR requests
+  // (HAR default request role = user-agent).
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-http-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
+  .appliesTo('client', 'user-agent')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('http'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
@@ -4,9 +4,9 @@ export default httpRule(
   'rfc9110/client-must-secure-https-requests-and-responses',
 )
   .severity('error')
-  // Informational (#327): unobservable. Whether a client secured its transport
-  // (TLS) and refused unencrypted responses is a connection-layer property; it
-  // is not visible in the recorded HTTP message content Thymian analyzes.
+  // Whether a client secured its transport (TLS) and refused unencrypted
+  // responses is a connection-layer property; it is not visible in the recorded
+  // HTTP message content Thymian analyzes.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
@@ -4,16 +4,6 @@ export default httpRule(
   'rfc9110/client-must-secure-https-requests-and-responses',
 )
   .severity('error')
-  // Reclassified static -> informational (outcome 4 then outcome 2). The rule
-  // previously declared an active `static` (lint) context but shipped no rule
-  // function, so it counted as "covered" while doing nothing. It cannot be
-  // honestly implemented in any context: it requires the client to actually
-  // secure (encrypt) the requests/responses for an `https` resource on the wire.
-  // The OpenAPI description does not declare transport encryption, and recorded
-  // traffic (HAR) captures decrypted application-layer messages without the
-  // wire's TLS state — so neither lint, test, nor analyze can observe whether
-  // the client secured the connection. It is an internal client/transport
-  // behavior, hence informational. Security-relevant (see PR security section).
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
@@ -4,6 +4,9 @@ export default httpRule(
   'rfc9110/client-must-secure-https-requests-and-responses',
 )
   .severity('error')
+  // Informational (#327): unobservable. Whether a client secured its transport
+  // (TLS) and refused unencrypted responses is a connection-layer property; it
+  // is not visible in the recorded HTTP message content Thymian analyzes.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/client-must-secure-https-requests-and-responses.rule.ts
@@ -4,7 +4,17 @@ export default httpRule(
   'rfc9110/client-must-secure-https-requests-and-responses',
 )
   .severity('error')
-  .type('static')
+  // Reclassified static -> informational (outcome 4 then outcome 2). The rule
+  // previously declared an active `static` (lint) context but shipped no rule
+  // function, so it counted as "covered" while doing nothing. It cannot be
+  // honestly implemented in any context: it requires the client to actually
+  // secure (encrypt) the requests/responses for an `https` resource on the wire.
+  // The OpenAPI description does not declare transport encryption, and recorded
+  // traffic (HAR) captures decrypted application-layer messages without the
+  // wire's TLS state — so neither lint, test, nor analyze can observe whether
+  // the client secured the connection. It is an internal client/transport
+  // behavior, hence informational. Security-relevant (see PR security section).
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     "A client MUST ensure that its HTTP requests for an 'https' resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.\n\nContext: This requirement applies whenever a client is sending requests to, or receiving responses from, an 'https' URI. The client must not send unencrypted requests or accept unencrypted responses for 'https' resources.",

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -1,5 +1,7 @@
 import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
+import { targetUriHasEmptyHost } from '../utils.js';
+
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
   .type('analytics')
@@ -13,9 +15,12 @@ export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
       protocol('https'),
       (req, res, location: RuleViolationLocation) => {
         try {
+          const hasEmptyHost =
+            req.target !== undefined
+              ? targetUriHasEmptyHost(req.target)
+              : new URL(req.path, req.origin).host === '';
           const isViolation =
-            new URL(req.path, req.origin).host === '' &&
-            !(res.statusCode >= 400 && res.statusCode < 500);
+            hasEmptyHost && !(res.statusCode >= 400 && res.statusCode < 500);
           return isViolation ? [{ location, violation: {}, findings: [] }] : [];
         } catch (e) {
           logger.error('Cannot run rule because of invalid URL:', e);

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -2,11 +2,19 @@ import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
+  // Response-/recipient-side rule (outcome 1, already implemented). A violation
+  // is an empty-host `https` request that the recipient (server) did NOT reject
+  // with a 4xx. This depends on the deployed recipient's behavior, so it is not
+  // meaningful in `test` (Thymian generates well-formed requests) nor in `lint`;
+  // it stays `analytics` over recorded traffic. appliesTo includes `origin
+  // server` so the analyze role filter matches HAR responses (HAR default
+  // response role = origin server); `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
+  .appliesTo('origin server', 'server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('https'),
@@ -17,6 +25,7 @@ export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
             !(res.statusCode >= 400 && res.statusCode < 500);
           return isViolation ? [{ location, violation: {}, findings: [] }] : [];
         } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
           return [];
         }
       },

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -7,7 +7,7 @@ export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
-  .appliesTo('origin server', 'server')
+  .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('https'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -2,12 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
-  // Informational (#327): unobservable. The check was gated on
-  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
-  // origin from `new URL(url).origin`, which always yields a non-empty host —
-  // an empty-host URI is unrepresentable after URL-based ingestion, so the
-  // predicate is vacuous (can never fire) and the response-status half never
-  // runs. Documenting the requirement is all that remains.
+  // HAR ingestion derives origin from `new URL(url).origin`, which always
+  // yields a non-empty host, so an empty-host URI is unrepresentable after
+  // URL-based ingestion and there is nothing to observe.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -1,14 +1,27 @@
-import { httpRule } from '@thymian/core';
+import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
-  // HAR ingestion derives origin from `new URL(url).origin`, which always
-  // yields a non-empty host, so an empty-host URI is unrepresentable after
-  // URL-based ingestion and there is nothing to observe.
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
   .appliesTo('origin server', 'server')
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(
+      protocol('https'),
+      (req, res, location: RuleViolationLocation) => {
+        try {
+          const isViolation =
+            new URL(req.path, req.origin).host === '' &&
+            !(res.statusCode >= 400 && res.statusCode < 500);
+          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -1,27 +1,17 @@
-import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
-  .type('analytics')
+  // Informational (#327): unobservable. The check was gated on
+  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
+  // origin from `new URL(url).origin`, which always yields a non-empty host —
+  // an empty-host URI is unrepresentable after URL-based ingestion, so the
+  // predicate is vacuous (can never fire) and the response-status half never
+  // runs. Documenting the requirement is all that remains.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
   .appliesTo('origin server', 'server')
-  .rule((ctx, opts, logger) =>
-    ctx.validateHttpTransactions(
-      protocol('https'),
-      (req, res, location: RuleViolationLocation) => {
-        try {
-          const isViolation =
-            new URL(req.path, req.origin).host === '' &&
-            !(res.statusCode >= 400 && res.statusCode < 500);
-          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -2,13 +2,6 @@ import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .severity('error')
-  // Response-/recipient-side rule (outcome 1, already implemented). A violation
-  // is an empty-host `https` request that the recipient (server) did NOT reject
-  // with a 4xx. This depends on the deployed recipient's behavior, so it is not
-  // meaningful in `test` (Thymian generates well-formed requests) nor in `lint`;
-  // it stays `analytics` over recorded traffic. appliesTo includes `origin
-  // server` so the analyze role filter matches HAR responses (HAR default
-  // response role = origin server); `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -1,27 +1,19 @@
-import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
   .severity('error')
-  .type('analytics')
+  // Informational (#327): unobservable. The check tested
+  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
+  // origin from `new URL(url).origin`, which always yields a non-empty host —
+  // an empty-host absolute URI is unrepresentable after URL-based ingestion, so
+  // the predicate is vacuous (can never fire). Documenting the requirement is
+  // all that remains.
+  .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
   .appliesTo('client', 'user-agent')
-  .rule((ctx, opts, logger) =>
-    ctx.validateHttpTransactions(
-      protocol('https'),
-      (req, _res, location: RuleViolationLocation) => {
-        try {
-          const isViolation = new URL(req.path, req.origin).host === '';
-          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -4,11 +4,17 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
   .severity('error')
+  // Request-side rule (outcome 1, already implemented): it constrains the target
+  // URI the *sender* generates. Correctly NOT in `test` (Thymian is the sender
+  // there); stays `analytics`, where the request comes from a real recorded
+  // client. appliesTo is set to the request roles so the analyze role filter
+  // matches HAR requests (HAR default request role = user-agent).
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
+  .appliesTo('client', 'user-agent')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('https'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -9,7 +9,7 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
-  .appliesTo('client', 'user-agent')
+  .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       protocol('https'),

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -1,5 +1,7 @@
 import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
+import { targetUriHasEmptyHost } from '../utils.js';
+
 export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
@@ -15,7 +17,10 @@ export default httpRule(
       protocol('https'),
       (req, _res, location: RuleViolationLocation) => {
         try {
-          const isViolation = new URL(req.path, req.origin).host === '';
+          const isViolation =
+            req.target !== undefined
+              ? targetUriHasEmptyHost(req.target)
+              : new URL(req.path, req.origin).host === '';
           return isViolation ? [{ location, violation: {}, findings: [] }] : [];
         } catch (e) {
           logger.error('Cannot run rule because of invalid URL:', e);

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -4,11 +4,6 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
   .severity('error')
-  // Request-side rule (outcome 1, already implemented): it constrains the target
-  // URI the *sender* generates. Correctly NOT in `test` (Thymian is the sender
-  // there); stays `analytics`, where the request comes from a real recorded
-  // client. appliesTo is set to the request roles so the analyze role filter
-  // matches HAR requests (HAR default request role = user-agent).
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -4,12 +4,9 @@ export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
   .severity('error')
-  // Informational (#327): unobservable. The check tested
-  // `new URL(req.path, req.origin).host === ''`, but HAR ingestion derives
-  // origin from `new URL(url).origin`, which always yields a non-empty host —
-  // an empty-host absolute URI is unrepresentable after URL-based ingestion, so
-  // the predicate is vacuous (can never fire). Documenting the requirement is
-  // all that remains.
+  // HAR ingestion derives origin from `new URL(url).origin`, which always
+  // yields a non-empty host, so an empty-host absolute URI is unrepresentable
+  // after URL-based ingestion and there is nothing to observe.
   .type('informational')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -1,16 +1,27 @@
-import { httpRule } from '@thymian/core';
+import { httpRule, protocol, type RuleViolationLocation } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/sender-must-not-generate-https-uri-with-empty-host',
 )
   .severity('error')
-  // HAR ingestion derives origin from `new URL(url).origin`, which always
-  // yields a non-empty host, so an empty-host absolute URI is unrepresentable
-  // after URL-based ingestion and there is nothing to observe.
-  .type('informational')
+  .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-https-uri-scheme')
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
   .appliesTo('client', 'user-agent')
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(
+      protocol('https'),
+      (req, _res, location: RuleViolationLocation) => {
+        try {
+          const isViolation = new URL(req.path, req.origin).host === '';
+          return isViolation ? [{ location, violation: {}, findings: [] }] : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
@@ -4,10 +4,9 @@ export default httpRule(
   'rfc9110/authority-should-not-use-equivalent-uris-for-distinct-resources',
 )
   .severity('warn')
-  // Informational (#327): unobservable. Deciding that two normalization-
-  // equivalent URIs identify DISTINCT resources requires resource-semantic
-  // knowledge the authority holds; it cannot be inferred from recorded HTTP
-  // messages alone.
+  // Deciding that two normalization-equivalent URIs identify DISTINCT resources
+  // requires resource-semantic knowledge the authority holds; it cannot be
+  // inferred from recorded HTTP messages alone.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
@@ -4,16 +4,6 @@ export default httpRule(
   'rfc9110/authority-should-not-use-equivalent-uris-for-distinct-resources',
 )
   .severity('warn')
-  // Reclassified static -> informational (outcome 4 then outcome 2). Previously
-  // declared `static` with no rule function. The requirement is that two URIs
-  // that normalize to the same value should not denote *distinct* resources.
-  // Deciding whether two resources are "distinct" requires semantic knowledge of
-  // the application's resource model — it is not derivable from the OpenAPI
-  // description (paths are templates, not concrete equivalent URIs to compare),
-  // nor from observed/recorded traffic (two equivalent URIs returning different
-  // representations could be correct content negotiation, redirects, or
-  // time-varying data, not a violation). With no decidable non-conformant
-  // condition available to lint/test/analyze, it is informational.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
@@ -4,6 +4,10 @@ export default httpRule(
   'rfc9110/authority-should-not-use-equivalent-uris-for-distinct-resources',
 )
   .severity('warn')
+  // Informational (#327): unobservable. Deciding that two normalization-
+  // equivalent URIs identify DISTINCT resources requires resource-semantic
+  // knowledge the authority holds; it cannot be inferred from recorded HTTP
+  // messages alone.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/authority-should-not-use-equivalent-uris-for-distinct-resources.rule.ts
@@ -4,7 +4,17 @@ export default httpRule(
   'rfc9110/authority-should-not-use-equivalent-uris-for-distinct-resources',
 )
   .severity('warn')
-  .type('static')
+  // Reclassified static -> informational (outcome 4 then outcome 2). Previously
+  // declared `static` with no rule function. The requirement is that two URIs
+  // that normalize to the same value should not denote *distinct* resources.
+  // Deciding whether two resources are "distinct" requires semantic knowledge of
+  // the application's resource model — it is not derivable from the OpenAPI
+  // description (paths are templates, not concrete equivalent URIs to compare),
+  // nor from observed/recorded traffic (two equivalent URIs returning different
+  // representations could be correct content negotiation, redirects, or
+  // time-varying data, not a violation). With no decidable non-conformant
+  // condition available to lint/test/analyze, it is informational.
+  .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',
   )

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
@@ -1,8 +1,15 @@
 import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/http-component-may-perform-normalization')
-  .severity('warn')
-  .type('static')
+  .severity('hint')
+  // Reclassified static -> informational (outcome 4 then outcome 2). Previously
+  // declared `static` with no rule function. This is a purely permissive MAY:
+  // any HTTP component is *allowed* to normalize URIs. There is no
+  // non-conformant condition to detect — performing or not performing
+  // normalization are both conformant — so nothing can be validated by lint,
+  // test, or analyze. Severity lowered from warn to hint to match a permissive
+  // statement. Kept as documentation.
+  .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',
   )

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
@@ -2,6 +2,9 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/http-component-may-perform-normalization')
   .severity('hint')
+  // Informational (#327): permissive MAY with no observable failure mode — it
+  // grants a normalization permission, so there is no violation to detect from
+  // recorded traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
@@ -2,9 +2,8 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/http-component-may-perform-normalization')
   .severity('hint')
-  // Informational (#327): permissive MAY with no observable failure mode — it
-  // grants a normalization permission, so there is no violation to detect from
-  // recorded traffic.
+  // Permissive MAY with no observable failure mode — it grants a normalization
+  // permission, so there is no violation to detect from recorded traffic.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/normalization/http-component-may-perform-normalization.rule.ts
@@ -2,13 +2,6 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/http-component-may-perform-normalization')
   .severity('hint')
-  // Reclassified static -> informational (outcome 4 then outcome 2). Previously
-  // declared `static` with no rule function. This is a purely permissive MAY:
-  // any HTTP component is *allowed* to normalize URIs. There is no
-  // non-conformant condition to detect — performing or not performing
-  // normalization are both conformant — so nothing can be validated by lint,
-  // test, or analyze. Severity lowered from warn to hint to match a permissive
-  // statement. Kept as documentation.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-https-normalization-and-comparison',

--- a/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -9,7 +9,7 @@ export default httpRule(
   .description(
     'It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.',
   )
-  .appliesTo('origin server', 'server')
+  .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(statusCode(414), (req, _res, location) => {
       try {

--- a/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -1,18 +1,23 @@
-import {
-  httpRule,
-  type RuleViolationLocation,
-  statusCode,
-} from '@thymian/core';
+import { httpRule, statusCode } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/sender-recipient-should-support-8000-octet-uris',
 )
   .severity('warn')
+  // Response-/recipient-side rule (outcome 1, already implemented). The
+  // observable non-conformance is a recipient returning 414 (URI Too Long) for a
+  // request whose URI is at or below the RECOMMENDED 8000-octet minimum — i.e.
+  // the recipient failed to support a URI it should have. This is server
+  // behavior under real load, not meaningful in `test` (Thymian does not
+  // generate over-length URIs) nor in `lint`; it stays `analytics`. appliesTo
+  // includes `origin server` so the analyze role filter matches HAR responses;
+  // `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-references')
   .description(
     'It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.',
   )
+  .appliesTo('origin server', 'server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(statusCode(414), (req, _res, location) => {
       try {

--- a/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -4,14 +4,6 @@ export default httpRule(
   'rfc9110/sender-recipient-should-support-8000-octet-uris',
 )
   .severity('warn')
-  // Response-/recipient-side rule (outcome 1, already implemented). The
-  // observable non-conformance is a recipient returning 414 (URI Too Long) for a
-  // request whose URI is at or below the RECOMMENDED 8000-octet minimum — i.e.
-  // the recipient failed to support a URI it should have. This is server
-  // behavior under real load, not meaningful in `test` (Thymian does not
-  // generate over-length URIs) nor in `lint`; it stays `analytics`. appliesTo
-  // includes `origin server` so the analyze role filter matches HAR responses;
-  // `server` is kept for non-HAR captures.
   .type('analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-references')
   .description(

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -1,14 +1,17 @@
-import {
-  httpRule,
-  or,
-  protocol,
-  type RuleViolationLocation,
-} from '@thymian/core';
+import { httpRule, or, protocol } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
 )
   .severity('warn')
+  // Response-/recipient-side rule (outcome 1, already implemented). The
+  // observable non-conformance is a recipient that accepted (did not reject with
+  // a 4xx) a target URI carrying userinfo. This is server/recipient behavior, so
+  // it is not meaningful in `test` (Thymian does not generate userinfo URIs) nor
+  // in `lint`; it stays `analytics`. appliesTo includes `origin server` so the
+  // analyze role filter matches HAR responses; `server` is kept for non-HAR
+  // captures. Security-relevant: userinfo in a URI is a phishing/authority-
+  // obfuscation vector (see PR security section).
   .type('analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
@@ -16,6 +19,7 @@ export default httpRule(
   .description(
     `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
   )
+  .appliesTo('origin server', 'server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(
       or(protocol('http'), protocol('https')),

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -1,21 +1,38 @@
-import { httpRule } from '@thymian/core';
+import {
+  httpRule,
+  or,
+  protocol,
+  type RuleViolationLocation,
+} from '@thymian/core';
 
 export default httpRule(
   'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
 )
   .severity('warn')
-  // HAR ingestion normalizes the request target URI via `new URL(url).origin`,
-  // which STRIPS userinfo before we see it. Detecting whether the recipient
-  // treated userinfo as an error requires the raw target-URI userinfo that
-  // ingestion discarded, so it is not observable from recorded traffic. Any
-  // surviving userinfo lives only in URI-bearing header values (e.g. Referer),
-  // covered elsewhere.
-  .type('informational')
+  .type('analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
   )
   .description(
     `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
   )
-  .appliesTo('origin server', 'server')
+  .appliesTo('server')
+  .rule((ctx, opts, logger) =>
+    ctx.validateHttpTransactions(
+      or(protocol('http'), protocol('https')),
+      (req, res, location) => {
+        try {
+          const url = new URL(req.target ?? req.path, req.origin);
+
+          return (!!url.username || !!url.password) &&
+            !(res.statusCode >= 400 && res.statusCode < 500)
+            ? [{ location, violation: {}, findings: [] }]
+            : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -4,14 +4,12 @@ export default httpRule(
   'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
 )
   .severity('warn')
-  // Informational (#327): unobservable. The check was gated on userinfo present
-  // in the request target URI, but HAR ingestion normalizes the URI via
-  // `new URL(url).origin`, which STRIPS userinfo before we see it, so the
-  // predicate is vacuous (can never fire) and the response-status half never
-  // runs. Detecting whether the recipient treated userinfo as an error also
-  // requires the raw target-URI userinfo that ingestion discarded, so this is
-  // not observable from recorded traffic. Any surviving userinfo lives only in
-  // URI-bearing header values (e.g. Referer), covered elsewhere.
+  // HAR ingestion normalizes the request target URI via `new URL(url).origin`,
+  // which STRIPS userinfo before we see it. Detecting whether the recipient
+  // treated userinfo as an error requires the raw target-URI userinfo that
+  // ingestion discarded, so it is not observable from recorded traffic. Any
+  // surviving userinfo lives only in URI-bearing header values (e.g. Referer),
+  // covered elsewhere.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -4,14 +4,6 @@ export default httpRule(
   'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
 )
   .severity('warn')
-  // Response-/recipient-side rule (outcome 1, already implemented). The
-  // observable non-conformance is a recipient that accepted (did not reject with
-  // a 4xx) a target URI carrying userinfo. This is server/recipient behavior, so
-  // it is not meaningful in `test` (Thymian does not generate userinfo URIs) nor
-  // in `lint`; it stays `analytics`. appliesTo includes `origin server` so the
-  // analyze role filter matches HAR responses; `server` is kept for non-HAR
-  // captures. Security-relevant: userinfo in a URI is a phishing/authority-
-  // obfuscation vector (see PR security section).
   .type('analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -1,10 +1,18 @@
-import { httpRule, or, protocol } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule(
   'rfc9110/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error',
 )
   .severity('warn')
-  .type('analytics')
+  // Informational (#327): unobservable. The check was gated on userinfo present
+  // in the request target URI, but HAR ingestion normalizes the URI via
+  // `new URL(url).origin`, which STRIPS userinfo before we see it, so the
+  // predicate is vacuous (can never fire) and the response-status half never
+  // runs. Detecting whether the recipient treated userinfo as an error also
+  // requires the raw target-URI userinfo that ingestion discarded, so this is
+  // not observable from recorded traffic. Any surviving userinfo lives only in
+  // URI-bearing header values (e.g. Referer), covered elsewhere.
+  .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
   )
@@ -12,22 +20,4 @@ export default httpRule(
     `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
   )
   .appliesTo('origin server', 'server')
-  .rule((ctx, opts, logger) =>
-    ctx.validateHttpTransactions(
-      or(protocol('http'), protocol('https')),
-      (req, res, location) => {
-        try {
-          const url = new URL(req.target ?? req.path, req.origin);
-
-          return (!!url.username || !!url.password) &&
-            !(res.statusCode >= 400 && res.statusCode < 500)
-            ? [{ location, violation: {}, findings: [] }]
-            : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -2,14 +2,12 @@ import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .severity('error')
-  // Informational (#327): unobservable. HAR ingestion normalizes the target URI
-  // via `new URL(url).origin`, which STRIPS any userinfo subcomponent before we
-  // ever see the request, so a userinfo check on origin/path is vacuous (can
-  // never fire). The only userinfo that survives in real traffic lives inside
-  // URI-bearing header VALUES (e.g. Referer), and that case is already covered
-  // by message-context/request-context/referer/
-  // user-agent-must-not-include-fragment-or-userinfo-in-referer. Nothing left to
-  // observe here beyond documenting the requirement.
+  // HAR ingestion normalizes the target URI via `new URL(url).origin`, which
+  // STRIPS any userinfo subcomponent before we ever see the request. The only
+  // userinfo that survives in real traffic lives inside URI-bearing header
+  // VALUES (e.g. Referer), and that case is already covered by
+  // message-context/request-context/referer/
+  // user-agent-must-not-include-fragment-or-userinfo-in-referer.
   .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -10,7 +10,7 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .description(
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
-  .appliesTo('client', 'user-agent')
+  .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateCommonHttpTransactions(
       or(protocol('http'), protocol('https')),

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -6,18 +6,19 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   // Request-side rule (outcome 1, already implemented). It forbids the *sender*
   // from putting userinfo in a generated http/https target URI. It is correctly
   // NOT in `test` (Thymian is the sender there and never emits userinfo, so the
-  // check is vacuous and outside user control). It remains a shared
-  // static + analytics rule: in `lint` it validates target URIs as *described*
-  // in the OpenAPI document (which the API author controls and can wrongly
-  // include userinfo), and in `analyze` it validates target URIs in recorded
-  // requests from real senders. The union (static + analytics, no test) infers a
-  // base ApiContext, so only the common projection is available — which is
-  // sufficient here because origin/path are read from the projection and only
-  // the URI structure (not header values) is needed. appliesTo names the
-  // request roles so the analyze role filter matches HAR requests; it is inert
-  // for the static slot. Security-relevant: userinfo is a phishing vector (see
-  // PR security section).
-  .type('static', 'analytics')
+  // check is vacuous and outside user control). It is analytics-only: a `static`
+  // (lint) slot would be a guaranteed no-op because the common projection for
+  // spec nodes is built by thymianToCommonHttpRequest, which sets
+  // `origin = ${protocol}://${host}:${port}` (userinfo already stripped) and
+  // `path = node.path` (path only). `new URL(req.path, req.origin)` can therefore
+  // never expose a username/password in lint — the userinfo subcomponent is not
+  // represented in spec nodes at all, so there is nothing for lint to inspect.
+  // The rule is validated only against recorded traffic (`analyze`), where the
+  // request comes from a real sender and the full target URI is observable.
+  // appliesTo names the request roles so the analyze role filter matches HAR
+  // requests (HAR default request role = user-agent). Security-relevant:
+  // userinfo is a phishing vector (see PR security section).
+  .type('analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
   )

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -3,6 +3,20 @@ import { httpRule, or, protocol } from '@thymian/core';
 
 export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .severity('error')
+  // Request-side rule (outcome 1, already implemented). It forbids the *sender*
+  // from putting userinfo in a generated http/https target URI. It is correctly
+  // NOT in `test` (Thymian is the sender there and never emits userinfo, so the
+  // check is vacuous and outside user control). It remains a shared
+  // static + analytics rule: in `lint` it validates target URIs as *described*
+  // in the OpenAPI document (which the API author controls and can wrongly
+  // include userinfo), and in `analyze` it validates target URIs in recorded
+  // requests from real senders. The union (static + analytics, no test) infers a
+  // base ApiContext, so only the common projection is available — which is
+  // sufficient here because origin/path are read from the projection and only
+  // the URI structure (not header values) is needed. appliesTo names the
+  // request roles so the analyze role filter matches HAR requests; it is inert
+  // for the static slot. Security-relevant: userinfo is a phishing vector (see
+  // PR security section).
   .type('static', 'analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
@@ -10,6 +24,7 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .description(
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
+  .appliesTo('client', 'user-agent')
   .rule((ctx, opts, logger) =>
     ctx.validateCommonHttpTransactions(
       or(protocol('http'), protocol('https')),

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -1,14 +1,9 @@
-import { httpRule } from '@thymian/core';
+import type { RuleViolationLocation } from '@thymian/core';
+import { httpRule, or, protocol } from '@thymian/core';
 
 export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .severity('error')
-  // HAR ingestion normalizes the target URI via `new URL(url).origin`, which
-  // STRIPS any userinfo subcomponent before we ever see the request. The only
-  // userinfo that survives in real traffic lives inside URI-bearing header
-  // VALUES (e.g. Referer), and that case is already covered by
-  // message-context/request-context/referer/
-  // user-agent-must-not-include-fragment-or-userinfo-in-referer.
-  .type('informational')
+  .type('static', 'analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
   )
@@ -16,4 +11,21 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
   .appliesTo('client', 'user-agent')
+  .rule((ctx, opts, logger) =>
+    ctx.validateCommonHttpTransactions(
+      or(protocol('http'), protocol('https')),
+      (req, _res, location: RuleViolationLocation) => {
+        try {
+          const url = new URL(req.target ?? req.path, req.origin);
+
+          return !!url.username || !!url.password
+            ? [{ location, violation: {}, findings: [] }]
+            : [];
+        } catch (e) {
+          logger.error('Cannot run rule because of invalid URL:', e);
+          return [];
+        }
+      },
+    ),
+  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -3,21 +3,6 @@ import { httpRule, or, protocol } from '@thymian/core';
 
 export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .severity('error')
-  // Request-side rule (outcome 1, already implemented). It forbids the *sender*
-  // from putting userinfo in a generated http/https target URI. It is correctly
-  // NOT in `test` (Thymian is the sender there and never emits userinfo, so the
-  // check is vacuous and outside user control). It is analytics-only: a `static`
-  // (lint) slot would be a guaranteed no-op because the common projection for
-  // spec nodes is built by thymianToCommonHttpRequest, which sets
-  // `origin = ${protocol}://${host}:${port}` (userinfo already stripped) and
-  // `path = node.path` (path only). `new URL(req.path, req.origin)` can therefore
-  // never expose a username/password in lint — the userinfo subcomponent is not
-  // represented in spec nodes at all, so there is nothing for lint to inspect.
-  // The rule is validated only against recorded traffic (`analyze`), where the
-  // request comes from a real sender and the full target URI is observable.
-  // appliesTo names the request roles so the analyze role filter matches HAR
-  // requests (HAR default request role = user-agent). Security-relevant:
-  // userinfo is a phishing vector (see PR security section).
   .type('analytics')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -1,9 +1,16 @@
-import type { RuleViolationLocation } from '@thymian/core';
-import { httpRule, or, protocol } from '@thymian/core';
+import { httpRule } from '@thymian/core';
 
 export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .severity('error')
-  .type('analytics')
+  // Informational (#327): unobservable. HAR ingestion normalizes the target URI
+  // via `new URL(url).origin`, which STRIPS any userinfo subcomponent before we
+  // ever see the request, so a userinfo check on origin/path is vacuous (can
+  // never fire). The only userinfo that survives in real traffic lives inside
+  // URI-bearing header VALUES (e.g. Referer), and that case is already covered
+  // by message-context/request-context/referer/
+  // user-agent-must-not-include-fragment-or-userinfo-in-referer. Nothing left to
+  // observe here beyond documenting the requirement.
+  .type('informational')
   .url(
     'https://www.rfc-editor.org/rfc/rfc9110.html#name-deprecation-of-userinfo-in-http',
   )
@@ -11,21 +18,4 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
   .appliesTo('client', 'user-agent')
-  .rule((ctx, opts, logger) =>
-    ctx.validateCommonHttpTransactions(
-      or(protocol('http'), protocol('https')),
-      (req, _res, location: RuleViolationLocation) => {
-        try {
-          const url = new URL(req.target ?? req.path, req.origin);
-
-          return !!url.username || !!url.password
-            ? [{ location, violation: {}, findings: [] }]
-            : [];
-        } catch (e) {
-          logger.error('Cannot run rule because of invalid URL:', e);
-          return [];
-        }
-      },
-    ),
-  )
   .done();

--- a/packages/rules-rfc-9110/src/rules/identifiers/utils.test.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { targetUriHasEmptyHost } from './utils';
+
+describe('targetUriHasEmptyHost', () => {
+  it('detects an empty authority', () => {
+    expect(targetUriHasEmptyHost('http:///path')).toBe(true);
+    expect(targetUriHasEmptyHost('https:///')).toBe(true);
+    expect(targetUriHasEmptyHost('http://')).toBe(true);
+    expect(targetUriHasEmptyHost('http://?query=1')).toBe(true);
+  });
+
+  it('detects an authority reduced to userinfo or port', () => {
+    expect(targetUriHasEmptyHost('http://user:pass@/path')).toBe(true);
+    expect(targetUriHasEmptyHost('http://@/path')).toBe(true);
+    expect(targetUriHasEmptyHost('https://:8080/path')).toBe(true);
+  });
+
+  it('accepts targets with a host', () => {
+    expect(targetUriHasEmptyHost('http://example.com/path')).toBe(false);
+    expect(targetUriHasEmptyHost('https://example.com:8443/path')).toBe(false);
+    expect(targetUriHasEmptyHost('http://user@example.com/path')).toBe(false);
+    expect(targetUriHasEmptyHost('https://[::1]:8080/path')).toBe(false);
+    expect(targetUriHasEmptyHost('HTTP://EXAMPLE.COM/path')).toBe(false);
+  });
+
+  it('ignores non-absolute-form targets', () => {
+    expect(targetUriHasEmptyHost('/path?query=1')).toBe(false);
+    expect(targetUriHasEmptyHost('example.com:443')).toBe(false);
+    expect(targetUriHasEmptyHost('*')).toBe(false);
+  });
+});

--- a/packages/rules-rfc-9110/src/rules/identifiers/utils.test.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/utils.test.ts
@@ -14,6 +14,7 @@ describe('targetUriHasEmptyHost', () => {
     expect(targetUriHasEmptyHost('http://user:pass@/path')).toBe(true);
     expect(targetUriHasEmptyHost('http://@/path')).toBe(true);
     expect(targetUriHasEmptyHost('https://:8080/path')).toBe(true);
+    expect(targetUriHasEmptyHost('https://:abc/path')).toBe(true);
   });
 
   it('accepts targets with a host', () => {

--- a/packages/rules-rfc-9110/src/rules/identifiers/utils.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/utils.ts
@@ -20,9 +20,12 @@ export function targetUriHasEmptyHost(target: string): boolean {
   }
 
   const authority = authorityMatch[1] ?? '';
-  const host = authority
-    .slice(authority.lastIndexOf('@') + 1)
-    .replace(/:\d*$/, '');
+  const hostAndPort = authority.slice(authority.lastIndexOf('@') + 1);
+  // An IPv6 host is bracketed and may contain ':'; everything after the first
+  // ':' outside brackets is the port — malformed non-numeric ports included.
+  const host = hostAndPort.startsWith('[')
+    ? hostAndPort.slice(0, hostAndPort.indexOf(']') + 1)
+    : (hostAndPort.split(':', 1)[0] ?? '');
 
   return host === '';
 }

--- a/packages/rules-rfc-9110/src/rules/identifiers/utils.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Utility functions for RFC9110 Identifiers validation
+ */
+
+/**
+ * Checks whether an absolute-form 'http' or 'https' request target has an
+ * empty host in its authority component.
+ *
+ * WHATWG URL cannot represent an empty host for these schemes — parsing
+ * either throws or folds the following path segment into the host — so the
+ * raw target string has to be inspected before any URL parsing.
+ *
+ * @param target The raw request target URI
+ * @returns true if the target is absolute-form http(s) with an empty host
+ */
+export function targetUriHasEmptyHost(target: string): boolean {
+  const authorityMatch = /^https?:\/\/([^/?#]*)/i.exec(target);
+  if (!authorityMatch) {
+    return false;
+  }
+
+  const authority = authorityMatch[1] ?? '';
+  const host = authority
+    .slice(authority.lastIndexOf('@') + 1)
+    .replace(/:\d*$/, '');
+
+  return host === '';
+}


### PR DESCRIPTION
## Align `identifiers` rule execution contexts (#327)

> **Depends on #316** (role-hierarchy expansion for `appliesTo`, thymianofficial/thymian-internal#355) — merge that first. The umbrella roles used below (`server`, `client`) only match HAR-imported traffic once the analyzer expands them to the concrete stored roles (`origin server`, `user-agent`).

Brings every rule under `packages/rules-rfc-9110/src/rules/identifiers/` in line with the execution context(s) that can *actually and meaningfully* run, using only the existing rule framework. Each rule lands in exactly one of the four triage outcomes, and every `informational` rule carries a written rationale comment near `.type(...)`.

**20 rules reviewed.** Outcome tally: **1 (implement)** = 7 · **2 (informational)** = 13 · **3 (infra-deferred)** = 0 · **4 (reclassify)** = 3 (all also resolved into outcomes 1/2, counted under their final state below).

### Coverage matrix

| Rule | Before type | After type | Outcome | Note |
|---|---|---|---|---|
| authoritative-access/automated-client-must-log-error-to-audit-log-for-bad-certificate | informational | informational | 2 | Client-internal audit logging; not observable from messages/HAR. Added rationale. |
| authoritative-access/automated-client-should-terminate-connection-for-bad-certificate | informational | informational | 2 | Client transport-layer connection handling on cert failure; no transaction to inspect. Added rationale. |
| authoritative-access/automated-clients-may-provide-setting-to-disable-certificate-check | informational | informational | 2 | Permissive MAY about a product config surface; no non-conformant condition. Added rationale. |
| authoritative-access/automated-clients-must-provide-setting-to-enable-certificate-check | informational | informational | 2 | Client config-surface property, not a transaction property. Added rationale. |
| authoritative-access/client-may-access-by-resolving-host-to-ip-address | informational | informational | 2 | Permissive MAY about DNS/TCP below HTTP; nothing to validate. Added rationale. |
| authoritative-access/client-must-construct-reference-identity | informational | informational | 2 | Internal step of client TLS identity verification (IP-ID/DNS-ID). Added rationale. Security-relevant. |
| authoritative-access/client-must-not-use-cn-id-reference-identity | informational | informational | 2 | Internal client verification choice; no observable footprint. Added rationale. Security-relevant. |
| authoritative-access/client-must-use-rfc6125-verification | informational | informational | 2 | RFC 6125 verification runs in the TLS handshake; not in HTTP traffic. Added rationale. Security-relevant. |
| authoritative-access/client-must-verify-service-identity | informational | informational | 2 | Client-side identity match during TLS; no message-level signal. Added rationale. Security-relevant. |
| authoritative-access/user-agent-must-handle-bad-certificate | informational | informational | 2 | User-agent interactive UX / connection termination; not observable. Added rationale. Security-relevant. |
| http/recipient-must-reject-http-uri-without-host | analytics | analytics | 1 | Response/recipient-side. Added `appliesTo('server')` (expanded to all server-side roles by #316); detects empty host from the raw target URI. |
| http/sender-must-not-generate-http-uri-with-empty-host | analytics | analytics | 1 | Request-side, correctly not in `test`. Added `appliesTo('client')`; detects empty host from the raw target URI. |
| https/client-must-secure-https-requests-and-responses | **static** | **informational** | 4→2 | Declared active `static` but shipped no function. Transport encryption unobservable from spec/HAR; reclassified. Security-relevant. |
| https/recipient-must-reject-https-uri-without-host | analytics | analytics | 1 | Response/recipient-side. Added `appliesTo('server')`; fixed silently-swallowed URL error (now logs); detects empty host from the raw target URI. |
| https/sender-must-not-generate-https-uri-with-empty-host | analytics | analytics | 1 | Request-side, not in `test`. Added `appliesTo('client')`; detects empty host from the raw target URI. |
| normalization/authority-should-not-use-equivalent-uris-for-distinct-resources | **static** | **informational** | 4→2 | `static` with no function. "Distinct resources" is a semantic judgment not decidable from spec or traffic; reclassified. |
| normalization/http-component-may-perform-normalization | **static** | **informational** | 4→2 | `static` with no function. Permissive MAY, no non-conformant condition. Reclassified; severity warn→hint. |
| sender-recipient-should-support-8000-octet-uris | analytics | analytics | 1 | Response/recipient-side (414 on a ≤8000-octet URI). Added `appliesTo('server')`; removed unused import. |
| userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error | analytics | analytics | 1 | Response/recipient-side. Added `appliesTo('server')`. Security-relevant. |
| userinfo/sender-must-not-generate-userinfo-in-uri | static, analytics | static, analytics | 1 | Request-side shared rule via common projection; correctly not in `test`. Added `appliesTo('client')`. Security-relevant. |

### Reclassification reasoning (non-trivial)

- **client-must-secure-https-requests-and-responses (`static`→`informational`)**: A `static` slot with no rule function counts as "covered" while doing nothing. The requirement is that the client actually encrypt https traffic on the wire. The OpenAPI description does not declare transport encryption, and HAR captures decrypted application-layer messages without TLS wire state. It is unobservable in lint/test/analyze → honest `informational`.
- **authority-should-not-use-equivalent-uris-for-distinct-resources (`static`→`informational`)**: Deciding two resources are *distinct* needs application-level semantic knowledge. The spec exposes path templates (not concrete equivalent URIs), and equivalent URIs returning different representations in traffic can be legitimate (negotiation, redirects, time-varying data). No decidable non-conformant condition → `informational`.
- **http-component-may-perform-normalization (`static`→`informational`)**: Pure permissive MAY — both performing and not performing normalization are conformant, so there is nothing to flag. Severity lowered warn→hint to match.
- **appliesTo (outcome-1 rules)**: Request-side (sender) rules use `appliesTo('client')`; response/recipient-side rules use `appliesTo('server')`. The analyzer expands these umbrella roles to every concrete participant role they subsume (`client` → `user-agent`; `server` → `origin server`, `cache`, `proxy`, `gateway`, `tunnel`, `intermediary`) since #316, so they match HAR defaults (request=`user-agent`, response=`origin server`). These rules previously had no `appliesTo` (evaluated all transactions); the explicit roles make the classification honest and HAR-correct.

### Security-relevant rules

- **TLS / certificate verification (authoritative-access, 6 MUST/MUST-NOT + the reclassified https client rule)**: `client-must-verify-service-identity`, `client-must-use-rfc6125-verification`, `client-must-construct-reference-identity`, `client-must-not-use-cn-id-reference-identity`, `user-agent-must-handle-bad-certificate`, `client-must-secure-https-requests-and-responses`. All are client/user-agent-internal behaviors performed in the TLS handshake/transport layer. They are genuinely unobservable from HTTP messages or HAR, so they remain `informational` with explicit security rationale rather than being faked into an active context. This is intentional: an honest informational classification is preferable to a function that cannot detect the violation.
- **userinfo as a phishing/authority-obfuscation vector (RFC 9110 §4.2.4 deprecation)**: `sender-must-not-generate-userinfo-in-uri` (sender, static+analytics) and `recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error` (recipient, analytics) actively detect userinfo in target URIs. Both resolve `new URL(req.target ?? req.path, req.origin)`, so they observe the raw target URI that #315 preserves through capture and persistence.
- **Empty-host URIs (request smuggling / ambiguous authority surface)**: the http/https sender + recipient empty-host rules remain active (`analytics`) and carry role filtering. They now inspect the raw target URI's authority component (`identifiers/utils.ts`): WHATWG `URL` cannot represent an empty host for http(s) — parsing throws or folds the next path segment into the host — so `new URL(...).host === ''` was unfireable-by-construction. When no raw target is captured, the previous URL-based check remains as fallback.

### Review round updates

- **Userinfo observability (Copilot round 1+2, r3504948627/r3504948676/r3526775290/r3526775319)**: the vacuity root cause — HAR ingestion reducing every URL to `origin` + `path` via `new URL(url).origin`, which strips userinfo — was fixed upstream in **#315** by threading the raw request `target` URI through ingestion and persistence. Both userinfo rules are active again and read `req.target ?? req.path`; the interim informational reclassification and its rationale comments are gone.
- **Empty-host MUST rules**: restored as active `analytics` rules (the interim reclassification comments criticized in r3526775335/r3526775350/r3526775357/r3526775365 no longer exist).
- **`appliesTo` simplification (matthyk)**: all seven suggestions applied — `appliesTo('origin server', 'server')` → `appliesTo('server')`, `appliesTo('client', 'user-agent')` → `appliesTo('client')`. This relies on the role-hierarchy expansion from thymianofficial/thymian-internal#355, implemented in **#316**, which this PR now depends on.
- **PR description (Copilot r3504948712)**: matrix and tally above updated to reflect the final classifications.
- **Empty-host observability (Copilot round 3)**: the four empty-host rules now check the raw target URI's authority instead of `new URL(req.path, req.origin).host === ''`, which could never fire (host always came from the parsed origin, and WHATWG URL cannot represent an empty http(s) host anyway). New `targetUriHasEmptyHost` helper with unit tests.
- **RFC anchors (Copilot round 3, inverted)**: the rfc-editor.org anchor really is the truncated `#name-https-certificate-verificat`; the five rules linking the spelled-out `...verification` variant pointed at a non-existent fragment and were fixed to the truncated one (the opposite direction of the bot's suggestion).

### Per-PR checklist

- [x] Every rule in the category reviewed exactly once (20 rules).
- [x] No declared active context (`static`/`test`/`analytics`) left without a rule function (the two ex-`static` rules with no function were reclassified to `informational`; no outcome-3 deferrals were needed in this category).
- [x] No request-side rule assigned to `test` (sender rules are `analytics`, or `static`+`analytics` for the shared userinfo rule).
- [x] Every `informational` rule carries a written reason in a code comment near `.type(...)`.
- [x] Security-relevant rules (TLS/cert verification, userinfo, empty-host) addressed explicitly.
- [x] Header/role checks honest: recipient-side analyze rules use `appliesTo('server')`, sender-side `appliesTo('client')`, expanded to concrete roles by the analyzer (#316).
- [x] `npx nx build rules-rfc-9110 --skip-nx-cache` exits 0.
- [x] `npx prettier --check` clean on changed files.
- [x] Lint: 0 new errors/warnings in changed files. The only eslint output on these files is the pre-existing, project-wide `@nx/enforce-module-boundaries` "Imports of apps are forbidden" on the `@thymian/core` import — it fires identically on untouched files in other categories and is not introduced by this PR.
- [x] Scope respected: only files under `src/rules/identifiers/**` changed.

### Quality gate status

- Build: **pass** (exit 0, builds core + rules-rfc-9110).
- Format: **pass** (prettier clean).
- Lint: **pass** for changed files (0 new issues; only the pre-existing repo-wide module-boundary false positive remains, present on untouched files too).
