### PR TITLE
docs/ci hygiene: fixes from the 2026-07-20 drift analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - rework-arch
   pull_request: {}
   workflow_dispatch:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - rework-arch
   pull_request: {}
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,24 +4,32 @@
 
 When making commits, use one of the following scopes to indicate the area of the codebase your change affects:
 
-| Scope              | Description                                                       |
-| ------------------ | ----------------------------------------------------------------- |
-| repo               | Changes affecting repository-wide configuration, tooling, or docs |
-| release            | Release-related changes                                           |
-| deps               | Dependency updates and changes                                    |
-| cli                | Command-line interface and related commands                       |
-| core               | Core framework logic, plugin system, and main APIs                |
-| format-validator   | Plugin for format validation                                      |
-| http-linter        | Plugin for HTTP linting                                           |
-| http-testing       | Library for HTTP testing utilities                                |
-| openapi            | Plugin for OpenAPI support                                        |
-| reporter           | Plugin for reporting features                                     |
-| request-dispatcher | Plugin for request dispatching                                    |
-| rfc-9110-rules     | Library for reusable HTTP rules based on RFC 9110                 |
-| sampler            | Plugin for sampling logic                                         |
-| test-utils         | Shared test utilities                                             |
-| websocket-proxy    | Plugin for WebSocket proxy functionality                          |
-| astro-docs         | Changes to the Astro/Starlight documentation                      |
+> The authoritative list is `scope-enum` in [commitlint.config.js](commitlint.config.js) —
+> commits with any other (or no) scope are rejected by the commit hook. Keep this table in
+> sync when adding or renaming packages.
+
+| Scope                            | Description                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| repo                             | Repository-wide configuration, tooling, workflows, or docs (incl. the Astro docs site) |
+| release                          | Release tooling and pipelines                                                          |
+| deps                             | Dependency updates and changes                                                         |
+| cli                              | Cross-cutting CLI concerns                                                             |
+| thymian                          | The `thymian` CLI product package                                                      |
+| common-cli                       | Shared CLI base library (`@thymian/common-cli`)                                        |
+| core                             | Core framework: workflows, contracts, rule system (`@thymian/core`)                    |
+| core-testing                     | Test utilities for core (`@thymian/core-testing`)                                      |
+| plugin-http-linter               | Static lint plugin                                                                     |
+| plugin-http-tester               | Live HTTP testing plugin                                                               |
+| plugin-http-analyzer             | Traffic analysis plugin                                                                |
+| plugin-har                       | HAR loader plugin                                                                      |
+| plugin-openapi                   | OpenAPI loader plugin                                                                  |
+| plugin-reporter                  | Report file formatters plugin                                                          |
+| plugin-request-dispatcher        | HTTP request dispatch plugin                                                           |
+| plugin-sampler                   | Sample/request generation plugin                                                       |
+| plugin-websocket-proxy           | WebSocket remote-plugin transport                                                      |
+| rules-rfc-9110                   | RFC 9110 rule set                                                                      |
+| rules-api-description-validation | API description validation rule set                                                    |
+| e2e                              | End-to-end test workspace                                                              |
 
 Use these scopes in your commit messages for clarity and traceability.
 
@@ -35,13 +43,17 @@ Refer to this list when contributing to ensure consistent commit messages.
 
 ## Module boundaries
 
+> Enforced by `@nx/enforce-module-boundaries` in [eslint.config.mjs](eslint.config.mjs) —
+> that file is the source of truth.
+
 ### Dimension "scope"
 
-| Tag            | Allowed Dependencies                      | Description                                                    |
-| -------------- | ----------------------------------------- | -------------------------------------------------------------- |
-| `scope:cli`    | `scope:core`, `scope:cli`                 | CLI functionality (package.json dependencies are runtime only) |
-| `scope:core`   | `scope:core`                              | Core functionlity like event system or Thymian format types    |
-| `scope:plugin` | `scope:core`, `scope:cli`, `scope:plugin` | Plugins                                                        |
+| Tag            | Allowed Dependencies                                     | Description                                                                                                         |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `scope:cli`    | `scope:core`, `scope:cli`, `scope:plugin`, `scope:rules` | CLI packages (the `thymian` app aggregates plugins and rule sets)                                                   |
+| `scope:core`   | `scope:core`                                             | Core framework (contracts, rule system, Thymian format)                                                             |
+| `scope:plugin` | `scope:core`, `scope:cli`, `scope:plugin`                | Plugins (note: plugins may **not** depend on `scope:rules` — rules reach plugins via the core loader, per ADR-0009) |
+| `scope:rules`  | constrained via `type`/`npm` dimensions                  | Rule set packages; depend only on `@thymian/core` in practice                                                       |
 
 ### Dimension "type"
 
@@ -50,8 +62,18 @@ Refer to this list when contributing to ensure consistent commit messages.
 | `type:app`         | All types                      | Executable packages or nx apps                                                                               |
 | `type:lib`         | `type:lib`                     | A library                                                                                                    |
 | `type:lib-feature` | `type:lib`, `type:lib-feature` | Features add functionality to libraries. E.g. publishable config, rule-sets or just splitted out source code |
-| `type:testing`     | All types                      | Testing libraries that should be accessible to all other projects for testing purposes                       |
 | `type:e2e`         | All types                      | End-to-end tests and testing utilities                                                                       |
+
+In **test files** (`**/test/**`, `*.test.ts`, `*.spec.ts`) every constraint additionally
+allows `type:testing`, so testing libraries are reachable from any project's tests without
+being a production dependency.
+
+### Dimension "npm"
+
+| Tag           | Allowed Dependencies        | Description                                              |
+| ------------- | --------------------------- | -------------------------------------------------------- |
+| `npm:public`  | `npm:public`                | Published packages may only depend on published packages |
+| `npm:private` | `npm:public`, `npm:private` | Private projects may depend on anything                  |
 
 ## Releases
 
@@ -263,7 +285,9 @@ No commits since last release match conventional commit format or no changes det
 Check:
 
 1. `npm` environment is configured with approval gates
-2. `NPM_TOKEN` secret is set
+2. npm **trusted publishing (OIDC)** is configured for every published package — the
+   workflow uses `id-token: write` and no npm token (`NODE_AUTH_TOKEN` is deliberately
+   empty); brand-new packages need a one-time `npm run bootstrap-npm-packages`
 3. User is in allowlist
 4. Release tag format is valid semver
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,12 @@ Refer to this list when contributing to ensure consistent commit messages.
 
 ### Dimension "type"
 
-| Tag                | Allowed Dependencies           | Description                                                                                                  |
-| ------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `type:app`         | All types                      | Executable packages or nx apps                                                                               |
-| `type:lib`         | `type:lib`                     | A library                                                                                                    |
-| `type:lib-feature` | `type:lib`, `type:lib-feature` | Features add functionality to libraries. E.g. publishable config, rule-sets or just splitted out source code |
-| `type:e2e`         | All types                      | End-to-end tests and testing utilities                                                                       |
+| Tag                | Allowed Dependencies           | Description                                                                                               |
+| ------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `type:app`         | All types                      | Executable packages or nx apps                                                                            |
+| `type:lib`         | `type:lib`                     | A library                                                                                                 |
+| `type:lib-feature` | `type:lib`, `type:lib-feature` | Features add functionality to libraries. E.g. publishable config, rule-sets or just split out source code |
+| `type:e2e`         | All types                      | End-to-end tests and testing utilities                                                                    |
 
 In **test files** (`**/test/**`, `*.test.ts`, `*.spec.ts`) every constraint additionally
 allows `type:testing`, so testing libraries are reachable from any project's tests without

--- a/astro-docs/package.json
+++ b/astro-docs/package.json
@@ -19,7 +19,6 @@
     "starlight-blog": "^0.28.0",
     "starlight-links-validator": "^0.25.2",
     "starlight-llms-txt": "^0.11.0",
-    "starlight-versions": "^0.9.1",
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {

--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -131,7 +131,7 @@ C4Container
 | HTTP Analyzer                    | `packages/plugin-http-analyzer`             | `@thymian/plugin-http-analyzer`             |
 | OpenAPI Loader                   | `packages/plugin-openapi`                   | `@thymian/plugin-openapi`                   |
 | Text / CSV / Markdown Reporter   | `packages/plugin-reporter`                  | `@thymian/plugin-reporter`                  |
-| HAR Loader                       | `packages/plugin-http-analyzer`             | (built into the analyzer plugin)            |
+| HAR Loader                       | `packages/plugin-har`                       | `@thymian/plugin-har`                       |
 | Request Dispatcher               | `packages/plugin-request-dispatcher`        | `@thymian/plugin-request-dispatcher`        |
 | Sampler                          | `packages/plugin-sampler`                   | `@thymian/plugin-sampler`                   |
 | WebSocket Proxy                  | `packages/plugin-websocket-proxy`           | `@thymian/plugin-websocket-proxy`           |

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "starlight-blog": "^0.28.0",
         "starlight-links-validator": "^0.25.2",
         "starlight-llms-txt": "^0.11.0",
-        "starlight-versions": "^0.9.1",
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
@@ -18381,19 +18380,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
-      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -18756,14 +18742,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.17"
-      }
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/forwarded": {
@@ -23822,36 +23800,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-frontmatter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
-      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-extension-frontmatter": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
@@ -24293,22 +24241,6 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-frontmatter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
-      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
-      "license": "MIT",
-      "dependencies": {
-        "fault": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -29901,22 +29833,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
-      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-directive": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
@@ -29926,22 +29842,6 @@
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
         "micromark-extension-directive": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-frontmatter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
-      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-frontmatter": "^2.0.0",
-        "micromark-extension-frontmatter": "^2.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -31418,31 +31318,6 @@
       "peerDependencies": {
         "@astrojs/starlight": ">=0.41.0",
         "astro": "^7.0.0"
-      }
-    },
-    "node_modules/starlight-versions": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/starlight-versions/-/starlight-versions-0.9.1.tgz",
-      "integrity": "sha512-wtYZhlcWcKsnyTO0BZoWXHzHUrNIvSr5ukEMLg3RFKesFEEcMepngn15Igw5pj8DBlkKMo7bBhF2fR0bfiXcpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@pagefind/default-ui": "^1.3.0",
-        "github-slugger": "^2.0.0",
-        "mdast-util-mdx-jsx": "^3.2.0",
-        "mdast-util-mdxjs-esm": "^2.0.1",
-        "remark": "^15.0.1",
-        "remark-directive": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-mdx": "^3.1.1",
-        "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3",
-        "yaml": "^2.8.2"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "@astrojs/starlight": ">=0.39.0"
       }
     },
     "node_modules/statuses": {
@@ -35067,26 +34942,9 @@
       },
       "devDependencies": {
         "@oclif/test": "^4.1.13",
-        "@types/node": "^18.19.112",
+        "@types/node": "^22.15.1",
         "tsx": "^4.20.3"
       }
-    },
-    "packages/thymian/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "packages/thymian/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/packages/thymian/package.json
+++ b/packages/thymian/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@oclif/test": "^4.1.13",
-    "@types/node": "^18.19.112",
+    "@types/node": "^22.15.1",
     "tsx": "^4.20.3"
   }
 }


### PR DESCRIPTION
Small hygiene sweep from the brownfield drift analysis (thymianofficial/thymian-internal#404):

- **CONTRIBUTING.md**: commit-scope table synced with `commitlint.config.js` (the old table listed pre-rewrite scopes the hook now rejects); module-boundary tables synced with `eslint.config.mjs` (adds `scope:rules`, `npm:*` dimension, test-file relaxation); troubleshooting now describes OIDC trusted publishing instead of `NPM_TOKEN`.
- **arc42 §5**: HAR Loader container now maps to `plugin-har` (extracted 2026-04-17), no longer 'built into the analyzer plugin'.
- **CI**: residual `rework-arch` push triggers removed from `ci.yaml`/`e2e.yml` (the rewrite landed on main in April).
- **deps**: unused `starlight-versions` removed (installed but never wired into the Starlight plugins array); `@types/node` in `packages/thymian` aligned with the workspace (^18 → ^22).

Docs/config only — no runtime code changes.