### PR TITLE
feat(plugin-sampler): add validate command for generated samples

### DIFF
--- a/e2e-tests/src/cli-sampler-validate.test.ts
+++ b/e2e-tests/src/cli-sampler-validate.test.ts
@@ -45,7 +45,7 @@ describe('thymian sampler validate', () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('changed-artifact: types.d.ts');
     expect(result.output).toMatch(
-      /Checked \d+ generated artifacts in .+\. \d+ failed\./,
+      /Checked \d+ generated artifacts in .+\. \d+ out of sync\./,
     );
     expect(result.output).not.toContain('sampler init');
     expect(result.output).not.toContain('Re-run:');
@@ -169,6 +169,22 @@ describe('thymian sampler validate', () => {
     expect(result.output).toContain('does-not-exist.json');
   }, 180_000);
 
+  it('emits a JSON report and exit 2 when --json --for-path targets an unknown artifact', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const result = execThymianRaw(
+      ['sampler', 'validate', '--json', '--for-path', 'does-not-exist.json'],
+      { cwd: getTempDir(), allowFailure: true },
+    );
+
+    expect(result.exitCode).toBe(2);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.checkedArtifacts).toBe(0);
+    expect(report.failures).toEqual([]);
+  }, 180_000);
+
   it('emits a machine-readable report and non-zero exit with --json', () => {
     copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
     execThymian(['sampler', 'init'], { cwd: getTempDir() });
@@ -262,8 +278,8 @@ describe('thymian sampler validate', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.output).toContain(
-      'Sampler validation passed: 5 generated artifacts are in sync.',
+    expect(result.output).toMatch(
+      /Sampler validation passed: \d+ generated artifacts are in sync\./,
     );
   }, 180_000);
 });

--- a/e2e-tests/src/cli-sampler-validate.test.ts
+++ b/e2e-tests/src/cli-sampler-validate.test.ts
@@ -1,0 +1,269 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  copyFixturesToTempDir,
+  execThymian,
+  execThymianRaw,
+  fixturesDir,
+  useTempDir,
+} from './helpers.js';
+
+describe('thymian sampler validate', () => {
+  const getTempDir = useTempDir();
+
+  it('passes when generated sampler artifacts are in sync', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(
+      /Sampler validation passed: \d+ generated artifacts are in sync\./,
+    );
+  }, 180_000);
+
+  it('fails with file-specific diagnostics when generated artifacts drift', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'types.d.ts'),
+      'changed',
+    );
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('changed-artifact: types.d.ts');
+    expect(result.output).toMatch(
+      /Checked \d+ generated artifacts in .+\. \d+ failed\./,
+    );
+    expect(result.output).not.toContain('sampler init');
+    expect(result.output).not.toContain('Re-run:');
+    expect(result.output).not.toContain('--overwrite');
+  }, 180_000);
+
+  it('reports missing and unexpected generated artifacts', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    unlinkSync(join(getTempDir(), '.thymian', 'samples', 'tsconfig.json'));
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'orphan.json'),
+      '{}',
+    );
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('missing-artifact: tsconfig.json');
+    expect(result.output).toContain('unexpected-artifact: orphan.json');
+  }, 180_000);
+
+  it('reports additional sample tree elements without loading stale metadata', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const unexpectedDir = join(
+      getTempDir(),
+      '.thymian',
+      'samples',
+      'new-source',
+      'new-path',
+    );
+    mkdirSync(unexpectedDir, { recursive: true });
+    writeFileSync(join(unexpectedDir, 'new-sample.json'), '{}');
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain(
+      'unexpected-artifact: new-source/new-path/new-sample.json',
+    );
+    expect(result.output).not.toContain('Unknown type:');
+  }, 180_000);
+
+  it('summarizes without diffs by default and shows them with --full-diffs', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const metaPath = join(getTempDir(), '.thymian', 'samples', 'meta.json');
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
+    meta.version.version = 'old-format-hash';
+    writeFileSync(metaPath, JSON.stringify(meta));
+
+    const summary = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(summary.exitCode).toBe(1);
+    expect(summary.output).toContain('stale-root-metadata: meta.json');
+    // The default output lists the artifact but not the per-change diff.
+    expect(summary.output).not.toContain('JSON changes:');
+
+    const detailed = execThymianRaw(['sampler', 'validate', '--full-diffs'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(detailed.exitCode).toBe(1);
+    expect(detailed.output).toContain('stale-root-metadata: meta.json');
+    expect(detailed.output).toContain('JSON changes:');
+    expect(detailed.output).toContain('[update] /version/version');
+    expect(detailed.output).toContain('"old-format-hash"');
+  }, 180_000);
+
+  it('validates a single artifact with --for-path', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const metaPath = join(getTempDir(), '.thymian', 'samples', 'meta.json');
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
+    meta.version.version = 'old-format-hash';
+    writeFileSync(metaPath, JSON.stringify(meta));
+
+    // A different artifact is broken too, but --for-path scopes to meta.json.
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'types.d.ts'),
+      'changed',
+    );
+
+    const result = execThymianRaw(
+      ['sampler', 'validate', '--for-path', 'meta.json'],
+      { cwd: getTempDir(), allowFailure: true },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('stale-root-metadata: meta.json');
+    expect(result.output).toContain('[update] /version/version');
+    expect(result.output).not.toContain('types.d.ts');
+    expect(result.output).toContain('Checked 1 generated artifact ');
+  }, 180_000);
+
+  it('errors when --for-path targets an unknown artifact', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const result = execThymianRaw(
+      ['sampler', 'validate', '--for-path', 'does-not-exist.json'],
+      { cwd: getTempDir(), allowFailure: true },
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('does-not-exist.json');
+  }, 180_000);
+
+  it('emits a machine-readable report and non-zero exit with --json', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'types.d.ts'),
+      'changed',
+    );
+
+    const result = execThymianRaw(['sampler', 'validate', '--json'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.checkedArtifacts).toBeGreaterThan(0);
+    expect(
+      report.failures.some(
+        (failure: { type: string; path: string }) =>
+          failure.type === 'changed-artifact' && failure.path === 'types.d.ts',
+      ),
+    ).toBe(true);
+  }, 180_000);
+
+  it('exits zero and prints a JSON report with --json when in sync', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const result = execThymianRaw(['sampler', 'validate', '--json'], {
+      cwd: getTempDir(),
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const report = JSON.parse(result.stdout);
+    expect(report.failures).toEqual([]);
+  }, 180_000);
+
+  it('renders full content with --full-diffs', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'types.d.ts'),
+      'first line\nsecond line\n',
+    );
+
+    const result = execThymianRaw(['sampler', 'validate', '--full-diffs'], {
+      cwd: getTempDir(),
+      allowFailure: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('changed-artifact: types.d.ts');
+    expect(result.output).toContain('second line');
+    // The full expected content is shown, including a type that appears well
+    // into the generated file.
+    expect(result.output).toContain('HttpRequestTemplate');
+  }, 180_000);
+
+  it('ignores user hook files in the samples directory', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+    writeFileSync(
+      join(getTempDir(), '.thymian', 'samples', 'custom.beforeEach.ts'),
+      'export default async function beforeEach() {}',
+    );
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+    });
+
+    expect(result.exitCode).toBe(0);
+  }, 180_000);
+
+  it('validates a custom sampler path from plugin options', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'dynamic-test'), getTempDir());
+    const configPath = join(getTempDir(), 'thymian.config.yaml');
+    const config = readFileSync(configPath, 'utf8').replace(
+      "'@thymian/plugin-sampler': {}",
+      "'@thymian/plugin-sampler':\n    options:\n      path: custom-samples",
+    );
+    writeFileSync(configPath, config);
+
+    execThymian(['sampler', 'init'], { cwd: getTempDir() });
+
+    const result = execThymianRaw(['sampler', 'validate'], {
+      cwd: getTempDir(),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(
+      'Sampler validation passed: 5 generated artifacts are in sync.',
+    );
+  }, 180_000);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33788,6 +33788,7 @@
       "version": "0.0.0-PLACEHOLDER",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@scalar/json-magic": "^0.9.0",
         "@thymian/common-cli": "0.0.0-PLACEHOLDER",
         "@thymian/core": "0.0.0-PLACEHOLDER",
         "@thymian/plugin-request-dispatcher": "0.0.0-PLACEHOLDER",

--- a/packages/plugin-sampler/eslint.config.mjs
+++ b/packages/plugin-sampler/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['vitest', 'tslib', 'ajv'],
+          ignoredDependencies: ['vitest', 'tslib'],
         },
       ],
     },

--- a/packages/plugin-sampler/eslint.config.mjs
+++ b/packages/plugin-sampler/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
-          ignoredDependencies: ['vitest', 'tslib'],
+          ignoredDependencies: ['vitest', 'tslib', 'ajv'],
         },
       ],
     },

--- a/packages/plugin-sampler/package.json
+++ b/packages/plugin-sampler/package.json
@@ -41,6 +41,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
+    "@scalar/json-magic": "^0.9.0",
     "@thymian/common-cli": "0.0.0-PLACEHOLDER",
     "@thymian/core": "0.0.0-PLACEHOLDER",
     "@thymian/plugin-request-dispatcher": "0.0.0-PLACEHOLDER",

--- a/packages/plugin-sampler/src/cli/commands/sampler/validate.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/validate.ts
@@ -1,0 +1,203 @@
+import { BaseCliRunCommand, oclif } from '@thymian/common-cli';
+import {
+  errorSymbol,
+  type Severity,
+  SEVERITY_COLORS,
+  SEVERITY_SYMBOLS,
+  successSymbol,
+} from '@thymian/core';
+
+import type {
+  SamplerValidationContentChange,
+  SamplerValidationFinding,
+  SamplerValidationFindingType,
+  SamplerValidationReport,
+} from '../../../validation/validate-sampler-output.js';
+
+const { colorize } = oclif.ux;
+
+// Map each finding to a core report severity so the command reuses the exact
+// colors and symbols of the Thymian report renderer (see report-style.ts)
+// without constructing a Report. A missing/changed artifact is an error; an
+// unexpected extra file is a warning.
+const FINDING_SEVERITY: Record<SamplerValidationFindingType, Severity> = {
+  'missing-artifact': 'error',
+  'changed-artifact': 'error',
+  'stale-root-metadata': 'error',
+  'metadata-out-of-sync': 'error',
+  'invalid-json': 'error',
+  'unexpected-artifact': 'warn',
+};
+
+export default class Validate extends BaseCliRunCommand<typeof Validate> {
+  static override enableJsonFlag = true;
+
+  static override description =
+    'Validate generated sampler artifacts for the current API specification.';
+
+  static override flags = {
+    ['full-diffs']: oclif.Flags.boolean({
+      default: false,
+      description:
+        'Show the full diff for every out-of-sync artifact instead of a summary.',
+    }),
+    ['for-path']: oclif.Flags.string({
+      description:
+        'Validate a single generated artifact by its relative path (e.g. meta.json) and show its full diff.',
+    }),
+  };
+
+  async run(): Promise<SamplerValidationReport> {
+    return this.thymian.run(async (emitter) => {
+      if (
+        !this.thymian.plugins.find(
+          (p) => p.plugin.name === '@thymian/plugin-sampler',
+        )
+      ) {
+        this.error(
+          'Cannot validate sampler if sampler plugin is not registered.',
+          {
+            exit: 1,
+          },
+        );
+      }
+
+      const format = await this.thymian.loadFormat(
+        {
+          inputs: this.thymianConfig.specifications ?? [],
+          validateSpecs: this.flags['validate-specs'],
+        },
+        {
+          emitFormat: false,
+        },
+      );
+
+      const forPath = this.flags['for-path'];
+
+      const report = await emitter.emitAction(
+        'sampler.validate',
+        {
+          format: format.export(),
+          ...(forPath !== undefined ? { forPath } : {}),
+        },
+        {
+          strategy: 'first',
+        },
+      );
+
+      // A scoped run reports 0 checked artifacts only when the path is not a
+      // known generated artifact — surface that as an error in every mode.
+      if (forPath !== undefined && report.checkedArtifacts === 0) {
+        this.error(
+          `No generated sampler artifact found at path "${forPath}".`,
+          {
+            exit: 2,
+          },
+        );
+      }
+
+      if (this.jsonEnabled()) {
+        // oclif serializes the returned value as JSON and suppresses `this.log`.
+        // Signal failure through the exit code without throwing, because a throw
+        // would abort before the JSON is printed.
+        if (report.failures.length > 0) {
+          process.exitCode = 1;
+        }
+
+        return report;
+      }
+
+      if (report.failures.length === 0) {
+        this.log(
+          `${colorize(SEVERITY_COLORS.info, successSymbol)} ${
+            forPath !== undefined
+              ? `Generated sampler artifact "${forPath}" is in sync.`
+              : `Sampler validation passed: ${report.checkedArtifacts} generated artifacts are in sync.`
+          }`,
+        );
+
+        return report;
+      }
+
+      // `--for-path` targets one artifact, so its diff is always shown;
+      // otherwise details are opt-in via `--full-diffs`.
+      const showDiffs = this.flags['full-diffs'] || forPath !== undefined;
+      const failed = report.failures.length;
+
+      for (const failure of report.failures) {
+        this.logFailure(failure, showDiffs);
+      }
+
+      const checked = report.checkedArtifacts;
+
+      this.log();
+      this.log(
+        `Checked ${checked} generated ${checked === 1 ? 'artifact' : 'artifacts'} in ${report.samplePath}. ${colorize(SEVERITY_COLORS.error, `${failed} failed`)}.`,
+      );
+
+      this.exit(1);
+    });
+  }
+
+  private logFailure(
+    failure: SamplerValidationFinding,
+    showDiffs: boolean,
+  ): void {
+    const severity = FINDING_SEVERITY[failure.type];
+    const color = SEVERITY_COLORS[severity];
+    const symbol = SEVERITY_SYMBOLS[severity];
+
+    this.log(
+      `${colorize(color, `${symbol} ${failure.type}`)}: ${failure.path}`,
+    );
+
+    if (!showDiffs) {
+      return;
+    }
+
+    this.log(colorize(SEVERITY_COLORS.info, `  ${failure.message}`));
+
+    if (failure.changes && failure.changes.length > 0) {
+      this.logJsonChanges(failure.changes);
+    } else {
+      this.logContentField('expected', failure.expected);
+      this.logContentField('actual', failure.actual);
+    }
+
+    this.log();
+  }
+
+  private logJsonChanges(changes: SamplerValidationContentChange[]): void {
+    this.log(colorize(SEVERITY_COLORS.info, '  JSON changes:'));
+
+    for (const change of changes) {
+      const pointer = change.pointer || '/';
+      let detail: string;
+
+      if (change.type === 'add') {
+        detail = `[add] ${pointer} → ${JSON.stringify(change.actual)}`;
+      } else if (change.type === 'delete') {
+        detail = `[delete] ${pointer} (was ${JSON.stringify(change.expected)})`;
+      } else {
+        detail = `[update] ${pointer}: ${JSON.stringify(change.expected)} → ${JSON.stringify(change.actual)}`;
+      }
+
+      this.log(colorize(SEVERITY_COLORS.info, `    ${detail}`));
+    }
+  }
+
+  private logContentField(
+    label: 'expected' | 'actual',
+    value: string | undefined,
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+
+    this.log(colorize(SEVERITY_COLORS.info, `  ${label}:`));
+
+    for (const line of value.split('\n')) {
+      this.log(colorize(SEVERITY_COLORS.info, `    ${line}`));
+    }
+  }
+}

--- a/packages/plugin-sampler/src/cli/commands/sampler/validate.ts
+++ b/packages/plugin-sampler/src/cli/commands/sampler/validate.ts
@@ -1,6 +1,5 @@
 import { BaseCliRunCommand, oclif } from '@thymian/common-cli';
 import {
-  errorSymbol,
   type Severity,
   SEVERITY_COLORS,
   SEVERITY_SYMBOLS,
@@ -43,7 +42,7 @@ export default class Validate extends BaseCliRunCommand<typeof Validate> {
     }),
     ['for-path']: oclif.Flags.string({
       description:
-        'Validate a single generated artifact by its relative path (e.g. meta.json) and show its full diff.',
+        'Validate a single generated artifact by its relative path (e.g. meta.json) and show its full diff. Note: the full artifact set is still regenerated internally, so this scopes the output, not the work.',
     }),
   };
 
@@ -88,6 +87,15 @@ export default class Validate extends BaseCliRunCommand<typeof Validate> {
       // A scoped run reports 0 checked artifacts only when the path is not a
       // known generated artifact — surface that as an error in every mode.
       if (forPath !== undefined && report.checkedArtifacts === 0) {
+        if (this.jsonEnabled()) {
+          // Keep machine output consistent: emit the (empty) report as JSON and
+          // signal the usage error through the exit code instead of throwing,
+          // which would abort before any JSON is printed.
+          process.exitCode = 2;
+
+          return report;
+        }
+
         this.error(
           `No generated sampler artifact found at path "${forPath}".`,
           {
@@ -122,17 +130,32 @@ export default class Validate extends BaseCliRunCommand<typeof Validate> {
       // `--for-path` targets one artifact, so its diff is always shown;
       // otherwise details are opt-in via `--full-diffs`.
       const showDiffs = this.flags['full-diffs'] || forPath !== undefined;
-      const failed = report.failures.length;
 
       for (const failure of report.failures) {
         this.logFailure(failure, showDiffs);
       }
 
       const checked = report.checkedArtifacts;
+      // `checkedArtifacts` counts only expected (generated) artifacts, so keep
+      // unexpected extras in their own tally — otherwise "N failed" against
+      // "Checked M" reads as "N of M generated artifacts failed" when the extras
+      // were never part of that set.
+      const unexpected = report.failures.filter(
+        (failure) => failure.type === 'unexpected-artifact',
+      ).length;
+      const outOfSync = report.failures.length - unexpected;
+
+      const summaryParts: string[] = [];
+      if (outOfSync > 0) {
+        summaryParts.push(`${outOfSync} out of sync`);
+      }
+      if (unexpected > 0) {
+        summaryParts.push(`${unexpected} unexpected`);
+      }
 
       this.log();
       this.log(
-        `Checked ${checked} generated ${checked === 1 ? 'artifact' : 'artifacts'} in ${report.samplePath}. ${colorize(SEVERITY_COLORS.error, `${failed} failed`)}.`,
+        `Checked ${checked} generated ${checked === 1 ? 'artifact' : 'artifacts'} in ${report.samplePath}. ${colorize(SEVERITY_COLORS.error, `${summaryParts.join(', ')}.`)}`,
       );
 
       this.exit(1);

--- a/packages/plugin-sampler/src/constants.ts
+++ b/packages/plugin-sampler/src/constants.ts
@@ -2,3 +2,17 @@ export const SAMPLE_FILE = /.*request\.json/;
 export const BEFORE_EACH_HOOK = /(.*\.)?beforeEach\.(ts|js|mjs|cjs|mts|cts)/;
 export const AFTER_EACH_HOOK = /(.*\.)?afterEach\.(ts|js|mjs|cjs|mts|cts)/;
 export const AUTHORIZE_HOOK = /(.*\.)?authorize\.(ts|js|mjs|cjs|mts|cts)/;
+
+/**
+ * Whether a file name is a sampler hook file. This must mirror how hooks are
+ * actually discovered when reading samples (see `extractHooksFromDir` in
+ * read-samples-from-dir.ts), so that `sampler validate` never flags a file the
+ * sampler loads as a hook — the matching lives here to keep the two in sync.
+ */
+export function isHookFileName(fileName: string): boolean {
+  return (
+    BEFORE_EACH_HOOK.test(fileName) ||
+    AFTER_EACH_HOOK.test(fileName) ||
+    AUTHORIZE_HOOK.test(fileName)
+  );
+}

--- a/packages/plugin-sampler/src/constants.ts
+++ b/packages/plugin-sampler/src/constants.ts
@@ -1,7 +1,7 @@
-export const SAMPLE_FILE = /.*request\.json/;
-export const BEFORE_EACH_HOOK = /(.*\.)?beforeEach\.(ts|js|mjs|cjs|mts|cts)/;
-export const AFTER_EACH_HOOK = /(.*\.)?afterEach\.(ts|js|mjs|cjs|mts|cts)/;
-export const AUTHORIZE_HOOK = /(.*\.)?authorize\.(ts|js|mjs|cjs|mts|cts)/;
+export const SAMPLE_FILE = /request\.json$/;
+export const BEFORE_EACH_HOOK = /(?:^|[/\\.])beforeEach\.[cm]?[jt]s$/;
+export const AFTER_EACH_HOOK = /(?:^|[/\\.])afterEach\.[cm]?[jt]s$/;
+export const AUTHORIZE_HOOK = /(?:^|[/\\.])authorize\.[cm]?[jt]s$/;
 
 /**
  * Whether a file name is a sampler hook file. This must mirror how hooks are

--- a/packages/plugin-sampler/src/index.ts
+++ b/packages/plugin-sampler/src/index.ts
@@ -27,6 +27,10 @@ import { readSamplesFromDir } from './samples-structure/read-samples-from-dir.js
 import type { SamplesStructure } from './samples-structure/samples-tree-structure.js';
 import { writeSamplesToDir } from './samples-structure/write-samples-to-dir.js';
 import { entryExists } from './utils.js';
+import {
+  type SamplerValidationReport,
+  validateSamplerOutput,
+} from './validation/validate-sampler-output.js';
 
 declare module '@thymian/core' {
   interface ThymianActions {
@@ -36,6 +40,14 @@ declare module '@thymian/core' {
         overwrite?: boolean;
       };
       response: void;
+    };
+
+    'sampler.validate': {
+      event: {
+        format: SerializedThymianFormat;
+        forPath?: string;
+      };
+      response: SamplerValidationReport;
     };
 
     'core.request.sample': {
@@ -66,6 +78,50 @@ declare module '@thymian/core' {
 export type SamplerPluginOptions = {
   path: string;
 };
+
+const samplerValidateActionSchema = {
+  event: {
+    type: 'object',
+    required: ['format'],
+    properties: {
+      format: {},
+      forPath: { type: 'string', nullable: true },
+    },
+  },
+  response: {
+    type: 'object',
+    required: ['samplePath', 'checkedArtifacts', 'failures'],
+    properties: {
+      samplePath: { type: 'string' },
+      checkedArtifacts: { type: 'integer' },
+      failures: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['type', 'path', 'message'],
+          properties: {
+            type: {
+              type: 'string',
+              enum: [
+                'missing-artifact',
+                'changed-artifact',
+                'stale-root-metadata',
+                'metadata-out-of-sync',
+                'unexpected-artifact',
+                'invalid-json',
+              ],
+            },
+            path: { type: 'string' },
+            message: { type: 'string' },
+            expected: { type: 'string', nullable: true },
+            actual: { type: 'string', nullable: true },
+            changes: { type: 'array', nullable: true },
+          },
+        },
+      },
+    },
+  },
+} as const;
 
 export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
   name: '@thymian/plugin-sampler',
@@ -107,6 +163,11 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
           },
         },
       },
+      // The strict `JSONSchemaType<T>` target can't be satisfied by this
+      // hand-written `as const` schema (readonly literals + a deliberately
+      // loose `format: {}`, which ajv validates at runtime). `never` is the
+      // bottom type, so it assigns past the check.
+      'sampler.validate': samplerValidateActionSchema as never,
     },
   },
   plugin: async (emitter, logger, options) => {
@@ -201,6 +262,19 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
       );
 
       ctx.reply();
+    });
+
+    emitter.onAction('sampler.validate', async ({ format, forPath }, ctx) => {
+      const parsedFormat = ThymianFormat.import(format);
+
+      ctx.reply(
+        await validateSamplerOutput({
+          format: parsedFormat,
+          emitter,
+          samplePath: basePath,
+          forPath,
+        }),
+      );
     });
 
     emitter.onAction('core.request.sample', async ({ transaction }, ctx) => {

--- a/packages/plugin-sampler/src/index.ts
+++ b/packages/plugin-sampler/src/index.ts
@@ -1,4 +1,3 @@
-import { writeFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 
 import {
@@ -19,7 +18,6 @@ import {
   generateTypesForThymianFormat,
 } from './hooks/generate-request-types.js';
 import { HookRunner } from './hooks/hook-runner.js';
-import { tsConfig } from './hooks/ts-config.js';
 import { requestSampleToRequestTemplate } from './request-sample-to-request-template.js';
 import { RequestSampler } from './request-sampler.js';
 import { getPathTransactionId } from './samples-structure/get-path-transaction-id.js';
@@ -85,7 +83,7 @@ const samplerValidateActionSchema = {
     required: ['format'],
     properties: {
       format: {},
-      forPath: { type: 'string', nullable: true },
+      forPath: { type: 'string' },
     },
   },
   response: {
@@ -113,9 +111,9 @@ const samplerValidateActionSchema = {
             },
             path: { type: 'string' },
             message: { type: 'string' },
-            expected: { type: 'string', nullable: true },
-            actual: { type: 'string', nullable: true },
-            changes: { type: 'array', nullable: true },
+            expected: { type: 'string' },
+            actual: { type: 'string' },
+            changes: { type: 'array' },
           },
         },
       },
@@ -165,9 +163,11 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
       },
       // The strict `JSONSchemaType<T>` target can't be satisfied by this
       // hand-written `as const` schema (readonly literals + a deliberately
-      // loose `format: {}`, which ajv validates at runtime). `never` is the
-      // bottom type, so it assigns past the check.
-      'sampler.validate': samplerValidateActionSchema as never,
+      // loose `format: {}`, which ajv validates at runtime). Suppress the
+      // structural check the same way `sampler.init` does above, for parity.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      'sampler.validate': samplerValidateActionSchema,
     },
   },
   plugin: async (emitter, logger, options) => {
@@ -247,19 +247,12 @@ export const samplePlugin: ThymianPlugin<Partial<SamplerPluginOptions>> = {
       await writeSamplesToDir(samples, generatedTypes.keyToTransactionId, {
         path: basePath,
         mode: typeof overwrite === 'boolean' ? 'overwrite' : 'failIfExist',
+        typeArtifacts: {
+          typesContent: generatedTypesToString(generatedTypes),
+        },
       });
 
       logger.debug(`Wrote samples at ${basePath}`);
-
-      await writeFile(
-        join(basePath, 'types.d.ts'),
-        generatedTypesToString(generatedTypes),
-      );
-
-      await writeFile(
-        join(basePath, 'tsconfig.json'),
-        JSON.stringify(tsConfig, null, 2),
-      );
 
       ctx.reply();
     });

--- a/packages/plugin-sampler/src/samples-structure/write-samples-to-dir.ts
+++ b/packages/plugin-sampler/src/samples-structure/write-samples-to-dir.ts
@@ -3,6 +3,7 @@ import { basename, format, join } from 'node:path';
 
 import { ThymianBaseError } from '@thymian/core';
 
+import { tsConfig } from '../hooks/ts-config.js';
 import {
   type ContentSource,
   type HttpRequestSample,
@@ -217,6 +218,15 @@ export type WriteOptions = {
   mode?: 'failIfExist' | 'overwrite';
   mkdir?: CreateDir;
   writeToFile?: WriteToFile;
+  /**
+   * When provided, the generated `types.d.ts` and `tsconfig.json` hook
+   * artifacts are emitted through the same `writeToFile` seam as the rest of
+   * the samples. Keeping these writes here guarantees `sampler.init` (on disk)
+   * and the validation flow (in memory) can never drift in how they emit them.
+   */
+  typeArtifacts?: {
+    typesContent: string;
+  };
 };
 
 export async function writeSamplesToDir(
@@ -286,4 +296,16 @@ export async function writeSamplesToDir(
 
     return dirPath;
   });
+
+  if (options.typeArtifacts) {
+    await writeToFile(
+      join(options.path, 'types.d.ts'),
+      options.typeArtifacts.typesContent,
+    );
+
+    await writeToFile(
+      join(options.path, 'tsconfig.json'),
+      JSON.stringify(tsConfig, null, 2),
+    );
+  }
 }

--- a/packages/plugin-sampler/src/samples-structure/write-samples-to-dir.ts
+++ b/packages/plugin-sampler/src/samples-structure/write-samples-to-dir.ts
@@ -22,6 +22,8 @@ import {
 import type { PathToNodeType } from './structure-meta-on-disc.js';
 import { traverse, traverseAsync } from './traverse.js';
 
+export type CreateDir = (path: string) => Promise<void>;
+
 export type WriteToFile = (
   path: string,
   content: string | Buffer,
@@ -213,6 +215,8 @@ export async function transformParameters({
 export type WriteOptions = {
   path: string;
   mode?: 'failIfExist' | 'overwrite';
+  mkdir?: CreateDir;
+  writeToFile?: WriteToFile;
 };
 
 export async function writeSamplesToDir(
@@ -222,21 +226,29 @@ export async function writeSamplesToDir(
 ): Promise<void> {
   const mode = options.mode ?? 'failIfExist';
 
-  const writeToFile: WriteToFile = async (path, content, encoding) => {
-    if (mode === 'failIfExist' && (await entryExists(path))) {
-      throw new ThymianBaseError(
-        `File/Directory at path "${path}" already exists. Use "overwrite" mode to overwrite it.`,
-        {
-          name: 'PathAlreadyExistsError',
-          ref: 'https://thymian.dev/references/errors/path-already-exists-error/',
-        },
-      );
-    }
+  const mkdirDir: CreateDir =
+    options.mkdir ??
+    (async (path) => {
+      await mkdir(path, { recursive: true });
+    });
 
-    await writeFile(path, content, encoding as BufferEncoding);
-  };
+  const writeToFile: WriteToFile =
+    options.writeToFile ??
+    (async (path, content, encoding) => {
+      if (mode === 'failIfExist' && (await entryExists(path))) {
+        throw new ThymianBaseError(
+          `File/Directory at path "${path}" already exists. Use "overwrite" mode to overwrite it.`,
+          {
+            name: 'PathAlreadyExistsError',
+            ref: 'https://thymian.dev/references/errors/path-already-exists-error/',
+          },
+        );
+      }
 
-  await mkdir(options.path, { recursive: true });
+      await writeFile(path, content, encoding as BufferEncoding);
+    });
+
+  await mkdirDir(options.path);
 
   await writeToFile(
     join(options.path, 'meta.json'),
@@ -257,13 +269,13 @@ export async function writeSamplesToDir(
     const dirPath = join(currentPath, folderName);
 
     if (nodeIsType(node, 'samples')) {
-      await mkdir(dirPath, { recursive: true });
+      await mkdirDir(dirPath);
 
       const metaPath = join(dirPath, 'meta.json');
 
       await writeToFile(metaPath, JSON.stringify(node.meta, null, 2));
     } else if (nodeIsType(node, 'requests')) {
-      await mkdir(dirPath, { recursive: true });
+      await mkdirDir(dirPath);
 
       for (const [idx, sample] of node.value.entries()) {
         const name = `${idx}-request`;

--- a/packages/plugin-sampler/src/validation/validate-sampler-output.ts
+++ b/packages/plugin-sampler/src/validation/validate-sampler-output.ts
@@ -1,0 +1,433 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+
+import { diff as diffJson, type Difference } from '@scalar/json-magic/diff';
+import type { ThymianEmitter, ThymianFormat } from '@thymian/core';
+
+import { isHookFileName } from '../constants.js';
+import { generateSamplesForThymianFormat } from '../generation/generate-samples-for-thymian-format.js';
+import {
+  generatedTypesToString,
+  generateTypesForThymianFormat,
+} from '../hooks/generate-request-types.js';
+import { tsConfig } from '../hooks/ts-config.js';
+import { writeSamplesToDir } from '../samples-structure/write-samples-to-dir.js';
+import { entryExists } from '../utils.js';
+
+export type SamplerValidationFindingType =
+  | 'missing-artifact'
+  | 'unexpected-artifact'
+  | 'changed-artifact'
+  | 'stale-root-metadata'
+  | 'metadata-out-of-sync'
+  | 'invalid-json';
+
+export type SamplerValidationContentChangeType = 'add' | 'update' | 'delete';
+
+export type SamplerValidationContentChange = {
+  type: SamplerValidationContentChangeType;
+  pointer: string;
+  expected?: unknown;
+  actual?: unknown;
+};
+
+export type SamplerValidationFinding = {
+  type: SamplerValidationFindingType;
+  path: string;
+  message: string;
+  expected?: string;
+  actual?: string;
+  changes?: SamplerValidationContentChange[];
+};
+
+export type SamplerValidationReport = {
+  samplePath: string;
+  checkedArtifacts: number;
+  failures: SamplerValidationFinding[];
+};
+
+type ValidateSamplerOutputOptions = {
+  format: ThymianFormat;
+  emitter: ThymianEmitter;
+  samplePath: string;
+  /**
+   * Restrict the report to a single generated artifact, identified by its
+   * relative path (e.g. `meta.json`). `checkedArtifacts` is then 1 when the
+   * path is a known artifact and 0 when it is not, which the CLI uses to tell
+   * an in-sync artifact apart from an unknown one.
+   */
+  forPath?: string;
+};
+
+export async function createExpectedSamplerFiles({
+  format,
+  emitter,
+}: Omit<ValidateSamplerOutputOptions, 'samplePath'>): Promise<
+  Map<string, Buffer>
+> {
+  const samples = await generateSamplesForThymianFormat(format, emitter);
+  const generatedTypes = await generateTypesForThymianFormat(format);
+  const expectedFiles = new Map<string, Buffer>();
+
+  await writeSamplesToDir(samples, generatedTypes.keyToTransactionId, {
+    path: '',
+    mkdir: async (path) => {
+      void path;
+    },
+    writeToFile: async (path, content, encoding) => {
+      expectedFiles.set(
+        normalizeRelativePath(path),
+        Buffer.isBuffer(content)
+          ? content
+          : Buffer.from(content, encoding as BufferEncoding | undefined),
+      );
+    },
+  });
+
+  expectedFiles.set(
+    'types.d.ts',
+    Buffer.from(generatedTypesToString(generatedTypes)),
+  );
+  expectedFiles.set(
+    'tsconfig.json',
+    Buffer.from(JSON.stringify(tsConfig, null, 2)),
+  );
+
+  return expectedFiles;
+}
+
+export async function validateSamplerOutput({
+  format,
+  emitter,
+  samplePath,
+  forPath,
+}: ValidateSamplerOutputOptions): Promise<SamplerValidationReport> {
+  const expectedFiles = await createExpectedSamplerFiles({ format, emitter });
+  const actualFiles = await collectActualSamplerFiles(samplePath);
+  const failures: SamplerValidationFinding[] = [];
+
+  preserveRootMetadataTimestamp(expectedFiles, actualFiles);
+
+  for (const [path, expected] of expectedFiles) {
+    const actual = actualFiles.get(path);
+
+    if (!actual) {
+      failures.push({
+        type: 'missing-artifact',
+        path,
+        message: 'Expected generated sampler artifact is missing.',
+        expected: bufferToText(expected),
+      });
+      continue;
+    }
+
+    if (expected.equals(actual)) {
+      continue;
+    }
+
+    const type = mismatchTypeForChangedPath(path, expected, actual);
+    const changes = createJsonDiffDetails(expected, actual);
+
+    failures.push({
+      type,
+      path,
+      message: messageForChangedPath(type),
+      expected: bufferToText(expected),
+      actual: bufferToText(actual),
+      ...(changes ? { changes } : {}),
+    });
+  }
+
+  for (const [path, actual] of actualFiles) {
+    if (!expectedFiles.has(path)) {
+      failures.push({
+        type: 'unexpected-artifact',
+        path,
+        message: 'Unexpected non-hook file exists under the sampler directory.',
+        actual: bufferToText(actual),
+      });
+    }
+  }
+
+  if (forPath !== undefined) {
+    const known = expectedFiles.has(forPath) || actualFiles.has(forPath);
+
+    return {
+      samplePath,
+      checkedArtifacts: known ? 1 : 0,
+      failures: failures.filter((failure) => failure.path === forPath),
+    };
+  }
+
+  return {
+    samplePath,
+    checkedArtifacts: expectedFiles.size,
+    failures,
+  };
+}
+
+async function collectActualSamplerFiles(
+  samplePath: string,
+): Promise<Map<string, Buffer>> {
+  const actualFiles = new Map<string, Buffer>();
+
+  if (!(await entryExists(samplePath))) {
+    return actualFiles;
+  }
+
+  await collectActualFilesRecursive(samplePath, samplePath, actualFiles);
+
+  return actualFiles;
+}
+
+async function collectActualFilesRecursive(
+  rootPath: string,
+  currentPath: string,
+  actualFiles: Map<string, Buffer>,
+): Promise<void> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = join(currentPath, entry.name);
+
+    if (entry.isDirectory()) {
+      await collectActualFilesRecursive(rootPath, entryPath, actualFiles);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const relativePath = normalizeRelativePath(relative(rootPath, entryPath));
+
+    if (isHookFile(relativePath)) {
+      continue;
+    }
+
+    actualFiles.set(relativePath, await readFile(entryPath));
+  }
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function isHookFile(path: string): boolean {
+  const fileName = path.split('/').at(-1) ?? path;
+  return isHookFileName(fileName);
+}
+
+function mismatchTypeForChangedPath(
+  path: string,
+  expected: Buffer,
+  actual: Buffer,
+): Exclude<
+  SamplerValidationFindingType,
+  'missing-artifact' | 'unexpected-artifact'
+> {
+  if (isInvalidJsonChange(expected, actual)) {
+    return 'invalid-json';
+  }
+
+  if (path === 'meta.json') {
+    return 'stale-root-metadata';
+  }
+
+  if (path.endsWith('/meta.json')) {
+    return 'metadata-out-of-sync';
+  }
+
+  return 'changed-artifact';
+}
+
+function messageForChangedPath(
+  type: Exclude<
+    SamplerValidationFindingType,
+    'missing-artifact' | 'unexpected-artifact'
+  >,
+): string {
+  if (type === 'invalid-json') {
+    return 'Generated JSON artifact is not valid JSON.';
+  }
+
+  if (type === 'stale-root-metadata') {
+    return 'Root sampler metadata does not match the current API format.';
+  }
+
+  if (type === 'metadata-out-of-sync') {
+    return 'Nested sampler metadata does not match the expected generated output.';
+  }
+
+  return 'Generated sampler artifact content differs from expected output.';
+}
+
+function isInvalidJsonChange(expected: Buffer, actual: Buffer): boolean {
+  const expectedJson = parseJsonValue(expected);
+  const actualJson = parseJsonValue(actual);
+
+  return (
+    expectedJson.valid &&
+    isJsonObjectLike(expectedJson.value) &&
+    !actualJson.valid
+  );
+}
+
+function createJsonDiffDetails(
+  expected: Buffer,
+  actual: Buffer,
+): SamplerValidationContentChange[] | undefined {
+  const expectedJson = parseJsonValue(expected);
+  const actualJson = parseJsonValue(actual);
+
+  if (!expectedJson.valid || !actualJson.valid) {
+    return undefined;
+  }
+
+  if (
+    !isJsonObjectLike(expectedJson.value) ||
+    !isJsonObjectLike(actualJson.value)
+  ) {
+    return undefined;
+  }
+
+  const expectedValue = expectedJson.value;
+  const actualValue = actualJson.value;
+
+  return diffJson(expectedValue, actualValue).map((change) =>
+    mapJsonMagicChange(change, expectedValue, actualValue),
+  );
+}
+
+function mapJsonMagicChange(
+  change: Difference<Record<string, unknown>>,
+  expected: Record<string, unknown>,
+  actual: Record<string, unknown>,
+): SamplerValidationContentChange {
+  const pointer = jsonPointerFromPath(change.path);
+
+  if (change.type === 'add') {
+    return {
+      type: change.type,
+      pointer,
+      actual: readJsonPath(actual, change.path),
+    };
+  }
+
+  if (change.type === 'delete') {
+    return {
+      type: change.type,
+      pointer,
+      expected: readJsonPath(expected, change.path),
+    };
+  }
+
+  return {
+    type: change.type,
+    pointer,
+    expected: readJsonPath(expected, change.path),
+    actual: readJsonPath(actual, change.path),
+  };
+}
+
+function preserveRootMetadataTimestamp(
+  expectedFiles: Map<string, Buffer>,
+  actualFiles: Map<string, Buffer>,
+): void {
+  const expected = expectedFiles.get('meta.json');
+  const actual = actualFiles.get('meta.json');
+
+  if (!expected || !actual) {
+    return;
+  }
+
+  const expectedJson = parseJsonObject(expected);
+  const actualJson = parseJsonObject(actual);
+
+  if (!expectedJson || !actualJson) {
+    return;
+  }
+
+  const expectedVersion = readVersionHash(expectedJson);
+  const actualVersion = readVersionHash(actualJson);
+
+  if (!expectedVersion || expectedVersion !== actualVersion) {
+    return;
+  }
+
+  expectedJson.version = actualJson.version;
+  expectedFiles.set('meta.json', Buffer.from(JSON.stringify(expectedJson)));
+}
+
+function readVersionHash(value: Record<string, unknown>): string | undefined {
+  const version = value.version;
+
+  if (!version || typeof version !== 'object' || Array.isArray(version)) {
+    return undefined;
+  }
+
+  const hash = (version as Record<string, unknown>).version;
+
+  return typeof hash === 'string' ? hash : undefined;
+}
+
+function parseJsonObject(buffer: Buffer): Record<string, unknown> | undefined {
+  const parsed = parseJsonValue(buffer);
+
+  if (!parsed.valid || !isJsonObject(parsed.value)) {
+    return undefined;
+  }
+
+  return parsed.value;
+}
+
+function parseJsonValue(
+  buffer: Buffer,
+): { valid: true; value: unknown } | { valid: false } {
+  try {
+    return {
+      valid: true,
+      value: JSON.parse(buffer.toString('utf8')),
+    };
+  } catch {
+    return { valid: false };
+  }
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isJsonObjectLike(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
+function readJsonPath(value: unknown, path: string[]): unknown {
+  let current = value;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+function jsonPointerFromPath(path: string[]): string {
+  if (path.length === 0) {
+    return '';
+  }
+
+  return `/${path.map(escapeJsonPointerSegment).join('/')}`;
+}
+
+function escapeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function bufferToText(buffer: Buffer): string {
+  return buffer.toString('utf8');
+}

--- a/packages/plugin-sampler/src/validation/validate-sampler-output.ts
+++ b/packages/plugin-sampler/src/validation/validate-sampler-output.ts
@@ -371,7 +371,19 @@ function preserveRootMetadataTimestamp(
     return;
   }
 
-  expectedJson.version = actualJson.version;
+  const expectedVersionObject = expectedJson.version;
+  const actualVersionObject = actualJson.version;
+
+  if (
+    !isJsonObject(expectedVersionObject) ||
+    !isJsonObject(actualVersionObject)
+  ) {
+    return;
+  }
+
+  // Only the timestamp is allowed to differ run-to-run; copy just that field so
+  // drift in any other `version.*` field (added later) is still validated.
+  expectedVersionObject.timestamp = actualVersionObject.timestamp;
   expectedFiles.set('meta.json', Buffer.from(JSON.stringify(expectedJson)));
 }
 

--- a/packages/plugin-sampler/src/validation/validate-sampler-output.ts
+++ b/packages/plugin-sampler/src/validation/validate-sampler-output.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 
 import { diff as diffJson, type Difference } from '@scalar/json-magic/diff';
@@ -11,7 +11,6 @@ import {
   generateTypesForThymianFormat,
 } from '../hooks/generate-request-types.js';
 import { writeSamplesToDir } from '../samples-structure/write-samples-to-dir.js';
-import { entryExists } from '../utils.js';
 
 export type SamplerValidationFindingType =
   | 'missing-artifact'
@@ -172,7 +171,17 @@ async function collectActualSamplerFiles(
 ): Promise<Map<string, Buffer>> {
   const actualFiles = new Map<string, Buffer>();
 
-  if (!(await entryExists(samplePath))) {
+  // A missing path — or a non-directory sitting where the samples directory is
+  // expected — means nothing generated is present. Treat both as an empty
+  // actual set so drift is reported instead of `readdir` crashing on ENOTDIR.
+  let stats;
+  try {
+    stats = await stat(samplePath);
+  } catch {
+    return actualFiles;
+  }
+
+  if (!stats.isDirectory()) {
     return actualFiles;
   }
 

--- a/packages/plugin-sampler/src/validation/validate-sampler-output.ts
+++ b/packages/plugin-sampler/src/validation/validate-sampler-output.ts
@@ -10,7 +10,6 @@ import {
   generatedTypesToString,
   generateTypesForThymianFormat,
 } from '../hooks/generate-request-types.js';
-import { tsConfig } from '../hooks/ts-config.js';
 import { writeSamplesToDir } from '../samples-structure/write-samples-to-dir.js';
 import { entryExists } from '../utils.js';
 
@@ -82,16 +81,10 @@ export async function createExpectedSamplerFiles({
           : Buffer.from(content, encoding as BufferEncoding | undefined),
       );
     },
+    typeArtifacts: {
+      typesContent: generatedTypesToString(generatedTypes),
+    },
   });
-
-  expectedFiles.set(
-    'types.d.ts',
-    Buffer.from(generatedTypesToString(generatedTypes)),
-  );
-  expectedFiles.set(
-    'tsconfig.json',
-    Buffer.from(JSON.stringify(tsConfig, null, 2)),
-  );
 
   return expectedFiles;
 }
@@ -150,12 +143,20 @@ export async function validateSamplerOutput({
   }
 
   if (forPath !== undefined) {
-    const known = expectedFiles.has(forPath) || actualFiles.has(forPath);
+    // Normalize so a platform-native argument (e.g. `a\b.json` on Windows)
+    // matches the `/`-joined keys used throughout the report.
+    const normalizedForPath = normalizeRelativePath(forPath);
+    // Only a generated (expected) artifact counts as "known" — pointing
+    // `--for-path` at an on-disk-only file must surface as an unknown-path
+    // usage error, not silently scope to that extra file.
+    const known = expectedFiles.has(normalizedForPath);
 
     return {
       samplePath,
       checkedArtifacts: known ? 1 : 0,
-      failures: failures.filter((failure) => failure.path === forPath),
+      failures: failures.filter(
+        (failure) => failure.path === normalizedForPath,
+      ),
     };
   }
 
@@ -231,7 +232,7 @@ function mismatchTypeForChangedPath(
   }
 
   if (path === 'meta.json') {
-    return 'stale-root-metadata';
+    return rootMetadataMismatchType(expected, actual);
   }
 
   if (path.endsWith('/meta.json')) {
@@ -239,6 +240,26 @@ function mismatchTypeForChangedPath(
   }
 
   return 'changed-artifact';
+}
+
+// The root `meta.json` is only "stale" when the format hash (`/version/version`)
+// differs — that means the artifacts were generated against a different API
+// format. Drift in other root fields (e.g. `types`, `transactions`) is an
+// ordinary content change and should not claim the metadata is out of date.
+function rootMetadataMismatchType(
+  expected: Buffer,
+  actual: Buffer,
+): 'stale-root-metadata' | 'changed-artifact' {
+  const expectedObject = parseJsonObject(expected);
+  const actualObject = parseJsonObject(actual);
+
+  if (!expectedObject || !actualObject) {
+    return 'stale-root-metadata';
+  }
+
+  return readVersionHash(expectedObject) !== readVersionHash(actualObject)
+    ? 'stale-root-metadata'
+    : 'changed-artifact';
 }
 
 function messageForChangedPath(
@@ -267,9 +288,7 @@ function isInvalidJsonChange(expected: Buffer, actual: Buffer): boolean {
   const actualJson = parseJsonValue(actual);
 
   return (
-    expectedJson.valid &&
-    isJsonObjectLike(expectedJson.value) &&
-    !actualJson.valid
+    expectedJson.valid && isJsonObject(expectedJson.value) && !actualJson.valid
   );
 }
 
@@ -284,10 +303,7 @@ function createJsonDiffDetails(
     return undefined;
   }
 
-  if (
-    !isJsonObjectLike(expectedJson.value) ||
-    !isJsonObjectLike(actualJson.value)
-  ) {
+  if (!isJsonObject(expectedJson.value) || !isJsonObject(actualJson.value)) {
     return undefined;
   }
 
@@ -396,10 +412,6 @@ function parseJsonValue(
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isJsonObjectLike(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object';
 }
 
 function readJsonPath(value: unknown, path: string[]): unknown {

--- a/packages/plugin-sampler/test/validate-sampler-output.test.ts
+++ b/packages/plugin-sampler/test/validate-sampler-output.test.ts
@@ -68,8 +68,9 @@ describe('validateSamplerOutput', () => {
     await writeExpectedFiles(tempDir, emitter);
     await writeFile(join(tempDir, 'orphan.json'), '{}');
     await writeFile(join(tempDir, 'custom.beforeEach.ts'), 'export default {}');
-    // `notbeforeEach.ts` matches the sampler's (substring) hook loading, so it
-    // is treated as a hook and must not be flagged as an unexpected artifact.
+    // `notbeforeEach.ts` is NOT a hook: the anchored hook pattern only matches
+    // `beforeEach.<ext>` at a boundary (start or after `.`/`/`), so it must be
+    // flagged as an unexpected artifact like any other non-hook file.
     await writeFile(join(tempDir, 'notbeforeEach.ts'), 'export default {}');
 
     const report = await validateSamplerOutput({
@@ -78,12 +79,19 @@ describe('validateSamplerOutput', () => {
       samplePath: tempDir,
     });
 
-    expect(report.failures).toEqual([
-      expect.objectContaining({
-        type: 'unexpected-artifact',
-        path: 'orphan.json',
-      }),
-    ]);
+    expect(report.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'unexpected-artifact',
+          path: 'orphan.json',
+        }),
+        expect.objectContaining({
+          type: 'unexpected-artifact',
+          path: 'notbeforeEach.ts',
+        }),
+      ]),
+    );
+    expect(report.failures).toHaveLength(2);
   }, 30_000);
 
   it('reports missing artifacts without creating a missing samples directory', async () => {

--- a/packages/plugin-sampler/test/validate-sampler-output.test.ts
+++ b/packages/plugin-sampler/test/validate-sampler-output.test.ts
@@ -197,6 +197,36 @@ describe('validateSamplerOutput', () => {
     ]);
   }, 30_000);
 
+  it('reports a changed artifact when non-hash root metadata drifts', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const metaPath = join(tempDir, 'meta.json');
+    const meta = JSON.parse(await readFile(metaPath, 'utf8'));
+    // Keep the format hash (`/version/version`) intact and drift an unrelated
+    // field: this is an ordinary content change, not stale format metadata.
+    meta.transactions = { ...(meta.transactions ?? {}), injected: 'drift' };
+    await writeFile(metaPath, JSON.stringify(meta));
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'changed-artifact',
+        path: 'meta.json',
+        changes: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'add',
+            pointer: '/transactions/injected',
+          }),
+        ]),
+      }),
+    ]);
+  }, 30_000);
+
   it('ignores timestamp-only root metadata differences', async () => {
     await writeExpectedFiles(tempDir, emitter);
 

--- a/packages/plugin-sampler/test/validate-sampler-output.test.ts
+++ b/packages/plugin-sampler/test/validate-sampler-output.test.ts
@@ -1,0 +1,291 @@
+import { mkdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { ThymianEmitter } from '@thymian/core';
+import { createThymianFormatWithTransactions } from '@thymian/core-testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createExpectedSamplerFiles,
+  validateSamplerOutput,
+} from '../src/validation/validate-sampler-output.js';
+import { createTempDir } from './utils.js';
+
+const format = createThymianFormatWithTransactions(3);
+
+describe('validateSamplerOutput', () => {
+  let tempDir!: string;
+  let emitter!: ThymianEmitter;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir('validateSamplerOutput-');
+    emitter = new ThymianEmitter();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns no failures when generated artifacts are in sync', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.checkedArtifacts).toBeGreaterThan(0);
+    expect(report.failures).toEqual([]);
+  }, 30_000);
+
+  it('reports changed and missing generated artifacts', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+    await writeFile(join(tempDir, 'types.d.ts'), 'changed');
+    await unlink(join(tempDir, 'tsconfig.json'));
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'changed-artifact',
+          path: 'types.d.ts',
+        }),
+        expect.objectContaining({
+          type: 'missing-artifact',
+          path: 'tsconfig.json',
+        }),
+      ]),
+    );
+  }, 30_000);
+
+  it('reports unexpected artifacts while ignoring hook files', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+    await writeFile(join(tempDir, 'orphan.json'), '{}');
+    await writeFile(join(tempDir, 'custom.beforeEach.ts'), 'export default {}');
+    // `notbeforeEach.ts` matches the sampler's (substring) hook loading, so it
+    // is treated as a hook and must not be flagged as an unexpected artifact.
+    await writeFile(join(tempDir, 'notbeforeEach.ts'), 'export default {}');
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'unexpected-artifact',
+        path: 'orphan.json',
+      }),
+    ]);
+  }, 30_000);
+
+  it('reports missing artifacts without creating a missing samples directory', async () => {
+    const samplePath = join(tempDir, 'missing');
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath,
+    });
+
+    expect(report.failures.length).toBe(report.checkedArtifacts);
+    expect(report.failures[0]).toEqual(
+      expect.objectContaining({
+        type: 'missing-artifact',
+      }),
+    );
+
+    await expect(stat(samplePath)).rejects.toThrow();
+  }, 30_000);
+
+  it('reports stale root metadata when the format hash differs', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const metaPath = join(tempDir, 'meta.json');
+    const meta = JSON.parse(await readFile(metaPath, 'utf8'));
+    meta.version.version = 'old-format-hash';
+    await writeFile(metaPath, JSON.stringify(meta));
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'stale-root-metadata',
+        path: 'meta.json',
+        changes: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'update',
+            pointer: '/version/version',
+          }),
+        ]),
+      }),
+    ]);
+  }, 30_000);
+
+  it('reports invalid JSON for generated JSON artifacts', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    await writeFile(join(tempDir, 'tsconfig.json'), '{');
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'invalid-json',
+        path: 'tsconfig.json',
+      }),
+    ]);
+  }, 30_000);
+
+  it('reports nested metadata that is out of sync', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const expectedFiles = await createExpectedSamplerFiles({ format, emitter });
+    const nestedMetaPath = [...expectedFiles.keys()].find(
+      (path) => path !== 'meta.json' && path.endsWith('/meta.json'),
+    );
+
+    if (!nestedMetaPath) {
+      throw new Error('Expected at least one nested sampler metadata file.');
+    }
+
+    await writeFile(
+      join(tempDir, nestedMetaPath),
+      JSON.stringify({ version: 'changed' }),
+    );
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'metadata-out-of-sync',
+        path: nestedMetaPath,
+        changes: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'add',
+            pointer: '/version',
+          }),
+        ]),
+      }),
+    ]);
+  }, 30_000);
+
+  it('ignores timestamp-only root metadata differences', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const metaPath = join(tempDir, 'meta.json');
+    const meta = JSON.parse(await readFile(metaPath, 'utf8'));
+    meta.version.timestamp = 1_234_567;
+    await writeFile(metaPath, JSON.stringify(meta));
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    expect(report.failures).toEqual([]);
+  }, 30_000);
+
+  it('returns full, untruncated change lists and content', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const replacement: Record<string, number> = {};
+    for (let i = 0; i < 30; i++) {
+      replacement[`key-${i}`] = i;
+    }
+    await writeFile(join(tempDir, 'meta.json'), JSON.stringify(replacement));
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+    });
+
+    const finding = report.failures.find((f) => f.path === 'meta.json');
+
+    expect(finding?.changes?.length).toBeGreaterThan(20);
+    expect(finding?.expected?.endsWith('...')).toBe(false);
+  }, 30_000);
+
+  it('scopes the report to a single artifact with forPath', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+    await writeFile(join(tempDir, 'types.d.ts'), 'changed');
+    await writeFile(join(tempDir, 'orphan.json'), '{}');
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+      forPath: 'types.d.ts',
+    });
+
+    expect(report.checkedArtifacts).toBe(1);
+    expect(report.failures).toEqual([
+      expect.objectContaining({
+        type: 'changed-artifact',
+        path: 'types.d.ts',
+      }),
+    ]);
+  }, 30_000);
+
+  it('reports an in-sync artifact as checked with no failures via forPath', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+      forPath: 'tsconfig.json',
+    });
+
+    expect(report.checkedArtifacts).toBe(1);
+    expect(report.failures).toEqual([]);
+  }, 30_000);
+
+  it('marks an unknown forPath as not checked', async () => {
+    await writeExpectedFiles(tempDir, emitter);
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath: tempDir,
+      forPath: 'does-not-exist.json',
+    });
+
+    expect(report.checkedArtifacts).toBe(0);
+    expect(report.failures).toEqual([]);
+  }, 30_000);
+});
+
+async function writeExpectedFiles(
+  samplePath: string,
+  emitter: ThymianEmitter,
+): Promise<void> {
+  const expectedFiles = await createExpectedSamplerFiles({ format, emitter });
+
+  for (const [relativePath, content] of expectedFiles) {
+    const filePath = join(samplePath, relativePath);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content);
+  }
+}

--- a/packages/plugin-sampler/test/validate-sampler-output.test.ts
+++ b/packages/plugin-sampler/test/validate-sampler-output.test.ts
@@ -113,6 +113,24 @@ describe('validateSamplerOutput', () => {
     await expect(stat(samplePath)).rejects.toThrow();
   }, 30_000);
 
+  it('treats a non-directory samples path as an empty actual set', async () => {
+    const samplePath = join(tempDir, 'samples-as-file');
+    await writeFile(samplePath, 'not a directory');
+
+    const report = await validateSamplerOutput({
+      format,
+      emitter,
+      samplePath,
+    });
+
+    // A file where the samples directory is expected must not crash `readdir`;
+    // every expected artifact should simply be reported as missing.
+    expect(report.failures.length).toBe(report.checkedArtifacts);
+    expect(
+      report.failures.every((failure) => failure.type === 'missing-artifact'),
+    ).toBe(true);
+  }, 30_000);
+
   it('reports stale root metadata when the format hash differs', async () => {
     await writeExpectedFiles(tempDir, emitter);
 


### PR DESCRIPTION
## Summary

Adds `thymian sampler validate` — a read-only command that verifies the
generated sampler artifacts committed in the repo still match what the
sampler would produce for the current API specification. It never writes
files, exits non-zero on any drift, and gives file-specific diagnostics,
so it works for local pre-commit checks and CI enforcement.

## How it works

- Computes the *expected* output in-memory by reusing the real generation
  path (`generateSamplesForThymianFormat` + type generation +
  `writeSamplesToDir`), then diffs it against the files on disk. To keep
  this side-effect-free, `writeSamplesToDir` gained injectable
  `mkdir`/`writeToFile` seams — the validator captures output into a map
  instead of touching the filesystem.
- Classifies each mismatch: `missing-artifact`, `changed-artifact`,
  `stale-root-metadata`, `metadata-out-of-sync`, `unexpected-artifact`,
  `invalid-json`. JSON artifacts get pointer-level diffs via
  `@scalar/json-magic`; timestamp-only root-metadata differences are
  ignored to avoid false positives.
- Diagnostics reuse the core report styling (`SEVERITY_COLORS` /
  `SEVERITY_SYMBOLS`) so output is consistent with the rest of the CLI —
  **without** constructing a `Report`.

## Command surface

| Invocation | Behavior |
|---|---|
| `sampler validate` | Summary — lists each out-of-sync artifact (`<type>: <path>`) and a checked/failed count. |
| `sampler validate --full-diffs` | Expands every out-of-sync artifact to its full diff. |
| `sampler validate --for-path <path>` | Scopes the whole report (output + exit code) to one artifact; errors if the path is unknown. |
| `sampler validate --json` | Machine-readable report on stdout for CI/agents; exit code preserved. |

Exit codes: `0` when in sync, `1` on drift, `2` on usage errors (e.g.
unknown `--for-path`).

## Notes / decisions

- **No fix-command hint** (e.g. "run `sampler generate`") in the output —
  intentional; that guidance is handled as a follow-up, not by this command.
- **Human vs. machine split:** `--json` covers agents/CI; `--full-diffs`
  and `--for-path` cover human inspection. The default stays a compact
  summary rather than dumping diffs.
- Hook-file detection is shared with the sampler's actual hook loader
  (single `isHookFileName` predicate) so validate can't flag a file the
  sampler loads as a hook.

## Testing

- Unit tests for the validation logic (in-sync, missing/changed/unexpected,
  stale/nested metadata, invalid JSON, `--for-path` scoping, full content).
- E2E tests covering the CLI surface: default summary, `--full-diffs`,
  `--for-path` (scoped + unknown), and both `--json` cases.
- Verified manually against the built CLI.