### PR TITLE
fix(plugin-http-analyzer): expand umbrella appliesTo roles to concrete participant roles

### DIFF
--- a/packages/core/src/rules/rule-meta.ts
+++ b/packages/core/src/rules/rule-meta.ts
@@ -15,6 +15,37 @@ export const httpParticipantRoles = [
 
 export type HttpParticipantRole = (typeof httpParticipantRoles)[number];
 
+// Captured traffic stores one concrete role per message and repositories match
+// role names exactly, so umbrella roles must be expanded to every concrete
+// role they subsume before filtering. 'server' covers every participant that
+// can receive and respond to requests; 'client' covers every participant that
+// originates requests.
+const httpParticipantRoleHierarchy: Partial<
+  Record<HttpParticipantRole, readonly HttpParticipantRole[]>
+> = {
+  server: [
+    'server',
+    'origin server',
+    'cache',
+    'proxy',
+    'gateway',
+    'tunnel',
+    'intermediary',
+  ],
+  client: ['client', 'user-agent'],
+  intermediary: ['intermediary', 'proxy', 'gateway', 'tunnel'],
+};
+
+export function expandHttpParticipantRoles(
+  roles: readonly HttpParticipantRole[],
+): HttpParticipantRole[] {
+  return [
+    ...new Set(
+      roles.flatMap((role) => httpParticipantRoleHierarchy[role] ?? [role]),
+    ),
+  ];
+}
+
 export const ruleTypes = [
   'static',
   'analytics',

--- a/packages/core/test/rules/expand-http-participant-roles.test.ts
+++ b/packages/core/test/rules/expand-http-participant-roles.test.ts
@@ -4,7 +4,9 @@ import { expandHttpParticipantRoles } from '../../src/rules/rule-meta.js';
 
 describe('expandHttpParticipantRoles', () => {
   it('expands server to all server-side participant roles', () => {
-    expect(expandHttpParticipantRoles(['server'])).toEqual(
+    const expanded = expandHttpParticipantRoles(['server']);
+
+    expect(expanded).toEqual(
       expect.arrayContaining([
         'server',
         'origin server',
@@ -15,7 +17,7 @@ describe('expandHttpParticipantRoles', () => {
         'intermediary',
       ]),
     );
-    expect(expandHttpParticipantRoles(['server'])).toHaveLength(7);
+    expect(expanded).toHaveLength(7);
   });
 
   it('does not expand server to client-side roles', () => {
@@ -33,10 +35,12 @@ describe('expandHttpParticipantRoles', () => {
   });
 
   it('expands intermediary to all intermediary roles', () => {
-    expect(expandHttpParticipantRoles(['intermediary'])).toEqual(
+    const expanded = expandHttpParticipantRoles(['intermediary']);
+
+    expect(expanded).toEqual(
       expect.arrayContaining(['intermediary', 'proxy', 'gateway', 'tunnel']),
     );
-    expect(expandHttpParticipantRoles(['intermediary'])).toHaveLength(4);
+    expect(expanded).toHaveLength(4);
   });
 
   it('keeps concrete roles unchanged', () => {

--- a/packages/core/test/rules/expand-http-participant-roles.test.ts
+++ b/packages/core/test/rules/expand-http-participant-roles.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { expandHttpParticipantRoles } from '../../src/rules/rule-meta.js';
+
+describe('expandHttpParticipantRoles', () => {
+  it('expands server to all server-side participant roles', () => {
+    expect(expandHttpParticipantRoles(['server'])).toEqual(
+      expect.arrayContaining([
+        'server',
+        'origin server',
+        'cache',
+        'proxy',
+        'gateway',
+        'tunnel',
+        'intermediary',
+      ]),
+    );
+    expect(expandHttpParticipantRoles(['server'])).toHaveLength(7);
+  });
+
+  it('does not expand server to client-side roles', () => {
+    const expanded = expandHttpParticipantRoles(['server']);
+
+    expect(expanded).not.toContain('client');
+    expect(expanded).not.toContain('user-agent');
+  });
+
+  it('expands client to all client-side participant roles', () => {
+    expect(expandHttpParticipantRoles(['client'])).toEqual([
+      'client',
+      'user-agent',
+    ]);
+  });
+
+  it('expands intermediary to all intermediary roles', () => {
+    expect(expandHttpParticipantRoles(['intermediary'])).toEqual(
+      expect.arrayContaining(['intermediary', 'proxy', 'gateway', 'tunnel']),
+    );
+    expect(expandHttpParticipantRoles(['intermediary'])).toHaveLength(4);
+  });
+
+  it('keeps concrete roles unchanged', () => {
+    expect(expandHttpParticipantRoles(['origin server'])).toEqual([
+      'origin server',
+    ]);
+    expect(expandHttpParticipantRoles(['user-agent'])).toEqual(['user-agent']);
+    expect(expandHttpParticipantRoles(['cache'])).toEqual(['cache']);
+  });
+
+  it('deduplicates roles covered by multiple expansions', () => {
+    const expanded = expandHttpParticipantRoles(['server', 'proxy']);
+
+    expect(expanded.filter((role) => role === 'proxy')).toHaveLength(1);
+  });
+
+  it('returns an empty list for no roles', () => {
+    expect(expandHttpParticipantRoles([])).toEqual([]);
+  });
+});

--- a/packages/plugin-http-analyzer/src/analytics-api-context.ts
+++ b/packages/plugin-http-analyzer/src/analytics-api-context.ts
@@ -7,6 +7,7 @@ import {
   type CommonHttpRequest,
   type CommonHttpResponse,
   createRegExpFromOriginWildcard,
+  expandHttpParticipantRoles,
   type HttpFilterExpression,
   type HttpParticipantRole,
   httpParticipantRoles,
@@ -136,11 +137,7 @@ export class AnalyticsApiContext implements AnalyzeContext {
     }
 
     if (roles) {
-      this.roles = roles.flatMap((role) =>
-        role === 'intermediary'
-          ? (['proxy', 'tunnel', 'gateway', 'intermediary'] as const)
-          : role,
-      );
+      this.roles = expandHttpParticipantRoles(roles);
     }
   }
 

--- a/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
+++ b/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
@@ -680,10 +680,10 @@ describe('AnalyticsApiContext', () => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            location: expect.stringMatching('https://api.example.com/users'),
+            location: expect.stringContaining('https://api.example.com/users'),
           }),
           expect.objectContaining({
-            location: expect.stringMatching('https://api.example.de/users'),
+            location: expect.stringContaining('https://api.example.de/users'),
           }),
         ]),
       );
@@ -756,7 +756,7 @@ describe('AnalyticsApiContext', () => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            location: expect.stringMatching('https://api.example.com/users'),
+            location: expect.stringContaining('https://api.example.com/users'),
           }),
         ]),
       );

--- a/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
+++ b/packages/plugin-http-analyzer/test/analytics-api-context.test.ts
@@ -588,6 +588,179 @@ describe('AnalyticsApiContext', () => {
         ]),
       );
     });
+
+    it('should match all server-side participant roles for the server role', async () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'origin server',
+          },
+        },
+      });
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.de',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'gateway',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'cache',
+          },
+        },
+      });
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.org',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'client',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+        undefined,
+        ['server'],
+      );
+
+      const result = await context.validateCommonHttpTransactions(
+        path('/users'),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: expect.stringMatching('https://api.example.com/users'),
+          }),
+          expect.objectContaining({
+            location: expect.stringMatching('https://api.example.de/users'),
+          }),
+        ]),
+      );
+    });
+
+    it('should match user-agent requests for the client role', async () => {
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.com',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'user-agent',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'origin server',
+          },
+        },
+      });
+      insertTransaction({
+        request: {
+          data: {
+            method: 'get',
+            origin: 'https://api.example.de',
+            path: '/users',
+            headers: {},
+          },
+          meta: {
+            role: 'proxy',
+          },
+        },
+        response: {
+          data: {
+            statusCode: 200,
+            headers: {},
+            trailers: {},
+            duration: 100,
+          },
+          meta: {
+            role: 'origin server',
+          },
+        },
+      });
+
+      const format = createThymianFormat();
+      const context = new AnalyticsApiContext(
+        repository,
+        new NoopLogger(),
+        format,
+        undefined,
+        ['client'],
+      );
+
+      const result = await context.validateCommonHttpTransactions(
+        path('/users'),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            location: expect.stringMatching('https://api.example.com/users'),
+          }),
+        ]),
+      );
+    });
   });
 
   describe('validateCapturedHttpTransactions', () => {


### PR DESCRIPTION
## What & why

`appliesTo` role filtering matched stored role names exactly (`reqRole.name IN (...) OR resRole.name IN (...)`), with `intermediary` as the only expanded alias. Rules tagged `server` or `client` therefore silently skipped traffic labeled with concrete roles such as `origin server` or `user-agent` — notably **all HAR imports**, which default to `user-agent` (request) and `origin server` (response).

Fixes thymianofficial/thymian-internal#355.

## The fix

- **`@thymian/core`**: new shared `expandHttpParticipantRoles()` next to the role list in `rule-meta.ts`, encoding the role hierarchy:
  - `server` → `server`, `origin server`, `cache`, `proxy`, `gateway`, `tunnel`, `intermediary` (every participant that can receive and respond to requests, per the issue)
  - `client` → `client`, `user-agent` (request originators)
  - `intermediary` → `intermediary`, `proxy`, `gateway`, `tunnel` (unchanged behavior, moved out of the analyzer)
  - concrete roles pass through; overlapping expansions are deduplicated
- **`@thymian/plugin-http-analyzer`**: `AnalyticsApiContext` now calls the shared helper instead of its local `intermediary` special case. Repository SQL filtering stays exact-match against the already-expanded list, as proposed in the issue.

Note beyond the issue's write-up: the `client` → `user-agent` expansion is included for the same reason as `server` → `origin server` — without it, request-side rules tagged `client` never fire on HAR imports. (Left `client` NOT expanding to intermediary roles: a proxy does act as a client on its outbound leg, but captured roles describe the participant, not the leg, and widening `client` to intermediaries would make user-agent-specific rules fire on proxies.)

## Tests

- `packages/core/test/rules/expand-http-participant-roles.test.ts`: expansion table per role, server excludes client-side roles, dedup, passthrough.
- `packages/plugin-http-analyzer/test/analytics-api-context.test.ts`: end-to-end through the SQLite repository — `['server']` matches transactions labeled `origin server`/`cache`/`gateway` but not `client`/`user-agent`; `['client']` matches the HAR-shaped `user-agent` request leg. Existing `intermediary` test unchanged and green.

## Impact

Unblocks simplifying rule metadata to single umbrella roles (e.g. `.appliesTo('server')` instead of `.appliesTo('origin server', 'server')`) — wanted by the review on #300.

## Verification

- `nx build core`, `nx build plugin-http-analyzer`: pass
- Full vitest suites: core 186/186, plugin-http-analyzer 91/91
- Prettier/eslint via pre-commit hooks: clean