### PR TITLE
ci: add workflow_dispatch trigger to Deploy Docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The **Deploy Docs** GitHub Pages workflow ([run #28769141028](https://github.com/thymianofficial/thymian/actions/runs/28769141028)) failed with:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found
for this workflow run. Artifact count is 3.
```

### What actually happened

1. **Attempt 1** hit a *transient* GitHub Pages backend error: `Deployment failed, try again later.` (nothing wrong with our config). It left behind one `github-pages` artifact.
2. The run was then **re-run** twice. `actions/upload-pages-artifact` uploads an artifact named `github-pages`, and re-runs *retain* artifacts from previous attempts (upload-artifact v4 artifacts are immutable, per-attempt).
3. `actions/deploy-pages@v4` looks up the artifact by name across the whole run, found 3, and hard-failed.

So **re-running** the failed run turns a transient hiccup into a permanent failure — each re-run just adds another duplicate artifact and can never succeed.

## What this changes

Adds a `workflow_dispatch:` trigger so the deploy can be launched as a **fresh run** (attempt 1, single artifact) instead of re-running a failed one. This is the safe way to recover from a transient Pages failure without tripping the duplicate-artifact check.

No behavior change to the existing `push` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)