### PR TITLE
feat(thymian): Stabilize, widen, and harden the new report model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,10 @@ jobs:
       fail-fast: false
       matrix:
         version: [20, 22, 24]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # Pin Windows to 2022: windows-latest now maps to the VS 2026 (v18) image,
+        # which node-gyp 10 (bundled with Node 20/22's npm) cannot detect, breaking
+        # any better-sqlite3 source-build fallback. VS 2022 is detectable.
+        os: [ubuntu-latest, windows-2022, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/packages/common-cli/src/render/cli-report.ts
+++ b/packages/common-cli/src/render/cli-report.ts
@@ -3,9 +3,6 @@ import {
   type AnalyzeExecution,
   buildRuleIndex,
   createLocationResolver,
-  isAnalyzeExecution,
-  isLintExecution,
-  isTestCaseExecution,
   type LintExecution,
   type Report,
   resolveExecutionSeverity,
@@ -36,7 +33,7 @@ export function collectSeverityCounts(
 
   for (const run of report.runs) {
     const ruleIndex = buildRuleIndex(run.rules);
-    for (const { execution } of walkExecutions(run.executions)) {
+    for (const execution of walkExecutions(run.executions)) {
       const severity = resolveExecutionSeverity(execution, ruleIndex);
       if (severity !== undefined) {
         counts[severity] += 1;
@@ -91,10 +88,9 @@ export function renderReport(
         1,
       );
 
-      const executions = run.executions.filter(
-        (execution) =>
-          isLintExecution(execution) || isAnalyzeExecution(execution),
-      );
+      // `ToolRun` is a discriminated union on `runType`, so a lint/analyze run's
+      // executions are already lint/analyze — no runtime filtering needed.
+      const executions: (LintExecution | AnalyzeExecution)[] = run.executions;
 
       lines.push(...render(executions, ruleIndex, resolveLocation, run));
     } else {
@@ -104,9 +100,7 @@ export function renderReport(
         1,
       );
 
-      const executions = run.executions.filter((execution) =>
-        isTestCaseExecution(execution),
-      );
+      const executions: TestCaseExecution[] = run.executions;
 
       lines.push(...render(executions, ruleIndex, resolveLocation, run));
     }

--- a/packages/common-cli/src/workflow-outcome.ts
+++ b/packages/common-cli/src/workflow-outcome.ts
@@ -32,7 +32,7 @@ export function classificationToExitCode(
 }
 
 function collectExecutions(report: Report): Execution[] {
-  return report.runs.flatMap((run) => run.executions ?? []);
+  return report.runs.flatMap((run): Execution[] => run.executions ?? []);
 }
 
 export function classifyReport(

--- a/packages/core/src/events/report.event.ts
+++ b/packages/core/src/events/report.event.ts
@@ -43,14 +43,14 @@ const findingSchema = {
 } as unknown as JSONSchemaType<unknown>;
 
 /**
- * `Execution` schema. Report Format v4 (issue #323/#334) replaced the
- * hierarchical `Execution.children`/`nestedFindings` shape with a flat,
- * per-runType union: `LintExecution`/`AnalyzeExecution` (`location` +
- * `findings`) and `TestCaseExecution` (`name` + `steps`, no `location`).
- * `kind` and `status` are the only fields common to every variant, so only
- * those are `required`; the rest are optional and validated loosely rather
- * than as a strict discriminated union (ajv's `JSONSchemaType` cannot express
- * "required iff kind === X" without repeating the whole union per branch).
+ * `Execution` schema. Executions are a flat, per-runType union of leaf
+ * executions: `LintExecution`/`AnalyzeExecution`
+ * (`location` + `findings`) and `TestCaseExecution` (`name` + `steps`, no
+ * `location`); executions do not nest. `kind` and `status` are the only fields
+ * common to every variant, so only those are `required`; the rest are optional
+ * and validated loosely rather than as a strict discriminated union (ajv's
+ * `JSONSchemaType` cannot express "required iff kind === X" without repeating
+ * the whole union per branch).
  */
 const executionSchema = {
   type: 'object',

--- a/packages/core/src/http-testing/operators/expect-for-transaction.operator.ts
+++ b/packages/core/src/http-testing/operators/expect-for-transaction.operator.ts
@@ -33,7 +33,10 @@ export function expectForTransactions<Steps extends HttpTestCaseStep[]>(
       return { current, ctx };
     }
 
-    for (const transaction of step.transactions) {
+    // `expectForTransaction` always validates the last (most recent) step.
+    const stepIdx = current.steps.length - 1;
+
+    for (const [transactionIdx, transaction] of step.transactions.entries()) {
       try {
         fn(transaction);
       } catch (e) {
@@ -46,6 +49,9 @@ export function expectForTransactions<Steps extends HttpTestCaseStep[]>(
             expected: e.expected,
             actual: e.actual,
             transaction: transaction.source,
+            // Tag the failure with its position so the report can trace it back
+            // to the exact step and HTTP transaction (see BaseFinding.transactionIndex).
+            location: { stepIdx, transactionIdx },
           });
 
           return ctx.fail(current, e.message);

--- a/packages/core/src/http-testing/operators/run-requests.operator.ts
+++ b/packages/core/src/http-testing/operators/run-requests.operator.ts
@@ -58,7 +58,7 @@ export function runRequests<
         );
       }
 
-      for (const transaction of step.transactions) {
+      for (const [transactionIdx, transaction] of step.transactions.entries()) {
         if (options.origin) {
           transaction.requestTemplate = {
             ...transaction.requestTemplate,
@@ -226,6 +226,11 @@ export function runRequests<
               ...results.map((r) => {
                 if (r.type === 'assertion-failure') {
                   r.transaction = transaction.source;
+                  // Tag the failure with its position so the report can trace it
+                  // back to the exact step and HTTP transaction (mirrors
+                  // expectForTransactions). Without a location, buildTestStep
+                  // can't associate the detail with a step and drops it.
+                  r.location = { stepIdx, transactionIdx };
                 }
 
                 return r;

--- a/packages/core/src/http-testing/test-builder/compilers/response-scoped-to-transaction-validator.ts
+++ b/packages/core/src/http-testing/test-builder/compilers/response-scoped-to-transaction-validator.ts
@@ -19,6 +19,7 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
         assert.strictEqual(
           transaction.response?.headers['content-type'],
           expression.mediaType,
+          `Response Content-Type should be "${expression.mediaType}"`,
         );
     case 'responseTrailer':
       if (typeof expression.trailer === 'undefined') {
@@ -30,18 +31,27 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
           assert.strictEqual(
             transaction.response?.trailers[expression.trailer!],
             expression.value,
+            `Response trailer "${expression.trailer}" should be "${expression.value}"`,
           );
         } else {
-          assert.ok(transaction.response?.trailers[expression.trailer!]);
+          assert.ok(
+            transaction.response?.trailers[expression.trailer!],
+            `Response should include trailer "${expression.trailer}"`,
+          );
         }
       };
     case 'constant':
       return () => Boolean(expression.value);
     case 'statusCode':
       return (transaction) =>
-        assert.strictEqual(transaction.response?.statusCode, expression.code);
+        assert.strictEqual(
+          transaction.response?.statusCode,
+          expression.code,
+          `Response status code should be ${expression.code}`,
+        );
     case 'hasResponseBody':
-      return (transaction) => assert.ok(transaction.response?.body);
+      return (transaction) =>
+        assert.ok(transaction.response?.body, 'Response should have a body');
     case 'responseHeader': {
       if (typeof expression.header === 'undefined') {
         return () => true;
@@ -54,14 +64,16 @@ export function compileResponseScopedExpressionToTransactionValidationFn(
             expression.header!,
             ...Object.keys(transaction.response?.headers ?? {}),
           ),
+          `Response should include header "${expression.header}"`,
         );
     }
     case 'statusCodeRange':
       return (transaction) => {
-        assert.ok(transaction.response?.statusCode);
-        assert.ok(Number.isInteger(transaction.response?.statusCode));
-        assert.ok(transaction.response.statusCode >= expression.start);
-        assert.ok(transaction.response.statusCode <= expression.end);
+        const range = `Response status code should be between ${expression.start} and ${expression.end}`;
+        assert.ok(transaction.response?.statusCode, range);
+        assert.ok(Number.isInteger(transaction.response?.statusCode), range);
+        assert.ok(transaction.response.statusCode >= expression.start, range);
+        assert.ok(transaction.response.statusCode <= expression.end, range);
       };
     case 'and':
       return (transaction) =>

--- a/packages/core/src/http-testing/validate/ajv.ts
+++ b/packages/core/src/http-testing/validate/ajv.ts
@@ -1,7 +1,11 @@
 import { Ajv2020 } from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 
-export const ajv = new Ajv2020();
+// `allErrors` so schema validation collects every error, letting validators
+// surface one assertion-failure per error instead of only the first one.
+// `verbose` so each error carries the offending `data` (and `schema`), letting
+// validators report the actual value alongside the expected constraint.
+export const ajv = new Ajv2020({ allErrors: true, verbose: true });
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error

--- a/packages/core/src/http-testing/validate/schema-error.ts
+++ b/packages/core/src/http-testing/validate/schema-error.ts
@@ -78,6 +78,23 @@ export function describeSchemaError(
   return subject ? `${subject} ${what}` : what;
 }
 
+/**
+ * Keywords whose failing `error.schema`/`params.limit` is a numeric bound rather
+ * than an expected value, so they must not produce an `expected`/`actual` pair.
+ */
+const BOUNDARY_KEYWORDS = new Set<string>([
+  'maxLength',
+  'minLength',
+  'maximum',
+  'minimum',
+  'exclusiveMaximum',
+  'exclusiveMinimum',
+  'maxItems',
+  'minItems',
+  'maxProperties',
+  'minProperties',
+]);
+
 function isPrimitive(value: unknown): boolean {
   return (
     value === null ||
@@ -107,6 +124,15 @@ export function schemaErrorDetail(error: ErrorObject): {
     return {};
   }
 
+  // Boundary keywords express a limit, not an expected value: ajv sets
+  // `params.limit` (and `error.schema`) to the bound, so pairing it as
+  // `expected` would mislabel e.g. `maxLength: 3` on "abcd" as
+  // `expected: 3, actual: "abcd"`. The human-readable message already states
+  // the bound ("must NOT have more than 3 characters"), so emit no pair here.
+  if (BOUNDARY_KEYWORDS.has(error.keyword)) {
+    return {};
+  }
+
   const params = error.params as Record<string, unknown>;
   const expected =
     params.type ??
@@ -114,7 +140,6 @@ export function schemaErrorDetail(error: ErrorObject): {
     params.allowedValue ??
     params.pattern ??
     params.format ??
-    params.limit ??
     (isPrimitive(error.schema) ? error.schema : undefined);
 
   return expected !== undefined ? { expected, actual } : {};

--- a/packages/core/src/http-testing/validate/schema-error.ts
+++ b/packages/core/src/http-testing/validate/schema-error.ts
@@ -1,0 +1,104 @@
+import type { ErrorObject } from 'ajv';
+
+/**
+ * Convert an ajv `instancePath` (a JSON pointer such as `/user/age` or
+ * `/items/2/id`) to a readable property path (`user.age`, `items[2].id`).
+ * Numeric segments render as array indices. Returns an empty string for the root.
+ */
+function instancePathToProperty(instancePath: string): string {
+  if (!instancePath) {
+    return '';
+  }
+
+  const segments = instancePath
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    // Un-escape JSON pointer tokens (`~1` → `/`, `~0` → `~`).
+    .map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+  let path = '';
+  for (const segment of segments) {
+    if (/^\d+$/.test(segment)) {
+      path += `[${segment}]`;
+    } else {
+      path += path.length > 0 ? `.${segment}` : segment;
+    }
+  }
+  return path;
+}
+
+/**
+ * Describe a schema-validation error in plain English, answering both *where* the
+ * problem is and *what* it is.
+ *
+ * When the error targets a property, the message names that property path (e.g.
+ * `property "user.age" must be integer`, `property "items[2].id" must be integer`,
+ * `property "user.name" is required`). When it targets a single value with no
+ * property context (e.g. a header or parameter value), it falls back to the given
+ * `subject` (e.g. `header "x-count" must match pattern "^[0-9]+$"`).
+ */
+export function describeSchemaError(
+  error: ErrorObject,
+  subject?: string,
+): string {
+  const base = instancePathToProperty(error.instancePath);
+
+  if (error.keyword === 'required') {
+    const missing = (error.params as { missingProperty?: string })
+      .missingProperty;
+    const path = base ? `${base}.${missing}` : missing;
+    return path
+      ? `property "${path}" is required`
+      : 'a required property is missing';
+  }
+
+  const what = error.message ?? 'is invalid';
+
+  if (base) {
+    return `property "${base}" ${what}`;
+  }
+
+  return subject ? `${subject} ${what}` : what;
+}
+
+function isPrimitive(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+/**
+ * Derive `expected`/`actual` detail for a schema error, for renderers that show
+ * them as a pair. Requires ajv `verbose` (so `error.data`/`error.schema` are
+ * populated). Returns nothing for `required` (no value was present) or when the
+ * offending value is not a scalar (the property path already localizes it) or no
+ * concrete expectation can be derived.
+ */
+export function schemaErrorDetail(error: ErrorObject): {
+  expected?: unknown;
+  actual?: unknown;
+} {
+  if (error.keyword === 'required') {
+    return {};
+  }
+
+  const actual = isPrimitive(error.data) ? error.data : undefined;
+  if (actual === undefined) {
+    return {};
+  }
+
+  const params = error.params as Record<string, unknown>;
+  const expected =
+    params.type ??
+    params.allowedValues ??
+    params.allowedValue ??
+    params.pattern ??
+    params.format ??
+    params.limit ??
+    (isPrimitive(error.schema) ? error.schema : undefined);
+
+  return expected !== undefined ? { expected, actual } : {};
+}

--- a/packages/core/src/http-testing/validate/schema-error.ts
+++ b/packages/core/src/http-testing/validate/schema-error.ts
@@ -52,6 +52,23 @@ export function describeSchemaError(
       : 'a required property is missing';
   }
 
+  if (
+    error.keyword === 'additionalProperties' ||
+    error.keyword === 'unevaluatedProperties'
+  ) {
+    const params = error.params as {
+      additionalProperty?: string;
+      unevaluatedProperty?: string;
+    };
+    const extra = params.additionalProperty ?? params.unevaluatedProperty;
+    const prop = base && extra ? `${base}.${extra}` : (extra ?? base);
+    return prop
+      ? `property "${prop}" is not allowed`
+      : subject
+        ? `${subject} has an unexpected property`
+        : 'an unexpected property is present';
+  }
+
   const what = error.message ?? 'is invalid';
 
   if (base) {

--- a/packages/core/src/http-testing/validate/validate-body.ts
+++ b/packages/core/src/http-testing/validate/validate-body.ts
@@ -4,6 +4,7 @@ import { is } from 'type-is';
 import { type ThymianHttpResponse } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 export function validateJsonBody(
   body: string,
@@ -26,14 +27,15 @@ export function validateJsonBody(
 
     validate(json);
 
-    if (validate.errors) {
-      return [
-        {
-          type: 'assertion-failure',
-          message: `Invalid response body: ${validate.errors.map((err) => err.instancePath + ' ' + err.message).join(', ')}`,
-          timestamp: Date.now(),
-        },
-      ];
+    if (validate.errors && validate.errors.length > 0) {
+      // Emit one assertion-failure per schema error instead of collapsing all of
+      // them into a single joined message, so each error is reported on its own.
+      return validate.errors.map((err) => ({
+        type: 'assertion-failure',
+        message: describeSchemaError(err, 'response body'),
+        ...schemaErrorDetail(err),
+        timestamp: Date.now(),
+      }));
     }
 
     return [

--- a/packages/core/src/http-testing/validate/validate-headers.ts
+++ b/packages/core/src/http-testing/validate/validate-headers.ts
@@ -5,6 +5,7 @@ import {
 } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 export const commonHttpHeaders = [
   'date',
@@ -90,32 +91,38 @@ export function validateExistingHeader(
 ): HttpTestCaseResult[] {
   return Object.entries(headers)
     .filter(([name]) => Object.hasOwn(response.headers, name))
-    .map(([name, value]) => {
+    .flatMap(([name, value]): HttpTestCaseResult[] => {
       if (response.headers[name]?.schema) {
         const validate = ajv.compile(response.headers[name]?.schema);
 
         validate(value);
 
-        if (validate.errors) {
-          return {
+        if (validate.errors && validate.errors.length > 0) {
+          // One assertion-failure per schema error rather than a joined message.
+          return validate.errors.map((err) => ({
             type: 'assertion-failure',
-            message: `Invalid value for header ${name}: ${validate.errors.map((err) => err.message).join(', ')}.`,
+            message: describeSchemaError(err, `header "${name}"`),
+            ...schemaErrorDetail(err),
             timestamp: Date.now(),
-          };
-        } else {
-          return {
+          }));
+        }
+
+        return [
+          {
             type: 'assertion-success',
             message: `Valid header ${name}.`,
             timestamp: Date.now(),
-          };
-        }
+          },
+        ];
       }
 
-      return {
-        type: 'info',
-        message: `No schema provided for header ${name}.`,
-        timestamp: Date.now(),
-      };
+      return [
+        {
+          type: 'info',
+          message: `No schema provided for header ${name}.`,
+          timestamp: Date.now(),
+        },
+      ];
     });
 }
 

--- a/packages/core/src/http-testing/validate/validate-request-body.ts
+++ b/packages/core/src/http-testing/validate/validate-request-body.ts
@@ -3,6 +3,7 @@ import { parse } from 'secure-json-parse';
 import type { ThymianHttpRequest } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 export function validateJsonRequestBody(
   body: string,
@@ -26,14 +27,15 @@ export function validateJsonRequestBody(
 
     validate(json);
 
-    if (validate.errors) {
-      return [
-        {
-          type: 'assertion-failure',
-          message: `Invalid request body: ${validate.errors.map((err) => err.instancePath + ' ' + err.message).join(', ')}`,
-          timestamp: Date.now(),
-        },
-      ];
+    if (validate.errors && validate.errors.length > 0) {
+      // Emit one assertion-failure per schema error instead of collapsing all of
+      // them into a single joined message, so each error is reported on its own.
+      return validate.errors.map((err) => ({
+        type: 'assertion-failure',
+        message: describeSchemaError(err, 'request body'),
+        ...schemaErrorDetail(err),
+        timestamp: Date.now(),
+      }));
     }
 
     return [

--- a/packages/core/src/http-testing/validate/validate-request-headers.ts
+++ b/packages/core/src/http-testing/validate/validate-request-headers.ts
@@ -5,6 +5,7 @@ import {
 } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 export const commonRequestHeaders = [
   'accept',
@@ -82,32 +83,38 @@ export function validateExistingRequestHeader(
 ): HttpTestCaseResult[] {
   return Object.entries(headers)
     .filter(([name]) => Object.hasOwn(request.headers, name))
-    .map(([name, value]) => {
+    .flatMap(([name, value]): HttpTestCaseResult[] => {
       if (request.headers[name]?.schema) {
         const validate = ajv.compile(request.headers[name]?.schema);
 
         validate(value);
 
-        if (validate.errors) {
-          return {
+        if (validate.errors && validate.errors.length > 0) {
+          // One assertion-failure per schema error rather than a joined message.
+          return validate.errors.map((err) => ({
             type: 'assertion-failure',
-            message: `Invalid value for request header ${name}: ${validate.errors.map((err) => err.message).join(', ')}.`,
+            message: describeSchemaError(err, `request header "${name}"`),
+            ...schemaErrorDetail(err),
             timestamp: Date.now(),
-          };
-        } else {
-          return {
+          }));
+        }
+
+        return [
+          {
             type: 'assertion-success',
             message: `Valid request header ${name}.`,
             timestamp: Date.now(),
-          };
-        }
+          },
+        ];
       }
 
-      return {
-        type: 'info',
-        message: `No schema provided for request header ${name}.`,
-        timestamp: Date.now(),
-      };
+      return [
+        {
+          type: 'info',
+          message: `No schema provided for request header ${name}.`,
+          timestamp: Date.now(),
+        },
+      ];
     });
 }
 

--- a/packages/core/src/http-testing/validate/validate-request-path-parameters.ts
+++ b/packages/core/src/http-testing/validate/validate-request-path-parameters.ts
@@ -3,6 +3,7 @@ import { match } from 'path-to-regexp';
 import type { ThymianHttpRequest } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 function extractPathParameters(
   actualPath: string,
@@ -44,32 +45,38 @@ export function validateExistingPathParameter(
 ): HttpTestCaseResult[] {
   return Object.entries(pathParams)
     .filter(([name]) => Object.hasOwn(request.pathParameters, name))
-    .map(([name, value]) => {
+    .flatMap(([name, value]): HttpTestCaseResult[] => {
       if (request.pathParameters[name]?.schema) {
         const validate = ajv.compile(request.pathParameters[name]?.schema);
 
         validate(value);
 
-        if (validate.errors) {
-          return {
+        if (validate.errors && validate.errors.length > 0) {
+          // One assertion-failure per schema error rather than a joined message.
+          return validate.errors.map((err) => ({
             type: 'assertion-failure',
-            message: `Invalid value for path parameter "${name}": ${validate.errors.map((err) => err.message).join(', ')}.`,
+            message: describeSchemaError(err, `path parameter "${name}"`),
+            ...schemaErrorDetail(err),
             timestamp: Date.now(),
-          };
-        } else {
-          return {
+          }));
+        }
+
+        return [
+          {
             type: 'assertion-success',
             message: `Valid path parameter "${name}".`,
             timestamp: Date.now(),
-          };
-        }
+          },
+        ];
       }
 
-      return {
-        type: 'info',
-        message: `No schema provided for path parameter "${name}".`,
-        timestamp: Date.now(),
-      };
+      return [
+        {
+          type: 'info',
+          message: `No schema provided for path parameter "${name}".`,
+          timestamp: Date.now(),
+        },
+      ];
     });
 }
 

--- a/packages/core/src/http-testing/validate/validate-request-query-parameters.ts
+++ b/packages/core/src/http-testing/validate/validate-request-query-parameters.ts
@@ -1,6 +1,7 @@
 import type { ThymianHttpRequest } from '../../index.js';
 import type { HttpTestCaseResult } from '../http-test/index.js';
 import { ajv } from './ajv.js';
+import { describeSchemaError, schemaErrorDetail } from './schema-error.js';
 
 function parseQueryString(
   queryString: string,
@@ -82,32 +83,38 @@ export function validateExistingQueryParameter(
 ): HttpTestCaseResult[] {
   return Object.entries(queryParams)
     .filter(([name]) => Object.hasOwn(request.queryParameters, name))
-    .map(([name, value]) => {
+    .flatMap(([name, value]): HttpTestCaseResult[] => {
       if (request.queryParameters[name]?.schema) {
         const validate = ajv.compile(request.queryParameters[name]?.schema);
 
         validate(value);
 
-        if (validate.errors) {
-          return {
+        if (validate.errors && validate.errors.length > 0) {
+          // One assertion-failure per schema error rather than a joined message.
+          return validate.errors.map((err) => ({
             type: 'assertion-failure',
-            message: `Invalid value for query parameter "${name}": ${validate.errors.map((err) => err.message).join(', ')}.`,
+            message: describeSchemaError(err, `query parameter "${name}"`),
+            ...schemaErrorDetail(err),
             timestamp: Date.now(),
-          };
-        } else {
-          return {
+          }));
+        }
+
+        return [
+          {
             type: 'assertion-success',
             message: `Valid query parameter "${name}".`,
             timestamp: Date.now(),
-          };
-        }
+          },
+        ];
       }
 
-      return {
-        type: 'info',
-        message: `No schema provided for query parameter "${name}".`,
-        timestamp: Date.now(),
-      };
+      return [
+        {
+          type: 'info',
+          message: `No schema provided for query parameter "${name}".`,
+          timestamp: Date.now(),
+        },
+      ];
     });
 }
 

--- a/packages/core/src/report/index.ts
+++ b/packages/core/src/report/index.ts
@@ -15,12 +15,10 @@ export type {
   AnalyzeExecution,
   Artifact,
   BaseFinding,
-  BodyContent,
   Execution,
   ExecutionBase,
   ExecutionStatus,
   FindingRecord,
-  Headers,
   Informational,
   Invocation,
   LintExecution,
@@ -38,6 +36,7 @@ export type {
   ThymianFormatVersion,
   Tool,
   ToolRun,
+  ToolRunBase,
 } from './report.js';
 export type {
   AssertionFailure as ReportAssertionFailure,
@@ -61,7 +60,7 @@ export {
   rulesToRuleDescriptors,
 } from './report-builder.js';
 export * from './report-style.js';
-export type { ExecutionVisit, FindingVisit } from './report-traversal.js';
+export type { FindingVisit } from './report-traversal.js';
 export {
   collectFindings,
   walkExecutions,

--- a/packages/core/src/report/report-builder.ts
+++ b/packages/core/src/report/report-builder.ts
@@ -41,16 +41,24 @@ export function createReport(
   };
 }
 
-export function createToolRun(opts: {
+/**
+ * Build a {@link ToolRun}. Generic over `runType` so the `executions` type is
+ * correlated with the run kind (a `lint` run only accepts {@link LintExecution}s,
+ * etc.) — matching the discriminated {@link ToolRun} union.
+ */
+export function createToolRun<TRunType extends ToolRun['runType']>(opts: {
   tool: Tool;
-  runType: 'lint' | 'test' | 'analyze';
-  executions?: Execution[];
+  runType: TRunType;
+  executions?: Extract<ToolRun, { runType: TRunType }>['executions'];
   rules?: ToolRun['rules'];
   duration?: number;
   thymianFormatVersion?: string;
   artifacts?: ToolRun['artifacts'];
   invocations?: ToolRun['invocations'];
 }): ToolRun {
+  // The object is built with a fixed `runType`/`executions` pair, but TypeScript
+  // cannot correlate the generic `TRunType` back to a single union arm from an
+  // object literal, so we assert the constructed run to the union.
   return {
     runId: randomUUID(),
     tool: opts.tool,
@@ -62,39 +70,53 @@ export function createToolRun(opts: {
     invocations: opts.invocations,
     executions: opts.executions,
     rules: opts.rules,
+  } as ToolRun;
+}
+
+/**
+ * Build a leaf (lint/analyze) execution. Lint and analyze executions share an
+ * identical shape and differ only by their `kind` tag, so both are produced by
+ * this single parameterized factory; the public {@link createLintExecution} /
+ * {@link createAnalyzeExecution} are thin, type-narrowing wrappers over it.
+ */
+function createLeafExecution(
+  kind: 'lint',
+  opts: LeafExecutionOptions,
+): LintExecution;
+function createLeafExecution(
+  kind: 'analyze',
+  opts: LeafExecutionOptions,
+): AnalyzeExecution;
+function createLeafExecution(
+  kind: 'lint' | 'analyze',
+  opts: LeafExecutionOptions,
+): LintExecution | AnalyzeExecution {
+  return {
+    kind,
+    ...(opts.ruleId !== undefined ? { ruleId: opts.ruleId } : {}),
+    status: opts.status,
+    location: opts.location,
+    findings: opts.findings ?? [],
   };
+}
+
+interface LeafExecutionOptions {
+  location: Location;
+  status: ExecutionStatus;
+  ruleId?: string;
+  findings?: FindingRecord[];
 }
 
 /** Build a {@link LintExecution} (one rule evaluated against one location). */
-export function createLintExecution(opts: {
-  location: Location;
-  status: ExecutionStatus;
-  ruleId?: string;
-  findings?: FindingRecord[];
-}): LintExecution {
-  return {
-    kind: 'lint',
-    ...(opts.ruleId !== undefined ? { ruleId: opts.ruleId } : {}),
-    status: opts.status,
-    location: opts.location,
-    findings: opts.findings ?? [],
-  };
+export function createLintExecution(opts: LeafExecutionOptions): LintExecution {
+  return createLeafExecution('lint', opts);
 }
 
 /** Build an {@link AnalyzeExecution} (one rule evaluated against one location). */
-export function createAnalyzeExecution(opts: {
-  location: Location;
-  status: ExecutionStatus;
-  ruleId?: string;
-  findings?: FindingRecord[];
-}): AnalyzeExecution {
-  return {
-    kind: 'analyze',
-    ...(opts.ruleId !== undefined ? { ruleId: opts.ruleId } : {}),
-    status: opts.status,
-    location: opts.location,
-    findings: opts.findings ?? [],
-  };
+export function createAnalyzeExecution(
+  opts: LeafExecutionOptions,
+): AnalyzeExecution {
+  return createLeafExecution('analyze', opts);
 }
 
 /** Build a {@link TestCaseExecution}; findings live on its {@link TestStep}s. */
@@ -138,7 +160,7 @@ export function createTestStep(opts: {
 export function executionsFromViolations(
   violations: EvaluatedRuleViolation[],
   format: ThymianFormat,
-): Execution[] {
+): LintExecution[] {
   return violations.map((evaluatedViolation) => {
     const { location } = resolveViolationLocation(
       evaluatedViolation.location,
@@ -164,9 +186,8 @@ export function executionsFromViolations(
  * status: a `violation` → `failed`; a `rule-skip` signal → `skipped`; otherwise
  * `passed`. `rule-skip` is a producer signal and is never emitted as a report
  * finding, but any *other* findings on the same entry still are — a rule-skip
- * alongside e.g. an `informational` finding must not be reported as `passed`
- * (BaggersIO PR-311 finding 10), matching `plugin-http-tester`'s `noteResult`,
- * which treats the two signals independently rather than gating one on the
+ * alongside e.g. an `informational` finding must not be reported as `passed`.
+ * The two signals are treated independently rather than gating one on the
  * other's absence.
  */
 function statusAndFindingsFromEntry(
@@ -217,12 +238,27 @@ export function executionsFromRunRulesResult<TDiagnostics>(
   result: RunRulesResult<TDiagnostics>,
   rules: Rule[],
   format: ThymianFormat,
+): LintExecution[];
+export function executionsFromRunRulesResult<TDiagnostics>(
+  result: RunRulesResult<TDiagnostics>,
+  rules: Rule[],
+  format: ThymianFormat,
+  kind: 'lint',
+): LintExecution[];
+export function executionsFromRunRulesResult<TDiagnostics>(
+  result: RunRulesResult<TDiagnostics>,
+  rules: Rule[],
+  format: ThymianFormat,
+  kind: 'analyze',
+): AnalyzeExecution[];
+export function executionsFromRunRulesResult<TDiagnostics>(
+  result: RunRulesResult<TDiagnostics>,
+  rules: Rule[],
+  format: ThymianFormat,
   kind: 'lint' | 'analyze' = 'lint',
-): Execution[] {
+): (LintExecution | AnalyzeExecution)[] {
   const ruleMap = new Map(rules.map((r) => [r.meta.name, r]));
-  const executions: Execution[] = [];
-  const build =
-    kind === 'analyze' ? createAnalyzeExecution : createLintExecution;
+  const executions: (LintExecution | AnalyzeExecution)[] = [];
 
   for (const [ruleName, { ruleFnResult }] of Object.entries(result)) {
     const rule = ruleMap.get(ruleName);
@@ -238,7 +274,21 @@ export function executionsFromRunRulesResult<TDiagnostics>(
       );
       const { status, findings } = statusAndFindingsFromEntry(entry, rule);
 
-      executions.push(build({ location, ruleId: ruleName, status, findings }));
+      executions.push(
+        kind === 'analyze'
+          ? createLeafExecution('analyze', {
+              location,
+              ruleId: ruleName,
+              status,
+              findings,
+            })
+          : createLeafExecution('lint', {
+              location,
+              ruleId: ruleName,
+              status,
+              findings,
+            }),
+      );
     }
   }
 
@@ -269,6 +319,9 @@ export function ruleFindingToFindingRecord(
     ...(finding.message ? { message: { text: finding.message } } : {}),
     ...(finding.expected !== undefined ? { expected: finding.expected } : {}),
     ...(finding.actual !== undefined ? { actual: finding.actual } : {}),
+    ...(finding.transactionIndex !== undefined
+      ? { transactionIndex: finding.transactionIndex }
+      : {}),
   } satisfies FindingRecord;
 }
 
@@ -310,43 +363,45 @@ export function httpTestResultToRuleFindings(
   results: HttpTestCaseResult[],
 ): RuleFinding[] {
   return results.map((result) => {
+    // Findings carry no severity: it is resolved from the execution's
+    // `ruleId`/`status`. Transaction linkage (`result.location.transactionIdx`)
+    // is carried through so an assertion failure / invalid transaction in the
+    // final report can be traced back to the exact HTTP exchange.
+    const transactionIndex = result.location?.transactionIdx;
     switch (result.type) {
       case 'assertion-success':
+        // The title is the human-readable message (e.g. the assertion
+        // description), not the low-level assert operator, so it reads well when
+        // printed on its own in the CLI.
         return {
           kind: 'assertion-success',
-          title: result.assertion ?? result.message,
-          message: result.message,
-          severity: 'info',
+          title: result.message,
         } satisfies RuleFinding;
       case 'assertion-failure':
         return {
           kind: 'assertion-failure',
-          title: result.assertion ?? result.message,
-          message: result.message,
-          severity: 'error',
+          title: result.message,
           expected: result.expected,
           actual: result.actual,
+          ...(transactionIndex !== undefined ? { transactionIndex } : {}),
         } satisfies RuleFinding;
       case 'execution-error':
         return {
           kind: 'informational',
           title: result.error,
           message: result.message,
-          severity: 'error',
         } satisfies RuleFinding;
       case 'warning':
         return {
           kind: 'informational',
           title: result.message,
           message: result.details ?? result.message,
-          severity: 'warn',
         } satisfies RuleFinding;
       case 'info':
         return {
           kind: 'informational',
           title: result.message,
           message: result.details ?? result.message,
-          severity: 'info',
         } satisfies RuleFinding;
       // `timeout`/`skip`/`invalid-transaction` are produced only by the test
       // runner, never by the lint/analyze rule path that consumes this helper.
@@ -357,21 +412,19 @@ export function httpTestResultToRuleFindings(
           kind: 'informational',
           title: result.message,
           message: result.message,
-          severity: 'error',
         } satisfies RuleFinding;
       case 'skip':
         return {
           kind: 'informational',
           title: result.message,
           message: result.reason ?? result.message,
-          severity: 'info',
         } satisfies RuleFinding;
       case 'invalid-transaction':
         return {
           kind: 'informational',
           title: result.message,
           message: result.details ?? result.message,
-          severity: 'error',
+          ...(transactionIndex !== undefined ? { transactionIndex } : {}),
         } satisfies RuleFinding;
       default:
         return result satisfies never;

--- a/packages/core/src/report/report-traversal.ts
+++ b/packages/core/src/report/report-traversal.ts
@@ -1,19 +1,14 @@
 import type { Execution, FindingRecord, TestStep } from './report.js';
 
-/** One visited execution. Executions are a flat, non-recursive list per run. */
-export interface ExecutionVisit {
-  /** The visited execution. */
-  execution: Execution;
-}
-
 /**
- * Walk the executions of a run.
+ * Walk the executions of a run. Executions are a flat, non-recursive list per
+ * run, so this simply yields each {@link Execution} in order.
  */
 export function* walkExecutions(
   executions: Execution[] | undefined,
-): Generator<ExecutionVisit> {
+): Generator<Execution> {
   for (const execution of executions ?? []) {
-    yield { execution };
+    yield execution;
   }
 }
 
@@ -35,7 +30,7 @@ export interface FindingVisit {
 export function* walkFindings(
   executions: Execution[] | undefined,
 ): Generator<FindingVisit> {
-  for (const { execution } of walkExecutions(executions)) {
+  for (const execution of walkExecutions(executions)) {
     if (execution.kind === 'test') {
       for (const step of execution.steps) {
         for (const finding of step.findings) {

--- a/packages/core/src/report/report.ts
+++ b/packages/core/src/report/report.ts
@@ -19,6 +19,9 @@ export interface Message {
 /**
  * External or generated file that belongs to a tool run, such as HAR files,
  * screenshots, generated requests, raw logs, or exported diagnostics.
+ *
+ * Reserved public surface: referenced by {@link ToolRun.artifacts} but not yet
+ * populated by any producer. Kept as an intentional extension point.
  */
 export interface Artifact {
   /** Stable identifier within the report. */
@@ -35,21 +38,6 @@ export interface Artifact {
   mimeType?: string;
 }
 
-/** HTTP header bag as represented in report payloads. */
-export type Headers = Record<string, string | string[]>;
-
-/** Generic body representation for future report-owned HTTP payloads/artifacts. */
-export interface BodyContent {
-  /** Textual body content, if it is safe and useful to inline. */
-  text?: string;
-  /** Base64-encoded body content for binary payloads. */
-  binaryBase64?: string;
-  /** Media type of the body content. */
-  mimeType?: string;
-  /** Encoding marker for consumers that need to decode the body. */
-  encoding?: 'plain' | 'base64' | (string & {});
-}
-
 /** HTTP request shape reused from the core HTTP model. */
 export type ReportHttpRequest = HttpRequest;
 
@@ -57,10 +45,12 @@ export type ReportHttpRequest = HttpRequest;
 export type ReportHttpResponse = HttpResponse;
 
 /**
- * Captured HTTP transaction associated with an execution. It is intentionally
- * attached to executions, not findings, because multiple findings can originate
- * from the same transaction and renderers may decide how much transaction detail
- * to show.
+ * Captured HTTP transaction collected while running a test. Transactions are
+ * attached at {@link TestStep} granularity (see {@link TestStep.httpTransactions}),
+ * not to individual findings, because multiple findings can originate from the
+ * same transaction and renderers may decide how much transaction detail to show.
+ * A finding may point at a specific transaction within its step via
+ * {@link BaseFinding.transactionIndex}.
  */
 export interface ReportHttpTransaction {
   /** Captured request. */
@@ -94,7 +84,14 @@ export interface RuleDescriptor {
   }>;
 }
 
-/** Invocation describes one process/command that contributed to a tool run. */
+/**
+ * Invocation describes one process/command that contributed to a tool run.
+ *
+ * Reserved public surface: the model carries it and {@link ToolRun.invocations}
+ * references it, but no producer populates it yet. Kept (not removed) as an
+ * intentional SARIF-parity extension point for capturing CLI/process invocation
+ * detail in a future story.
+ */
 export interface Invocation {
   /** Optional invocation identifier. */
   id?: string;
@@ -127,7 +124,11 @@ export interface Invocation {
 export interface BaseFinding {
   /** Stable identifier within the report. */
   id: string;
-  /** Discriminator describing what kind of fact this finding represents. */
+  /**
+   * Discriminator describing what kind of fact this finding represents. Kept
+   * open (`string & {}`) so producers can emit custom finding kinds; consumers
+   * should handle unknown kinds gracefully.
+   */
   kind:
     | 'rule-violation'
     | 'informational'
@@ -138,6 +139,14 @@ export interface BaseFinding {
   title: string;
   /** Optional longer message. */
   message?: Message;
+  /**
+   * Zero-based index into the owning {@link TestStep.httpTransactions} of the
+   * transaction this finding is about, when it is tied to a specific transaction.
+   * Lets a consumer trace a finding (e.g. an assertion failure or an invalid
+   * transaction) back to the exact HTTP exchange. Undefined when no single
+   * transaction applies (e.g. lint/analyze findings, or step-wide findings).
+   */
+  transactionIndex?: number;
 }
 
 /**
@@ -316,14 +325,16 @@ export interface TestCaseExecution extends ExecutionBase {
  */
 export type Execution = LintExecution | TestCaseExecution | AnalyzeExecution;
 
-/** One run of one tool/plugin for a workflow mode such as lint/test/analyze. */
-export interface ToolRun {
+/**
+ * Fields shared by every {@link ToolRun}, independent of its run type. The
+ * discriminating `runType` and the type-correlated `executions` are added per
+ * arm of the {@link ToolRun} union.
+ */
+export interface ToolRunBase {
   /** Stable identifier for this run within the report. */
   runId: string;
   /** Tool/plugin that produced the data. */
   tool: Tool;
-  /** Workflow/run kind. Closed union — every execution's `kind` matches this. */
-  runType: 'lint' | 'test' | 'analyze';
   /** ISO timestamp when the run was created/started. */
   runAt: string;
   /** Duration in milliseconds, if measured. */
@@ -334,11 +345,24 @@ export interface ToolRun {
   artifacts?: Artifact[];
   /** External command/process invocations that contributed to this run. */
   invocations?: Invocation[];
-  /** Execution groups produced by this run. Omitted/empty means the plugin collected no reportable information. */
-  executions?: Execution[];
   /** List of rules that were checked during this run, including both passed and failed rules. */
   rules?: RuleDescriptor[];
 }
+
+/**
+ * One run of one tool/plugin for a workflow mode such as lint/test/analyze.
+ *
+ * Modelled as a discriminated union on `runType`: the run kind fixes the
+ * concrete execution type, so a `lint` run can only carry {@link LintExecution}s,
+ * a `test` run only {@link TestCaseExecution}s, and an `analyze` run only
+ * {@link AnalyzeExecution}s. This makes it impossible to attach executions whose
+ * `kind` disagrees with the run's `runType`. `executions` omitted/empty means the
+ * plugin collected no reportable information.
+ */
+export type ToolRun =
+  | (ToolRunBase & { runType: 'lint'; executions?: LintExecution[] })
+  | (ToolRunBase & { runType: 'test'; executions?: TestCaseExecution[] })
+  | (ToolRunBase & { runType: 'analyze'; executions?: AnalyzeExecution[] });
 
 /** Version/hash identifying a specific serialized Thymian format. */
 export type ThymianFormatVersion = string;

--- a/packages/core/src/rules/rule-violation.ts
+++ b/packages/core/src/rules/rule-violation.ts
@@ -9,8 +9,6 @@ export type RuleViolationLocation =
     }
   | string;
 
-export type RuleFindingSeverity = 'error' | 'warn' | 'info' | 'hint';
-
 /**
  * The rule-author input union (distinct from the report `FindingRecord` output
  * union). Findings carry *meta* information only — a rule violation is already
@@ -18,6 +16,9 @@ export type RuleFindingSeverity = 'error' | 'warn' | 'info' | 'hint';
  * no `rule-violation` finding kind here. `rule-skip` is a producer signal the
  * report builder maps to `status: skipped`; it is intentionally NOT a report
  * finding kind either (see `ruleFindingToFindingRecord`).
+ *
+ * Findings carry no `severity`: a violation's severity is resolved from its
+ * execution's `ruleId`/`status`.
  */
 export interface RuleFinding {
   kind:
@@ -28,13 +29,18 @@ export interface RuleFinding {
     | (string & {});
   title: string;
   message?: string;
-  severity?: RuleFindingSeverity;
   ruleId?: string;
   expected?: unknown;
   actual?: unknown;
   reason?: string;
   durationMilliseconds?: number;
   metadata?: Record<string, unknown>;
+  /**
+   * Zero-based index into the owning test step's transactions of the transaction
+   * this finding is about, when tied to a specific transaction. Carried through
+   * to {@link BaseFinding.transactionIndex} in the report.
+   */
+  transactionIndex?: number;
 }
 
 /**

--- a/packages/core/test/http-testing/operators/expect-for-transaction.operator.test.ts
+++ b/packages/core/test/http-testing/operators/expect-for-transaction.operator.test.ts
@@ -1,0 +1,114 @@
+import { AssertionError } from 'node:assert';
+
+import { lastValueFrom, of } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  HttpTestCase,
+  HttpTestCaseStep,
+  HttpTestCaseStepTransaction,
+  HttpTestContext,
+  PipelineItem,
+} from '../../../src/http-testing/http-test/index.js';
+import { expectForTransactions } from '../../../src/http-testing/operators/expect-for-transaction.operator.js';
+import type { ThymianHttpTransaction } from '../../../src/index.js';
+
+function transaction(id: string): HttpTestCaseStepTransaction {
+  return {
+    source: { transactionId: id } as unknown as ThymianHttpTransaction,
+  } as HttpTestCaseStepTransaction;
+}
+
+function step(
+  ...transactions: HttpTestCaseStepTransaction[]
+): HttpTestCaseStep {
+  return { transactions } as unknown as HttpTestCaseStep;
+}
+
+function makeItem(steps: HttpTestCaseStep[]): PipelineItem<HttpTestCase> {
+  const current = {
+    start: 0,
+    status: 'running',
+    name: 'case',
+    steps,
+    results: [],
+  } as unknown as HttpTestCase;
+
+  const ctx = {
+    logger: { warn: vi.fn() },
+    fail: (failed: HttpTestCase) => {
+      (failed as { status: string }).status = 'failed';
+      return { current: failed, ctx };
+    },
+  } as unknown as HttpTestContext;
+
+  return { current, ctx };
+}
+
+describe('expectForTransactions operator', () => {
+  it('tags a failure with the last step index and the failing transaction index', async () => {
+    const item = makeItem([
+      step(transaction('tx-0')),
+      step(transaction('tx-1')),
+    ]);
+
+    const fn = vi.fn(() => {
+      throw new AssertionError({
+        message: 'status should be 200',
+        operator: 'strictEqual',
+        expected: 200,
+        actual: 500,
+      });
+    });
+
+    const result = await lastValueFrom(
+      of(item).pipe(expectForTransactions(fn)),
+    );
+
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.results[0]).toMatchObject({
+      type: 'assertion-failure',
+      // Node augments the AssertionError message with an expected/actual diff.
+      message: expect.stringContaining('status should be 200'),
+      assertion: 'strictEqual',
+      expected: 200,
+      actual: 500,
+      // last step (index 1), first transaction of that step (index 0)
+      location: { stepIdx: 1, transactionIdx: 0 },
+    });
+  });
+
+  it('reports the correct transaction index when a later transaction fails', async () => {
+    const item = makeItem([step(transaction('tx-a'), transaction('tx-b'))]);
+
+    // Pass on the first transaction, fail on the second.
+    let call = 0;
+    const fn = vi.fn(() => {
+      if (call++ === 1) {
+        throw new AssertionError({ message: 'boom', operator: 'ok' });
+      }
+    });
+
+    const result = await lastValueFrom(
+      of(item).pipe(expectForTransactions(fn)),
+    );
+
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.results[0]).toMatchObject({
+      type: 'assertion-failure',
+      location: { stepIdx: 0, transactionIdx: 1 },
+    });
+  });
+
+  it('does not tag or fail when every transaction passes', async () => {
+    const item = makeItem([step(transaction('tx-0'))]);
+    const fn = vi.fn();
+
+    const result = await lastValueFrom(
+      of(item).pipe(expectForTransactions(fn)),
+    );
+
+    expect(result.current.results).toHaveLength(0);
+    expect(result.current.status).toBe('running');
+  });
+});

--- a/packages/core/test/http-testing/test-builder/response-scoped-to-transaction-validator.test.ts
+++ b/packages/core/test/http-testing/test-builder/response-scoped-to-transaction-validator.test.ts
@@ -1,0 +1,69 @@
+import { AssertionError } from 'node:assert';
+
+import { describe, expect, it } from 'vitest';
+
+import { responseMediaType, statusCode } from '../../../src/http-filter.js';
+import type { HttpTestCaseStepTransaction } from '../../../src/http-testing/http-test/index.js';
+import { compileResponseScopedExpressionToTransactionValidationFn } from '../../../src/http-testing/test-builder/compilers/response-scoped-to-transaction-validator.js';
+
+function transactionWithResponse(
+  response: Record<string, unknown>,
+): HttpTestCaseStepTransaction {
+  return { response } as unknown as HttpTestCaseStepTransaction;
+}
+
+describe('compileResponseScopedExpressionToTransactionValidationFn', () => {
+  it('throws a descriptive AssertionError for a status code mismatch', () => {
+    const validate = compileResponseScopedExpressionToTransactionValidationFn(
+      statusCode(200),
+    );
+    const transaction = transactionWithResponse({
+      statusCode: 500,
+      headers: {},
+      trailers: {},
+      duration: 0,
+    });
+
+    expect(() => validate(transaction)).toThrow(
+      /Response status code should be 200/,
+    );
+
+    try {
+      validate(transaction);
+    } catch (error) {
+      expect(error).toBeInstanceOf(AssertionError);
+      expect((error as AssertionError).expected).toBe(200);
+      expect((error as AssertionError).actual).toBe(500);
+    }
+  });
+
+  it('describes a content-type mismatch', () => {
+    const validate = compileResponseScopedExpressionToTransactionValidationFn(
+      responseMediaType('application/json'),
+    );
+    const transaction = transactionWithResponse({
+      statusCode: 200,
+      headers: { 'content-type': 'text/plain' },
+      trailers: {},
+      duration: 0,
+    });
+
+    expect(() => validate(transaction)).toThrow(
+      /Response Content-Type should be "application\/json"/,
+    );
+  });
+
+  it('passes when the response matches', () => {
+    const validate = compileResponseScopedExpressionToTransactionValidationFn(
+      statusCode(200),
+    );
+    const transaction = transactionWithResponse({
+      statusCode: 200,
+      headers: {},
+      trailers: {},
+      duration: 0,
+    });
+
+    expect(() => validate(transaction)).not.toThrow();
+  });
+});

--- a/packages/core/test/http-testing/validate/schema-error.test.ts
+++ b/packages/core/test/http-testing/validate/schema-error.test.ts
@@ -1,0 +1,131 @@
+import type { ErrorObject } from 'ajv';
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeSchemaError,
+  schemaErrorDetail,
+} from '../../../src/http-testing/validate/schema-error.js';
+
+function error(overrides: Partial<ErrorObject>): ErrorObject {
+  return {
+    keyword: 'type',
+    instancePath: '',
+    schemaPath: '',
+    params: {},
+    ...overrides,
+  } as ErrorObject;
+}
+
+describe('describeSchemaError', () => {
+  it('names the property path for a nested value error', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'type',
+          instancePath: '/user/age',
+          message: 'must be integer',
+        }),
+      ),
+    ).toBe('property "user.age" must be integer');
+  });
+
+  it('renders array indices in the property path', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'type',
+          instancePath: '/items/2/id',
+          message: 'must be integer',
+        }),
+      ),
+    ).toBe('property "items[2].id" must be integer');
+  });
+
+  it('resolves a required error to the missing property path', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'required',
+          instancePath: '/user',
+          params: { missingProperty: 'name' },
+          message: "must have required property 'name'",
+        }),
+      ),
+    ).toBe('property "user.name" is required');
+  });
+
+  it('resolves a required error at the root', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'required',
+          instancePath: '',
+          params: { missingProperty: 'email' },
+        }),
+      ),
+    ).toBe('property "email" is required');
+  });
+
+  it('falls back to the subject when there is no property path', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'pattern',
+          instancePath: '',
+          message: 'must match pattern "^[0-9]+$"',
+        }),
+        'header "x-count"',
+      ),
+    ).toBe('header "x-count" must match pattern "^[0-9]+$"');
+  });
+
+  it('uses the raw message when neither a path nor a subject is available', () => {
+    expect(
+      describeSchemaError(
+        error({ instancePath: '', message: 'must be object' }),
+      ),
+    ).toBe('must be object');
+  });
+});
+
+describe('schemaErrorDetail', () => {
+  it('returns the expected constraint and the actual value for a type error', () => {
+    expect(
+      schemaErrorDetail(
+        error({
+          keyword: 'type',
+          params: { type: 'integer' },
+          data: 'abc',
+        }),
+      ),
+    ).toEqual({ expected: 'integer', actual: 'abc' });
+  });
+
+  it('returns the pattern constraint for a pattern error', () => {
+    expect(
+      schemaErrorDetail(
+        error({
+          keyword: 'pattern',
+          params: { pattern: '^[0-9]+$' },
+          data: 'ab',
+        }),
+      ),
+    ).toEqual({ expected: '^[0-9]+$', actual: 'ab' });
+  });
+
+  it('returns nothing for a required error (no value was present)', () => {
+    expect(
+      schemaErrorDetail(
+        error({ keyword: 'required', params: { missingProperty: 'name' } }),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns nothing when the offending value is not a scalar', () => {
+    expect(
+      schemaErrorDetail(
+        error({ keyword: 'type', params: { type: 'string' }, data: { a: 1 } }),
+      ),
+    ).toEqual({});
+  });
+});

--- a/packages/core/test/http-testing/validate/schema-error.test.ts
+++ b/packages/core/test/http-testing/validate/schema-error.test.ts
@@ -86,6 +86,45 @@ describe('describeSchemaError', () => {
       ),
     ).toBe('must be object');
   });
+
+  it('names the offending key for an additionalProperties error', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'additionalProperties',
+          instancePath: '/user',
+          params: { additionalProperty: 'extra' },
+          message: 'must NOT have additional properties',
+        }),
+      ),
+    ).toBe('property "user.extra" is not allowed');
+  });
+
+  it('names a root-level additionalProperties key', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'additionalProperties',
+          instancePath: '',
+          params: { additionalProperty: 'extra' },
+          message: 'must NOT have additional properties',
+        }),
+      ),
+    ).toBe('property "extra" is not allowed');
+  });
+
+  it('names the offending key for an unevaluatedProperties error', () => {
+    expect(
+      describeSchemaError(
+        error({
+          keyword: 'unevaluatedProperties',
+          instancePath: '/payload',
+          params: { unevaluatedProperty: 'stray' },
+          message: 'must NOT have unevaluated properties',
+        }),
+      ),
+    ).toBe('property "payload.stray" is not allowed');
+  });
 });
 
 describe('schemaErrorDetail', () => {

--- a/packages/core/test/http-testing/validate/schema-error.test.ts
+++ b/packages/core/test/http-testing/validate/schema-error.test.ts
@@ -167,4 +167,33 @@ describe('schemaErrorDetail', () => {
       ),
     ).toEqual({});
   });
+
+  it('does not mislabel a maxLength bound as the expected value', () => {
+    // ajv (verbose) sets params.limit=3 and error.schema=3 for `maxLength: 3`.
+    // Pairing 3 as `expected` against actual "abcd" would be misleading; the
+    // message already states the bound, so no pair is emitted.
+    expect(
+      schemaErrorDetail(
+        error({
+          keyword: 'maxLength',
+          params: { limit: 3 },
+          schema: 3,
+          data: 'abcd',
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  it('does not mislabel a numeric maximum bound as the expected value', () => {
+    expect(
+      schemaErrorDetail(
+        error({
+          keyword: 'maximum',
+          params: { comparison: '<=', limit: 10 },
+          schema: 10,
+          data: 15,
+        }),
+      ),
+    ).toEqual({});
+  });
 });

--- a/packages/core/test/http-testing/validate/validate-body.test.ts
+++ b/packages/core/test/http-testing/validate/validate-body.test.ts
@@ -66,6 +66,7 @@ describe('validateJsonBody', () => {
             required: ['name'],
             properties: {
               name: { type: 'string' },
+              age: { type: 'integer' },
             },
           },
         },
@@ -75,8 +76,63 @@ describe('validateJsonBody', () => {
     expect(validateJsonBody('{"user":{}}', response)).toStrictEqual([
       {
         type: 'assertion-failure',
-        message:
-          "Invalid response body: /user must have required property 'name'",
+        message: 'property "user.name" is required',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('emits one assertion-failure per schema error', () => {
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      headers: {},
+      mediaType: 'application/json',
+      statusCode: 200,
+      schema: {
+        type: 'object',
+        required: ['name', 'email'],
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+      },
+    };
+
+    // The payload is missing both required properties → two distinct errors.
+    const results = validateJsonBody('{}', response);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.type === 'assertion-failure')).toBe(true);
+    expect(results.map((r) => r.message)).toEqual(
+      expect.arrayContaining([
+        'property "name" is required',
+        'property "email" is required',
+      ]),
+    );
+  });
+
+  it('reports the expected constraint and actual value for a type mismatch', () => {
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      headers: {},
+      mediaType: 'application/json',
+      statusCode: 200,
+      schema: {
+        type: 'object',
+        properties: {
+          age: { type: 'integer' },
+        },
+      },
+    };
+
+    expect(validateJsonBody('{"age":1.2}', response)).toStrictEqual([
+      {
+        type: 'assertion-failure',
+        message: 'property "age" must be integer',
+        expected: 'integer',
+        actual: 1.2,
         timestamp: expect.any(Number),
       },
     ]);

--- a/packages/core/test/http-testing/validate/validate-headers.test.ts
+++ b/packages/core/test/http-testing/validate/validate-headers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_HEADER_SERIALIZATION_STYLE } from '../../../src/constants.js';
+import type { ThymianHttpResponse } from '../../../src/format/nodes/http-response.node.js';
+import { validateExistingHeader } from '../../../src/http-testing/validate/validate-headers.js';
+
+function responseWithHeaderSchema(schema: unknown): ThymianHttpResponse {
+  return {
+    type: 'http-response',
+    label: '200 OK',
+    mediaType: 'application/json',
+    statusCode: 200,
+    headers: {
+      'x-count': {
+        required: true,
+        schema: schema as never,
+        style: DEFAULT_HEADER_SERIALIZATION_STYLE,
+      },
+    },
+  };
+}
+
+describe('validateExistingHeader', () => {
+  it('returns assertion-success for a header matching its schema', () => {
+    const response = responseWithHeaderSchema({ type: 'string' });
+
+    const results = validateExistingHeader({ 'x-count': '12345' }, response);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'assertion-success',
+      message: 'Valid header x-count.',
+    });
+  });
+
+  it('emits one assertion-failure per schema error', () => {
+    const response = responseWithHeaderSchema({
+      type: 'string',
+      minLength: 5,
+      pattern: '^[0-9]+$',
+    });
+
+    const results = validateExistingHeader({ 'x-count': 'ab' }, response);
+
+    const failures = results.filter((r) => r.type === 'assertion-failure');
+    expect(failures.length).toBeGreaterThanOrEqual(2);
+    expect(
+      failures.every((r) => r.message.startsWith('header "x-count"')),
+    ).toBe(true);
+  });
+
+  it('returns info when the response declares no schema for the header', () => {
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      mediaType: 'application/json',
+      statusCode: 200,
+      headers: {
+        'x-count': {
+          required: true,
+          schema: undefined as never,
+          style: DEFAULT_HEADER_SERIALIZATION_STYLE,
+        },
+      },
+    };
+
+    const results = validateExistingHeader({ 'x-count': '1' }, response);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: 'info' });
+  });
+});

--- a/packages/core/test/http-testing/validate/validate-request-body.test.ts
+++ b/packages/core/test/http-testing/validate/validate-request-body.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ThymianHttpRequest } from '../../../src/format/nodes/http-request.node.js';
+import { validateJsonRequestBody } from '../../../src/http-testing/validate/validate-request-body.js';
+
+function createRequest(schema: unknown): ThymianHttpRequest {
+  return {
+    type: 'http-request',
+    host: 'localhost',
+    port: 3000,
+    protocol: 'http',
+    path: '/users',
+    method: 'POST',
+    headers: {},
+    queryParameters: {},
+    cookies: {},
+    pathParameters: {},
+    bodyRequired: true,
+    body: schema as ThymianHttpRequest['body'],
+    mediaType: 'application/json',
+    label: '',
+    sourceName: '',
+  };
+}
+
+describe('validateJsonRequestBody', () => {
+  it('returns assertion-success for a valid body', () => {
+    const request = createRequest({
+      type: 'object',
+      required: ['name'],
+      properties: { name: { type: 'string' } },
+    });
+
+    const results = validateJsonRequestBody('{"name":"Ada"}', request);
+
+    expect(results).toStrictEqual([
+      {
+        type: 'assertion-success',
+        message: 'Valid request body.',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('emits one assertion-failure per schema error', () => {
+    const request = createRequest({
+      type: 'object',
+      required: ['name', 'email'],
+      properties: {
+        name: { type: 'string' },
+        email: { type: 'string' },
+      },
+    });
+
+    const results = validateJsonRequestBody('{}', request);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.type === 'assertion-failure')).toBe(true);
+    expect(results.map((r) => r.message)).toEqual(
+      expect.arrayContaining([
+        'property "name" is required',
+        'property "email" is required',
+      ]),
+    );
+  });
+
+  it('reports invalid JSON as a single assertion-failure', () => {
+    const request = createRequest({ type: 'object' });
+
+    const results = validateJsonRequestBody('{not json', request);
+
+    expect(results).toStrictEqual([
+      {
+        type: 'assertion-failure',
+        message: 'Request body is not valid JSON.',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('returns info when no request body schema is provided', () => {
+    const request = createRequest(undefined);
+
+    const results = validateJsonRequestBody('{"name":"Ada"}', request);
+
+    expect(results).toStrictEqual([
+      {
+        type: 'info',
+        message: 'No request body schema is provided.',
+        details: '',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+});

--- a/packages/core/test/http-testing/validate/validate-request-headers.test.ts
+++ b/packages/core/test/http-testing/validate/validate-request-headers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_HEADER_SERIALIZATION_STYLE } from '../../../src/constants.js';
+import type { ThymianHttpRequest } from '../../../src/format/nodes/http-request.node.js';
+import { validateExistingRequestHeader } from '../../../src/http-testing/validate/validate-request-headers.js';
+
+function requestWithHeaderSchema(schema: unknown): ThymianHttpRequest {
+  return {
+    type: 'http-request',
+    host: 'localhost',
+    port: 3000,
+    protocol: 'http',
+    path: '/users',
+    method: 'GET',
+    queryParameters: {},
+    cookies: {},
+    pathParameters: {},
+    bodyRequired: false,
+    body: {} as ThymianHttpRequest['body'],
+    mediaType: '',
+    label: '',
+    sourceName: '',
+    headers: {
+      'x-count': {
+        required: true,
+        schema: schema as never,
+        style: DEFAULT_HEADER_SERIALIZATION_STYLE,
+      },
+    },
+  };
+}
+
+describe('validateExistingRequestHeader', () => {
+  it('returns assertion-success for a request header matching its schema', () => {
+    const request = requestWithHeaderSchema({ type: 'string' });
+
+    const results = validateExistingRequestHeader(
+      { 'x-count': '12345' },
+      request,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'assertion-success',
+      message: 'Valid request header x-count.',
+    });
+  });
+
+  it('emits one assertion-failure per schema error', () => {
+    const request = requestWithHeaderSchema({
+      type: 'string',
+      minLength: 5,
+      pattern: '^[0-9]+$',
+    });
+
+    const results = validateExistingRequestHeader({ 'x-count': 'ab' }, request);
+
+    const failures = results.filter((r) => r.type === 'assertion-failure');
+    expect(failures.length).toBeGreaterThanOrEqual(2);
+    expect(
+      failures.every((r) => r.message.startsWith('request header "x-count"')),
+    ).toBe(true);
+  });
+});

--- a/packages/core/test/http-testing/validate/validate-request-query-parameters.test.ts
+++ b/packages/core/test/http-testing/validate/validate-request-query-parameters.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_QUERY_SERIALIZATION_STYLE } from '../../../src/constants.js';
+import type { ThymianHttpRequest } from '../../../src/format/nodes/http-request.node.js';
+import { validateExistingQueryParameter } from '../../../src/http-testing/validate/validate-request-query-parameters.js';
+
+function requestWithQuerySchema(schema: unknown): ThymianHttpRequest {
+  return {
+    type: 'http-request',
+    host: 'localhost',
+    port: 3000,
+    protocol: 'http',
+    path: '/users',
+    method: 'GET',
+    headers: {},
+    cookies: {},
+    pathParameters: {},
+    bodyRequired: false,
+    body: {} as ThymianHttpRequest['body'],
+    mediaType: '',
+    label: '',
+    sourceName: '',
+    queryParameters: {
+      page: {
+        required: true,
+        schema: schema as never,
+        style: DEFAULT_QUERY_SERIALIZATION_STYLE,
+      },
+    },
+  };
+}
+
+describe('validateExistingQueryParameter', () => {
+  it('returns assertion-success for a query parameter matching its schema', () => {
+    const request = requestWithQuerySchema({ type: 'string' });
+
+    const results = validateExistingQueryParameter({ page: '12345' }, request);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'assertion-success',
+      message: 'Valid query parameter "page".',
+    });
+  });
+
+  it('emits one assertion-failure per schema error', () => {
+    const request = requestWithQuerySchema({
+      type: 'string',
+      minLength: 5,
+      pattern: '^[0-9]+$',
+    });
+
+    const results = validateExistingQueryParameter({ page: 'ab' }, request);
+
+    const failures = results.filter((r) => r.type === 'assertion-failure');
+    expect(failures.length).toBeGreaterThanOrEqual(2);
+    expect(
+      failures.every((r) => r.message.startsWith('query parameter "page"')),
+    ).toBe(true);
+  });
+});

--- a/packages/core/test/report-builder.test.ts
+++ b/packages/core/test/report-builder.test.ts
@@ -41,10 +41,11 @@ describe('report builders', () => {
     ]);
 
     expect(findings).toHaveLength(2);
+    // Findings carry no severity — it is resolved from the execution's ruleId/status.
     expect(findings[0]).toMatchObject({
       kind: 'assertion-failure',
-      severity: 'error',
     });
+    expect(findings[0]).not.toHaveProperty('severity');
     // `skip`/`timeout`/`invalid-transaction` are dead in the lint/analyze path
     // and map defensively to `informational` (test-case outcomes are `status`).
     expect(findings[1]).toMatchObject({ kind: 'informational' });
@@ -59,7 +60,7 @@ describe('report builders', () => {
       .done();
     const format = new ThymianFormat();
 
-    it('maps a violation to a failed status (AC2)', () => {
+    it('maps a violation to a failed status', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {
@@ -90,7 +91,7 @@ describe('report builders', () => {
       ).toBeUndefined();
     });
 
-    it('surfaces findings on a passing result with no violation (AC5)', () => {
+    it('surfaces findings on a passing result with no violation', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {
@@ -139,7 +140,7 @@ describe('report builders', () => {
       expect(findings.map((f) => f.kind)).toEqual(['assertion-failure']);
     });
 
-    it('emits a passed execution for a pure-pass result (AC3)', () => {
+    it('emits a passed execution for a pure-pass result', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {
@@ -156,7 +157,7 @@ describe('report builders', () => {
       expect((executions[0] as { findings: unknown[] }).findings).toEqual([]);
     });
 
-    it('maps a rule-skip-only result to a skipped status (AC4)', () => {
+    it('maps a rule-skip-only result to a skipped status', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {
@@ -184,7 +185,7 @@ describe('report builders', () => {
       expect((executions[0] as { findings: unknown[] }).findings).toEqual([]);
     });
 
-    it('maps a rule-skip alongside another finding to skipped, not passed (regression, BaggersIO PR-311 finding 10)', () => {
+    it('maps a rule-skip alongside another finding to skipped, not passed', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {
@@ -241,7 +242,7 @@ describe('report builders', () => {
       });
     });
 
-    it('marks the execution kind as analyze when requested (AC10)', () => {
+    it('marks the execution kind as analyze when requested', () => {
       const executions = executionsFromRunRulesResult(
         {
           'rfc9110/example': {

--- a/packages/core/test/report-traversal.test.ts
+++ b/packages/core/test/report-traversal.test.ts
@@ -44,7 +44,7 @@ const executions: Execution[] = [
 describe('walkExecutions', () => {
   it('yields every execution as a flat list', () => {
     const visits = [...walkExecutions(executions)];
-    expect(visits.map((v) => v.execution.ruleId)).toEqual([
+    expect(visits.map((execution) => execution.ruleId)).toEqual([
       'rule-a',
       'rule-b',
       'rule-c',

--- a/packages/core/test/validate-request-path-parameters.test.ts
+++ b/packages/core/test/validate-request-path-parameters.test.ts
@@ -187,8 +187,29 @@ describe('validateRequestPathParameters', () => {
       expect(results).toHaveLength(1);
       expect(results[0]).toMatchObject({
         type: 'assertion-failure',
-        message: expect.stringContaining('Invalid value for path parameter'),
+        message: 'path parameter "userId" must be integer',
       });
+    });
+
+    it('should emit one assertion-failure per schema error', () => {
+      const request = createRequest({
+        pathParameters: {
+          userId: {
+            required: true,
+            // A value can violate both constraints at once.
+            schema: { type: 'string', minLength: 5, pattern: '^[0-9]+$' },
+            style: DEFAULT_PATH_SERIALIZATION_STYLE,
+          },
+        },
+      });
+
+      const results = validateExistingPathParameter({ userId: 'ab' }, request);
+
+      const failures = results.filter((r) => r.type === 'assertion-failure');
+      expect(failures.length).toBeGreaterThanOrEqual(2);
+      expect(
+        failures.every((r) => r.message.startsWith('path parameter "userId"')),
+      ).toBe(true);
     });
 
     it('should return info when no schema is provided for parameter', () => {

--- a/packages/plugin-http-analyzer/src/index.ts
+++ b/packages/plugin-http-analyzer/src/index.ts
@@ -66,8 +66,7 @@ declare module '@thymian/core' {
 }
 
 export type HttpAnalyzerStorage =
-  | { type: 'memory' }
-  | { type: 'sqlite'; path?: string };
+  { type: 'memory' } | { type: 'sqlite'; path?: string };
 
 export type HttpAnalyzerPluginOptions = {
   storage?: HttpAnalyzerStorage;
@@ -99,6 +98,7 @@ function createRuns(
   ruleResults: RunRulesResult,
   _transactions: CapturedTransaction[] = [],
   rules: Rule[] = [],
+  thymianFormatVersion?: string,
 ): ToolRun[] {
   const executions = executionsFromRunRulesResult(
     ruleResults,
@@ -115,7 +115,9 @@ function createRuns(
       runType: 'analyze',
       executions,
       rules: ruleDescriptors.length > 0 ? ruleDescriptors : undefined,
-      thymianFormatVersion: format.toHash(),
+      // Reuse the hash carried by the serialized input format when present;
+      // fall back to recomputation (e.g. when no format was supplied).
+      thymianFormatVersion: thymianFormatVersion ?? format.toHash(),
     }),
   ];
 }
@@ -228,6 +230,7 @@ export function createHttpAnalyzerPlugin(
               ruleResults,
               traffic.transactions ?? [],
               rules,
+              format?.attributes.hash,
             ),
           );
         },
@@ -250,7 +253,14 @@ export function createHttpAnalyzerPlugin(
           const violations = runRulesResultToViolations(ruleResults, rules);
 
           ctx.reply({
-            runs: createRuns(pluginName, thymianFormat, ruleResults, [], rules),
+            runs: createRuns(
+              pluginName,
+              thymianFormat,
+              ruleResults,
+              [],
+              rules,
+              format?.attributes.hash,
+            ),
             violations,
             valid: violations.length === 0,
           });
@@ -299,6 +309,7 @@ export function createHttpAnalyzerPlugin(
               ruleResults,
               transactions ?? [],
               rules,
+              format?.attributes.hash,
             ),
             violations,
             valid: violations.length === 0,

--- a/packages/plugin-http-linter/src/index.ts
+++ b/packages/plugin-http-linter/src/index.ts
@@ -68,6 +68,7 @@ function createRuns(
   format: ThymianFormat,
   ruleResults: RunRulesResult,
   rules: Rule[] = [],
+  thymianFormatVersion?: string,
 ): ToolRun[] {
   const executions = executionsFromRunRulesResult(
     ruleResults,
@@ -84,7 +85,9 @@ function createRuns(
       runType: 'lint',
       executions,
       rules: ruleDescriptors.length > 0 ? ruleDescriptors : undefined,
-      thymianFormatVersion: format.toHash(),
+      // Reuse the hash already carried by the serialized format instead of
+      // recomputing `toHash()`; fall back to recomputation if it is absent.
+      thymianFormatVersion: thymianFormatVersion ?? format.toHash(),
     }),
   ];
 }
@@ -111,7 +114,15 @@ export function createHttpLinterPlugin(
             rulesConfig,
             createStaticLinterAdapter(logger, thymianFormat, rulesConfig),
           );
-          ctx.reply(createRuns(pluginName, thymianFormat, ruleResults, rules));
+          ctx.reply(
+            createRuns(
+              pluginName,
+              thymianFormat,
+              ruleResults,
+              rules,
+              format.attributes.hash,
+            ),
+          );
         },
       );
 
@@ -130,7 +141,13 @@ export function createHttpLinterPlugin(
           const violations = runRulesResultToViolations(ruleResults, rules);
 
           ctx.reply({
-            runs: createRuns(pluginName, thymianFormat, ruleResults, rules),
+            runs: createRuns(
+              pluginName,
+              thymianFormat,
+              ruleResults,
+              rules,
+              format.attributes.hash,
+            ),
             violations,
             valid: violations.length === 0,
           });

--- a/packages/plugin-http-tester/src/http-test-api-context.ts
+++ b/packages/plugin-http-tester/src/http-test-api-context.ts
@@ -254,36 +254,55 @@ export class HttpTestApiContext<
     const placements: RuleFnResultPlacement[] = [];
 
     testResult.cases.forEach((testCase, testCaseIndex) => {
-      if (testCase.status === 'failed') {
-        const assertionFailure = testCase.results.find(
-          (r) => r.type === 'assertion-failure' && !!r.transaction,
-        ) as
-          | Extract<HttpTestCaseResult, { type: 'assertion-failure' }>
-          | undefined;
+      if (testCase.status !== 'failed') {
+        return;
+      }
 
-        if (assertionFailure && assertionFailure.transaction) {
-          // Mark the case as violated for status derivation, but keep the
-          // assertion detail on the raw test-case `results`; the report mapping
-          // (index.ts `buildTestStep`) maps those results into findings so all
-          // HttpTestCaseResult → report mapping lives in one place.
-          const result: RuleFnResult = {
+      // A `failed` case is a real *test* failure only when an assertion actually
+      // failed. Prefer an assertion failure anchored to a transaction so the
+      // violation renders on the right edge/step; otherwise take any assertion
+      // failure (e.g. from a top-level `expect`) and surface it at the case level.
+      const assertionFailures = testCase.results.filter(
+        (r) => r.type === 'assertion-failure',
+      ) as Extract<HttpTestCaseResult, { type: 'assertion-failure' }>[];
+      const assertionFailure =
+        assertionFailures.find((r) => !!r.transaction) ?? assertionFailures[0];
+
+      // No assertion failed ⇒ the case could not be executed (an HTTP-level
+      // failure); computeTestCaseStatus intentionally surfaces that as skipped,
+      // so leave it unplaced.
+      if (assertionFailure === undefined) {
+        return;
+      }
+
+      // Mark the case as violated for status derivation, keeping the assertion
+      // detail on the raw test-case `results`; the report mapping (index.ts
+      // `buildTestStep`) maps those results into findings so all
+      // HttpTestCaseResult → report mapping lives in one place. When the failure
+      // is anchored to a transaction we locate it on that edge; otherwise it is
+      // a case-level violation.
+      const result: RuleFnResult = assertionFailure.transaction
+        ? {
             location: {
               elementId: assertionFailure.transaction.transactionId,
               elementType: 'edge',
             },
             violation: {},
             findings: [],
+          }
+        : {
+            location: `${this.name}:${testCase.name}`,
+            violation: {},
+            findings: [],
           };
-          ruleFnResult.push(result);
-          // stepIndex is undefined when the assertion failure has no step location,
-          // making this a test-case-level placement (intentional — see createRuns).
-          placements.push({
-            result,
-            testCaseIndex,
-            stepIndex: assertionFailure.location?.stepIdx,
-          });
-        }
-      }
+      ruleFnResult.push(result);
+      // stepIndex is undefined when the assertion failure has no step location,
+      // making this a test-case-level placement (intentional — see createRuns).
+      placements.push({
+        result,
+        testCaseIndex,
+        stepIndex: assertionFailure.location?.stepIdx,
+      });
     });
 
     this.diagnosticEntries.push({ testResult, placements });

--- a/packages/plugin-http-tester/src/http-test-api-context.ts
+++ b/packages/plugin-http-tester/src/http-test-api-context.ts
@@ -1,5 +1,4 @@
 import {
-  type AssertionFailure,
   type CommonHttpRequest,
   type CommonHttpResponse,
   createRegExpFromOriginWildcard,
@@ -143,24 +142,24 @@ export class HttpTestApiContext<
 
       const transactionsToValidate = transactions
         .filter(hasSource)
-        .map<
-          [CommonHttpRequest, CommonHttpResponse, RuleViolationLocation]
-        >((transaction) => [
-          httpRequestToCommonHttpRequest(
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            transaction.request!,
-            transaction.source.thymianReqId,
-          ),
-          httpResponseToCommonHttpResponse(
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            transaction.response!,
-            transaction.source.thymianResId,
-          ),
-          {
-            elementId: transaction.source.transactionId,
-            elementType: 'edge',
-          },
-        ]);
+        .map<[CommonHttpRequest, CommonHttpResponse, RuleViolationLocation]>(
+          (transaction) => [
+            httpRequestToCommonHttpRequest(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              transaction.request!,
+              transaction.source.thymianReqId,
+            ),
+            httpResponseToCommonHttpResponse(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              transaction.response!,
+              transaction.source.thymianResId,
+            ),
+            {
+              elementId: transaction.source.transactionId,
+              elementType: 'edge',
+            },
+          ],
+        );
 
       const results = validationFn(source.key, transactionsToValidate);
       callViolations.push(...results);
@@ -263,6 +262,10 @@ export class HttpTestApiContext<
           | undefined;
 
         if (assertionFailure && assertionFailure.transaction) {
+          // Mark the case as violated for status derivation, but keep the
+          // assertion detail on the raw test-case `results`; the report mapping
+          // (index.ts `buildTestStep`) maps those results into findings so all
+          // HttpTestCaseResult → report mapping lives in one place.
           const result: RuleFnResult = {
             location: {
               elementId: assertionFailure.transaction.transactionId,

--- a/packages/plugin-http-tester/src/index.ts
+++ b/packages/plugin-http-tester/src/index.ts
@@ -73,17 +73,14 @@ function ruleViolationToStepFinding(
 function buildTestStep(
   step: HttpTestCaseStep,
   stepIndex: number,
-  casePlacements: RuleFnResultPlacement[],
+  stepPlacements: RuleFnResultPlacement[],
   caseResults: readonly HttpTestCaseResult[],
   rule: Rule,
   location: Location,
 ): TestStep {
-  // Associate results with this step by their placement `stepIndex` (which the
-  // context derives from each result's `location.stepIdx`), rather than relying
-  // on the caller to pre-filter.
-  const stepPlacements = casePlacements.filter(
-    (p) => p.stepIndex === stepIndex,
-  );
+  // `stepPlacements` are the placements the caller has already grouped for this
+  // step (by each placement's `stepIndex`, derived from the result's
+  // `location.stepIdx`).
 
   // Build the step's transactions, keeping a map from a transaction's raw index
   // in `step.transactions` to its index in the (filtered) `httpTransactions`, so
@@ -364,11 +361,26 @@ export function createRuns(
             }
           }
 
+          // Group the case's placements by step once, so each step reads its
+          // own slice instead of re-scanning all case placements per step.
+          const placementsByStep = new Map<number, RuleFnResultPlacement[]>();
+          for (const placement of casePlacements) {
+            if (placement.stepIndex === undefined) {
+              continue; // case-level placement — not tied to a step
+            }
+            const list = placementsByStep.get(placement.stepIndex);
+            if (list) {
+              list.push(placement);
+            } else {
+              placementsByStep.set(placement.stepIndex, [placement]);
+            }
+          }
+
           const steps = testCase.steps.map((step, stepIndex) =>
             buildTestStep(
               step,
               stepIndex,
-              casePlacements,
+              placementsByStep.get(stepIndex) ?? [],
               testCase.results,
               rule,
               stepToLocation(step),

--- a/packages/plugin-http-tester/src/index.ts
+++ b/packages/plugin-http-tester/src/index.ts
@@ -136,7 +136,9 @@ function buildTestStep(
   }
 
   // A violation with no failure detail still needs a visible marker; when detail
-  // findings already convey the failure, don't add a duplicate generic marker.
+  // findings already convey the failure, don't add a duplicate generic marker —
+  // UNLESS the violation carries its own message (a distinct rationale that the
+  // detail records don't convey), in which case keep it so it isn't dropped.
   const violation = stepPlacements.find(
     ({ result }) => result.violation !== undefined,
   )?.result.violation;
@@ -145,7 +147,10 @@ function buildTestStep(
   );
 
   const findings: FindingRecord[] = [];
-  if (violation !== undefined && !hasFailureDetail) {
+  if (
+    violation !== undefined &&
+    (!hasFailureDetail || violation.message !== undefined)
+  ) {
     findings.push(ruleViolationToStepFinding(violation, rule));
   }
   findings.push(...detailRecords);

--- a/packages/plugin-http-tester/src/index.ts
+++ b/packages/plugin-http-tester/src/index.ts
@@ -8,12 +8,16 @@ import {
   type ExecutionStatus,
   type FindingRecord,
   type HttpTestCase,
+  type HttpTestCaseResult,
   type HttpTestCaseStep,
+  type HttpTestResult,
+  httpTestResultToRuleFindings,
   isCustomHttpTestCaseStep,
   isGroupedHttpTestCaseStep,
   isSingleHttpTestCaseStep,
   type Location,
   type Logger,
+  type ReportHttpTransaction,
   resolveViolationLocation,
   type Rule,
   ruleFindingToFindingRecord,
@@ -66,36 +70,85 @@ function ruleViolationToStepFinding(
   } satisfies FindingRecord;
 }
 
-// stepPlacements must be pre-filtered to this step (testCaseIndex + stepIndex match).
 function buildTestStep(
   step: HttpTestCaseStep,
   stepIndex: number,
-  stepPlacements: RuleFnResultPlacement[],
+  casePlacements: RuleFnResultPlacement[],
+  caseResults: readonly HttpTestCaseResult[],
   rule: Rule,
   location: Location,
 ): TestStep {
-  const findings: FindingRecord[] = [];
+  // Associate results with this step by their placement `stepIndex` (which the
+  // context derives from each result's `location.stepIdx`), rather than relying
+  // on the caller to pre-filter.
+  const stepPlacements = casePlacements.filter(
+    (p) => p.stepIndex === stepIndex,
+  );
+
+  // Build the step's transactions, keeping a map from a transaction's raw index
+  // in `step.transactions` to its index in the (filtered) `httpTransactions`, so
+  // a finding's `transactionIndex` can be re-based onto the exposed array.
+  const httpTransactions: ReportHttpTransaction[] = [];
+  const rawToExposedTxIndex = new Map<number, number>();
+  step.transactions.forEach((t, rawIdx) => {
+    if (t.request !== undefined && t.response !== undefined) {
+      rawToExposedTxIndex.set(rawIdx, httpTransactions.length);
+      httpTransactions.push({ request: t.request, response: t.response });
+    }
+  });
+
+  const rebaseTransactionIndex = (finding: FindingRecord): FindingRecord => {
+    if (finding.transactionIndex === undefined) {
+      return finding;
+    }
+    const exposed = rawToExposedTxIndex.get(finding.transactionIndex);
+    if (exposed === undefined) {
+      const rest = { ...finding };
+      delete rest.transactionIndex;
+      return rest;
+    }
+    return { ...finding, transactionIndex: exposed };
+  };
+
+  // Detail findings come from two sources, both funneled through the shared
+  // HttpTestCaseResult/RuleFinding → FindingRecord mappers so all mapping lives
+  // in one place: rule-based validation results carried on `RuleFnResult.findings`,
+  // and the case's raw `HttpTestCaseResult`s tied to this step by `location.stepIdx`.
+  const detailRecords: FindingRecord[] = [];
 
   for (const { result } of stepPlacements) {
-    if (result.violation !== undefined) {
-      findings.push(ruleViolationToStepFinding(result.violation, rule));
-    }
     for (const finding of result.findings) {
       const record = ruleFindingToFindingRecord(finding);
       if (record) {
-        findings.push(record);
+        detailRecords.push(rebaseTransactionIndex(record));
       }
     }
   }
 
-  const httpTransactions = step.transactions
-    .filter((t) => t.request !== undefined && t.response !== undefined)
-    .map((t) => ({
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      request: t.request!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      response: t.response!,
-    }));
+  const stepResults = caseResults.filter(
+    (result) => result.location?.stepIdx === stepIndex,
+  );
+  for (const finding of httpTestResultToRuleFindings(stepResults)) {
+    const record = ruleFindingToFindingRecord(finding);
+    if (record) {
+      detailRecords.push(rebaseTransactionIndex(record));
+    }
+  }
+
+  // A violation with no failure detail still needs a visible marker; when detail
+  // findings already convey the failure, don't add a duplicate generic marker.
+  const violation = stepPlacements.find(
+    ({ result }) => result.violation !== undefined,
+  )?.result.violation;
+  const hasFailureDetail = detailRecords.some(
+    (f) => f.kind === 'assertion-failure' || f.kind === 'rule-violation',
+  );
+
+  const findings: FindingRecord[] = [];
+  if (violation !== undefined && !hasFailureDetail) {
+    findings.push(ruleViolationToStepFinding(violation, rule));
+  }
+  findings.push(...detailRecords);
 
   return createTestStep({
     name: `Step ${stepIndex + 1}`,
@@ -184,6 +237,61 @@ function computeTestCaseStatus(
   };
 }
 
+/**
+ * Combine the placements the context recorded with placements synthesized for
+ * rule results that reference an executed transaction but weren't placed.
+ *
+ * A rule may collect violations from a `.transactions()` inspection callback and
+ * return them directly (rather than failing the test case), so the context never
+ * records a placement for them. Each such result still carries the transaction's
+ * edge id, so we match it back to the test case/step that ran that transaction —
+ * letting it render on the right step instead of falling through to the unplaced
+ * fallback.
+ */
+function resolvePlacements(
+  testResult: HttpTestResult,
+  contextPlacements: RuleFnResultPlacement[],
+  ruleFnResult: RuleFnResult[],
+  alreadyConsumed: ReadonlySet<RuleFnResult>,
+): RuleFnResultPlacement[] {
+  const positionByEdgeId = new Map<
+    string,
+    { testCaseIndex: number; stepIndex: number }
+  >();
+  testResult.cases.forEach((testCase, testCaseIndex) => {
+    testCase.steps.forEach((step, stepIndex) => {
+      for (const transaction of step.transactions) {
+        const id = transaction.source?.transactionId;
+        if (id !== undefined && !positionByEdgeId.has(id)) {
+          positionByEdgeId.set(id, { testCaseIndex, stepIndex });
+        }
+      }
+    });
+  });
+
+  const placed = new Set(
+    contextPlacements.map((placement) => placement.result),
+  );
+  const synthesized: RuleFnResultPlacement[] = [];
+  for (const result of ruleFnResult) {
+    if (placed.has(result) || alreadyConsumed.has(result)) {
+      continue;
+    }
+    const { location } = result;
+    const edgeId =
+      typeof location !== 'string' && location.elementType === 'edge'
+        ? location.elementId
+        : undefined;
+    const position =
+      edgeId !== undefined ? positionByEdgeId.get(edgeId) : undefined;
+    if (position !== undefined) {
+      synthesized.push({ result, ...position });
+    }
+  }
+
+  return [...contextPlacements, ...synthesized];
+}
+
 // exported for testing
 export function createRuns(
   pluginName: string,
@@ -191,6 +299,7 @@ export function createRuns(
   rules: Rule[] = [],
   thymianFormat: ThymianFormat,
   logger: Logger,
+  thymianFormatVersion?: string,
 ): ToolRun[] {
   const ruleMap = new Map(rules.map((r) => [r.meta.name, r]));
   const executions: TestCaseExecution[] = [];
@@ -207,7 +316,17 @@ export function createRuns(
 
     if (diagnostics) {
       for (const { testResult, placements } of diagnostics) {
+        const resolvedPlacements = resolvePlacements(
+          testResult,
+          placements,
+          ruleFnResult,
+          consumedResults,
+        );
         testResult.cases.forEach((testCase, testCaseIndex) => {
+          const casePlacements = resolvedPlacements.filter(
+            (p) => p.testCaseIndex === testCaseIndex,
+          );
+
           // Case-level placements (no step index) no longer become findings —
           // the case outcome lives on `status`. Accumulate violation/rule-skip
           // signals across every placement (case- and step-level) to derive it.
@@ -215,7 +334,7 @@ export function createRuns(
             hasViolation: false,
             hasRuleSkip: false,
           };
-          const noteResult = (result: RuleFnResult): void => {
+          for (const { result } of casePlacements) {
             consumedResults.add(result);
             if (result.violation !== undefined) {
               signals.hasViolation = true;
@@ -231,32 +350,18 @@ export function createRuns(
                 }
               }
             }
-          };
-
-          for (const { result } of placements.filter(
-            (p) =>
-              p.testCaseIndex === testCaseIndex && p.stepIndex === undefined,
-          )) {
-            noteResult(result);
           }
 
-          const steps = testCase.steps.map((step, stepIndex) => {
-            const stepPlacements = placements.filter(
-              (p) =>
-                p.testCaseIndex === testCaseIndex && p.stepIndex === stepIndex,
-            );
-            for (const { result } of stepPlacements) {
-              noteResult(result);
-            }
-
-            return buildTestStep(
+          const steps = testCase.steps.map((step, stepIndex) =>
+            buildTestStep(
               step,
               stepIndex,
-              stepPlacements,
+              casePlacements,
+              testCase.results,
               rule,
               stepToLocation(step),
-            );
-          });
+            ),
+          );
 
           executions.push(
             createTestCaseExecution({
@@ -270,9 +375,10 @@ export function createRuns(
       }
     }
 
-    // Fallback: results not placed by diagnostics have no test-case/step slot in
-    // the strict model. This path is verified unreachable in production; emit a
-    // failed test case (folding any diagnostic text into the reason) and warn.
+    // Fallback: a result that could not be attached to any executed test
+    // case/step (it references no known transaction, e.g. a rule reporting at a
+    // non-edge location). Emit a standalone test case (folding any diagnostic
+    // text into the reason) and warn, so the result is still surfaced.
     for (const result of ruleFnResult) {
       if (consumedResults.has(result)) {
         continue;
@@ -324,7 +430,9 @@ export function createRuns(
       runType: 'test',
       executions,
       rules: ruleDescriptors.length > 0 ? ruleDescriptors : undefined,
-      thymianFormatVersion: thymianFormat.toHash(),
+      // Reuse the hash carried by the serialized input format when provided,
+      // instead of recomputing it here.
+      thymianFormatVersion: thymianFormatVersion ?? thymianFormat.toHash(),
     }),
   ];
 }
@@ -395,7 +503,14 @@ export function createHttpTesterPlugin(
           );
 
           ctx.reply(
-            createRuns(pluginName, ruleResults, rules, thymianFormat, logger),
+            createRuns(
+              pluginName,
+              ruleResults,
+              rules,
+              thymianFormat,
+              logger,
+              format.attributes.hash,
+            ),
           );
         },
       );

--- a/packages/plugin-http-tester/src/index.ts
+++ b/packages/plugin-http-tester/src/index.ts
@@ -259,6 +259,13 @@ function resolvePlacements(
   ruleFnResult: RuleFnResult[],
   alreadyConsumed: ReadonlySet<RuleFnResult>,
 ): RuleFnResultPlacement[] {
+  // Known limitation: an unplaced result carries only an edge id (no step
+  // index), so when the same `source.transactionId` runs in more than one
+  // step/case (e.g. a replayed step reuses the previous step's source — see
+  // replay-previous-step.operator), we cannot tell which occurrence the result
+  // belongs to. We deterministically attach it to the FIRST occurrence; a
+  // precise fix needs the producer to tag the result with its originating step.
+  // See https://github.com/thymianofficial/thymian-internal/issues/423.
   const positionByEdgeId = new Map<
     string,
     { testCaseIndex: number; stepIndex: number }

--- a/packages/plugin-http-tester/src/index.ts
+++ b/packages/plugin-http-tester/src/index.ts
@@ -136,18 +136,39 @@ function buildTestStep(
   // findings already convey the failure, don't add a duplicate generic marker —
   // UNLESS the violation carries its own message (a distinct rationale that the
   // detail records don't convey), in which case keep it so it isn't dropped.
-  const violation = stepPlacements.find(
-    ({ result }) => result.violation !== undefined,
-  )?.result.violation;
+  // Every violation-bearing placement is considered (not just the first), so a
+  // step carrying multiple violations with distinct messages renders each; the
+  // generic marker and identical messages are collapsed to one.
+  const violations = stepPlacements
+    .map(({ result }) => result.violation)
+    .filter((v) => v !== undefined);
   const hasFailureDetail = detailRecords.some(
     (f) => f.kind === 'assertion-failure' || f.kind === 'rule-violation',
   );
 
   const findings: FindingRecord[] = [];
-  if (
-    violation !== undefined &&
-    (!hasFailureDetail || violation.message !== undefined)
-  ) {
+  const seenMessages = new Set<string>();
+  let emittedGenericMarker = false;
+  for (const violation of violations) {
+    // Suppress a generic marker only when detail already conveys the failure
+    // AND the violation adds no distinct rationale of its own.
+    if (hasFailureDetail && violation.message === undefined) {
+      continue;
+    }
+    if (violation.message === undefined) {
+      // All message-less violations render the same generic marker (the rule's
+      // summary); emit it at most once.
+      if (emittedGenericMarker) {
+        continue;
+      }
+      emittedGenericMarker = true;
+    } else {
+      // Distinct messages each render; identical messages collapse to one.
+      if (seenMessages.has(violation.message)) {
+        continue;
+      }
+      seenMessages.add(violation.message);
+    }
     findings.push(ruleViolationToStepFinding(violation, rule));
   }
   findings.push(...detailRecords);
@@ -255,6 +276,7 @@ function resolvePlacements(
   contextPlacements: RuleFnResultPlacement[],
   ruleFnResult: RuleFnResult[],
   alreadyConsumed: ReadonlySet<RuleFnResult>,
+  allPlacedResults: ReadonlySet<RuleFnResult>,
 ): RuleFnResultPlacement[] {
   // Known limitation: an unplaced result carries only an edge id (no step
   // index), so when the same `source.transactionId` runs in more than one
@@ -278,12 +300,13 @@ function resolvePlacements(
     });
   });
 
-  const placed = new Set(
-    contextPlacements.map((placement) => placement.result),
-  );
+  // `allPlacedResults` spans EVERY diagnostics entry, not just this one: a
+  // result placed by another `ctx.httpTest()`/`ctx.validate*()` call must never
+  // be synthesized into a different entry that merely ran the same edge id, or
+  // one failure double-reports and flips a passing case from another call.
   const synthesized: RuleFnResultPlacement[] = [];
   for (const result of ruleFnResult) {
-    if (placed.has(result) || alreadyConsumed.has(result)) {
+    if (allPlacedResults.has(result) || alreadyConsumed.has(result)) {
       continue;
     }
     const { location } = result;
@@ -324,12 +347,18 @@ export function createRuns(
     const consumedResults = new Set<RuleFnResult>();
 
     if (diagnostics) {
+      // Every result placed by ANY diagnostics entry, computed once. Guards
+      // synthesis against cross-entry leaks (see resolvePlacements).
+      const allPlacedResults = new Set(
+        diagnostics.flatMap((d) => d.placements).map((p) => p.result),
+      );
       for (const { testResult, placements } of diagnostics) {
         const resolvedPlacements = resolvePlacements(
           testResult,
           placements,
           ruleFnResult,
           consumedResults,
+          allPlacedResults,
         );
         testResult.cases.forEach((testCase, testCaseIndex) => {
           const casePlacements = resolvedPlacements.filter(

--- a/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
+++ b/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
@@ -189,4 +189,76 @@ describe('assertion failure → transaction traceability', () => {
     expect(failedCase).toBeDefined();
     expect(failedCase!.status.kind).toBe('failed');
   });
+
+  it('renders a schema-validation (checkBody) failure on its step with a transaction link', async () => {
+    // The GET /users response is declared with a schema requiring an integer
+    // `id`; the live response body violates it, so run-requests emits a schema
+    // assertion-failure. Its per-property detail must render on the step (and
+    // trace back to the transaction) rather than being silently dropped.
+    const format = createThymianFormatWithTransaction(
+      createHttpRequest({ method: 'get', path: '/users' }),
+      createHttpResponse({
+        statusCode: 200,
+        mediaType: 'application/json',
+        schema: {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'integer' } },
+        },
+      }),
+    );
+
+    const context = new HttpTestApiContext(
+      'schema-detail-test',
+      mockContextReturning(format, {
+        statusCode: 200,
+        headers: {},
+        body: JSON.stringify({ id: 'not-an-integer' }),
+        duration: 0,
+        trailers: {},
+      }),
+    );
+
+    const ruleFnResult = await context.httpTest(
+      singleTestCase()
+        .forTransactionsWith(method('get'))
+        .run({ checkBody: true })
+        .done(),
+    );
+    const diagnostics = context.getRuleExecutionDiagnostics();
+
+    const rule = httpRule('test/response-body-schema')
+      .severity('error')
+      .type('test')
+      .summary('Response body conforms to schema')
+      .rule(() => [])
+      .done();
+
+    const [run] = createRuns(
+      'test-plugin',
+      { [rule.meta.name]: { ruleFnResult, diagnostics } },
+      [rule],
+      format,
+      makeLogger(),
+    );
+
+    const cases = (run?.executions ?? []) as TestCaseExecution[];
+    const failedCase = cases.find((c) => c.status.kind === 'failed');
+    expect(failedCase).toBeDefined();
+
+    const owningStep = failedCase!.steps.find((step) =>
+      step.findings.some((f) => f.kind === 'assertion-failure'),
+    );
+    expect(owningStep).toBeDefined();
+
+    const assertionFailure = owningStep!.findings.find(
+      (f) => f.kind === 'assertion-failure',
+    );
+    expect(assertionFailure).toBeDefined();
+    // The per-property schema detail is preserved (not dropped)...
+    expect(assertionFailure!.title).toContain('property "id"');
+    // ...and it traces back to a captured transaction on its step.
+    expect(assertionFailure!.transactionIndex).toBeDefined();
+    expect(owningStep!.httpTransactions).toBeDefined();
+  });
 });

--- a/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
+++ b/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
@@ -1,0 +1,131 @@
+import {
+  createHttpTestContext,
+  type HttpRequest,
+  type HttpRequestTemplate,
+  type HttpResponse,
+  httpRule,
+  type HttpTestContext,
+  type Logger,
+  method,
+  NoopLogger,
+  singleTestCase,
+  statusCode,
+  type TestCaseExecution,
+} from '@thymian/core';
+import {
+  createHttpRequest,
+  createHttpResponse,
+  createThymianFormatWithTransaction,
+} from '@thymian/core-testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HttpTestApiContext } from '../src/http-test-api-context.js';
+import { createRuns } from '../src/index.js';
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+function mockContextReturning(
+  format: ReturnType<typeof createThymianFormatWithTransaction>,
+  response: HttpResponse,
+): HttpTestContext {
+  return createHttpTestContext({
+    format,
+    logger: new NoopLogger(),
+    locals: {},
+    sampleRequest: async (transaction): Promise<HttpRequestTemplate> => ({
+      method: transaction.thymianReq.method,
+      origin: 'https://api.example.com',
+      path: transaction.thymianReq.path,
+      headers: transaction.thymianReq.headers ?? {},
+      pathParameters: {},
+      query: {},
+      authorize: true,
+      cookies: {},
+    }),
+    runRequest: async (_req: HttpRequest): Promise<HttpResponse> => response,
+    runHook: async (_hookName, hook) => ({ result: hook.value }),
+  });
+}
+
+describe('assertion failure → transaction traceability', () => {
+  it('traces a failed assertion in the report to its step transaction and HTTP detail', async () => {
+    // A valid GET /users transaction (live response matches the sampled 200) is
+    // then run through an assertion that (deliberately) expects a 500, so the
+    // assertion fails on a real, captured transaction — exercising the full path.
+    const format = createThymianFormatWithTransaction(
+      createHttpRequest({ method: 'get', path: '/users' }),
+      createHttpResponse({ statusCode: 200, headers: {} }),
+    );
+
+    const context = new HttpTestApiContext(
+      'trace-test',
+      mockContextReturning(format, {
+        statusCode: 200,
+        headers: {},
+        duration: 0,
+        trailers: {},
+      }),
+    );
+
+    const ruleFnResult = await context.httpTest(
+      singleTestCase()
+        .forTransactionsWith(method('get'))
+        .run()
+        .expectForTransactions(statusCode(500))
+        .done(),
+    );
+
+    const diagnostics = context.getRuleExecutionDiagnostics();
+    expect(diagnostics).toBeDefined();
+
+    const rule = httpRule('test/status-should-be-200')
+      .severity('error')
+      .type('test')
+      .summary('Status should be 200')
+      .rule(() => [])
+      .done();
+
+    const [run] = createRuns(
+      'test-plugin',
+      { [rule.meta.name]: { ruleFnResult, diagnostics } },
+      [rule],
+      format,
+      makeLogger(),
+    );
+
+    const cases = (run?.executions ?? []) as TestCaseExecution[];
+    const failedCase = cases.find((c) => c.status.kind === 'failed');
+    expect(failedCase).toBeDefined();
+
+    // Find the assertion-failure finding and the step that owns it.
+    const owningStep = failedCase!.steps.find((step) =>
+      step.findings.some((f) => f.kind === 'assertion-failure'),
+    );
+    expect(owningStep).toBeDefined();
+
+    const assertionFailure = owningStep!.findings.find(
+      (f) => f.kind === 'assertion-failure',
+    );
+    expect(assertionFailure).toBeDefined();
+
+    // The finding links to a specific transaction on its step, and that index
+    // resolves to a captured HTTP exchange with the response we can inspect.
+    expect(assertionFailure!.transactionIndex).toBeDefined();
+    expect(owningStep!.httpTransactions).toBeDefined();
+    const tracedTransaction =
+      owningStep!.httpTransactions![assertionFailure!.transactionIndex!];
+    expect(tracedTransaction).toBeDefined();
+    // The captured exchange the assertion ran against: the real 200 response
+    // that failed the `expect status 500` assertion is fully traceable.
+    expect(tracedTransaction!.response?.statusCode).toBe(200);
+    expect(tracedTransaction!.request.method.toLowerCase()).toBe('get');
+  });
+});

--- a/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
+++ b/packages/plugin-http-tester/test/assertion-transaction-trace.test.ts
@@ -1,10 +1,15 @@
+import { strict as assert } from 'node:assert';
+
 import {
   createHttpTestContext,
+  expect as expectAssertion,
   type HttpRequest,
   type HttpRequestTemplate,
   type HttpResponse,
   httpRule,
   type HttpTestContext,
+  type HttpTestContextLocals,
+  type HttpTestPipeline,
   type Logger,
   method,
   NoopLogger,
@@ -127,5 +132,61 @@ describe('assertion failure → transaction traceability', () => {
     // that failed the `expect status 500` assertion is fully traceable.
     expect(tracedTransaction!.response?.statusCode).toBe(200);
     expect(tracedTransaction!.request.method.toLowerCase()).toBe('get');
+  });
+
+  it('maps a failed top-level `expect` (no transaction) to a failed status, not skipped', async () => {
+    // A top-level `expect` assertion failure produces an assertion-failure
+    // result with NO transaction. It must still surface the case as `failed`
+    // (with the assertion message as the reason) rather than silently being
+    // reported as skipped and dropped from pass/fail counts.
+    const format = createThymianFormatWithTransaction(
+      createHttpRequest({ method: 'get', path: '/users' }),
+      createHttpResponse({ statusCode: 200, headers: {} }),
+    );
+
+    const context = new HttpTestApiContext(
+      'top-level-expect-test',
+      mockContextReturning(format, {
+        statusCode: 200,
+        headers: {},
+        duration: 0,
+        trailers: {},
+      }),
+    );
+
+    const base = singleTestCase()
+      .forTransactionsWith(method('get'))
+      .run()
+      .done();
+    const pipeline: HttpTestPipeline<HttpTestContextLocals> = (transactions) =>
+      base(transactions).pipe(
+        expectAssertion(() => {
+          assert.equal('actual', 'expected', 'top-level assertion failed');
+        }),
+      );
+
+    const ruleFnResult = await context.httpTest(pipeline);
+    const diagnostics = context.getRuleExecutionDiagnostics();
+
+    const rule = httpRule('test/top-level-expect')
+      .severity('error')
+      .type('test')
+      .summary('Top-level expect')
+      .rule(() => [])
+      .done();
+
+    const [run] = createRuns(
+      'test-plugin',
+      { [rule.meta.name]: { ruleFnResult, diagnostics } },
+      [rule],
+      format,
+      makeLogger(),
+    );
+
+    const cases = (run?.executions ?? []) as TestCaseExecution[];
+    expect(cases.filter((c) => c.status.kind === 'skipped')).toHaveLength(0);
+    const failedCase = cases.find((c) => c.status.kind === 'failed');
+    expect(failedCase).toBeDefined();
+    expect(failedCase!.status.kind).toBe('failed');
   });
 });

--- a/packages/plugin-http-tester/test/create-runs.test.ts
+++ b/packages/plugin-http-tester/test/create-runs.test.ts
@@ -271,6 +271,61 @@ describe('createRuns', () => {
     expect(stepFindings.some((f) => f.kind === 'assertion-failure')).toBe(true);
   });
 
+  it('renders every distinct violation message on a step, not just the first', () => {
+    // Two violation-bearing placements land on the same step (e.g. two failing
+    // transactions in one grouped step). Both messages must reach the step —
+    // selecting only the first would silently drop the second's rationale.
+    const first = makeResult('first violation');
+    const second = makeResult('second violation');
+    const cases = [makePassedCase('my-test', [makeStep()])];
+    const placements: RuleFnResultPlacement[] = [
+      { result: first, testCaseIndex: 0, stepIndex: 0 },
+      { result: second, testCaseIndex: 0, stepIndex: 0 },
+    ];
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      { testResult: { name: 'run', duration: 0, cases }, placements },
+    ];
+
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([first, second], diagnostics),
+      [rule],
+      FORMAT,
+      makeLogger(),
+    );
+    const messages = testCases(run!.executions)[0]!
+      .steps[0]!.findings.filter((f) => f.kind === 'rule-violation')
+      .map((f) => f.message?.text);
+    expect(messages).toContain('first violation');
+    expect(messages).toContain('second violation');
+  });
+
+  it('collapses identical violation messages on a step to a single marker', () => {
+    const a = makeResult('same message');
+    const b = makeResult('same message');
+    const cases = [makePassedCase('my-test', [makeStep()])];
+    const placements: RuleFnResultPlacement[] = [
+      { result: a, testCaseIndex: 0, stepIndex: 0 },
+      { result: b, testCaseIndex: 0, stepIndex: 0 },
+    ];
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      { testResult: { name: 'run', duration: 0, cases }, placements },
+    ];
+
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([a, b], diagnostics),
+      [rule],
+      FORMAT,
+      makeLogger(),
+    );
+    expect(
+      testCases(run!.executions)[0]!.steps[0]!.findings.filter(
+        (f) => f.kind === 'rule-violation',
+      ),
+    ).toHaveLength(1);
+  });
+
   it('maps a failed case WITHOUT a violation to skipped (could not execute)', () => {
     const cases = [makeFailedCase('failing-test', 'connection refused')];
     const diagnostics: HttpTesterRuleDiagnostics = [
@@ -531,6 +586,88 @@ describe('createRuns', () => {
       cases2[0]!.steps[0]!.findings.some((f) => f.kind === 'rule-violation'),
     ).toBe(true);
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not leak a placement from one diagnostics entry into another', () => {
+    // A rule makes two context calls that both run `tx-1`: a passing validate*()
+    // (entry A, no placement recorded) and a failing httpTest() (entry B, which
+    // places the failing result). The failure must render ONLY in entry B — the
+    // shared `ruleFnResult` must not be synthesized into entry A, which would
+    // flip its passing case to failed AND double-report the single failure.
+    const failing: RuleFnResult = {
+      location: { elementType: 'edge', elementId: 'tx-1' },
+      violation: { message: 'assertion failed in entry B' },
+      findings: [],
+    };
+    const makeEdgeStep = (): HttpTestCaseStep =>
+      ({
+        type: 'single',
+        source: { transactionId: 'tx-1' },
+        transactions: [
+          {
+            request: { origin: 'http://localhost', path: '/x', method: 'GET' },
+            response: { statusCode: 200, headers: {} },
+            source: { transactionId: 'tx-1' },
+          },
+        ],
+      }) as unknown as HttpTestCaseStep;
+    const makeEdgeCase = (name: string): HttpTestCase =>
+      ({
+        name,
+        status: 'passed',
+        start: 0,
+        end: 5,
+        steps: [makeEdgeStep()],
+        results: [],
+      }) as unknown as HttpTestCase;
+
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      {
+        testResult: {
+          name: 'validate',
+          duration: 0,
+          cases: [makeEdgeCase('case-a')],
+        },
+        placements: [],
+      },
+      {
+        testResult: {
+          name: 'httpTest',
+          duration: 0,
+          cases: [makeEdgeCase('case-b')],
+        },
+        placements: [{ result: failing, testCaseIndex: 0, stepIndex: 0 }],
+      },
+    ];
+
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([failing], diagnostics),
+      [rule],
+      FORMAT,
+      makeLogger(),
+    );
+    const cases = testCases(run!.executions);
+    expect(cases).toHaveLength(2);
+
+    const caseA = cases.find((c) => c.name === 'case-a')!;
+    const caseB = cases.find((c) => c.name === 'case-b')!;
+
+    // entry A's case stays passed — the failure belongs to entry B.
+    expect(caseA.status.kind).toBe('passed');
+    expect(
+      caseA.steps
+        .flatMap((s) => s.findings)
+        .some((f) => f.kind === 'rule-violation'),
+    ).toBe(false);
+
+    // entry B renders the failure exactly once.
+    expect(caseB.status.kind).toBe('failed');
+    expect(
+      caseB.steps
+        .flatMap((s) => s.findings)
+        .filter((f) => f.kind === 'rule-violation'),
+    ).toHaveLength(1);
   });
 
   describe('step locations', () => {

--- a/packages/plugin-http-tester/test/create-runs.test.ts
+++ b/packages/plugin-http-tester/test/create-runs.test.ts
@@ -210,6 +210,67 @@ describe('createRuns', () => {
     });
   });
 
+  it('keeps a distinct violation.message on the step even when failure detail exists', () => {
+    // A rule result that carries BOTH its own rationale (violation.message) and
+    // an assertion-failure finding: the rationale must not be suppressed by the
+    // presence of the detail — both should reach the step.
+    const result: RuleFnResult = {
+      location: { elementType: 'edge', elementId: 'tx-1' },
+      violation: { message: 'rule-specific rationale' },
+      findings: [{ kind: 'assertion-failure', title: 'value mismatch' }],
+    };
+    const cases = [makePassedCase('failing-test', [makeStep()])];
+    const placements: RuleFnResultPlacement[] = [
+      { result, testCaseIndex: 0, stepIndex: 0 },
+    ];
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      { testResult: { name: 'run', duration: 0, cases }, placements },
+    ];
+
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([result], diagnostics),
+      [rule],
+      FORMAT,
+      makeLogger(),
+    );
+
+    const stepFindings = testCases(run!.executions)[0]!.steps[0]!.findings;
+    expect(stepFindings.some((f) => f.kind === 'assertion-failure')).toBe(true);
+    const marker = stepFindings.find((f) => f.kind === 'rule-violation');
+    expect(marker).toBeDefined();
+    expect(marker!.message?.text).toBe('rule-specific rationale');
+  });
+
+  it('suppresses the generic marker when detail exists and the violation has no message', () => {
+    // The common case: an empty violation (no distinct rationale) alongside an
+    // assertion-failure detail should NOT add a duplicate generic marker.
+    const result: RuleFnResult = {
+      location: { elementType: 'edge', elementId: 'tx-1' },
+      violation: {},
+      findings: [{ kind: 'assertion-failure', title: 'value mismatch' }],
+    };
+    const cases = [makePassedCase('failing-test', [makeStep()])];
+    const placements: RuleFnResultPlacement[] = [
+      { result, testCaseIndex: 0, stepIndex: 0 },
+    ];
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      { testResult: { name: 'run', duration: 0, cases }, placements },
+    ];
+
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([result], diagnostics),
+      [rule],
+      FORMAT,
+      makeLogger(),
+    );
+
+    const stepFindings = testCases(run!.executions)[0]!.steps[0]!.findings;
+    expect(stepFindings.some((f) => f.kind === 'rule-violation')).toBe(false);
+    expect(stepFindings.some((f) => f.kind === 'assertion-failure')).toBe(true);
+  });
+
   it('maps a failed case WITHOUT a violation to skipped (could not execute)', () => {
     const cases = [makeFailedCase('failing-test', 'connection refused')];
     const diagnostics: HttpTesterRuleDiagnostics = [

--- a/packages/plugin-http-tester/test/create-runs.test.ts
+++ b/packages/plugin-http-tester/test/create-runs.test.ts
@@ -418,6 +418,60 @@ describe('createRuns', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('attaches a returned edge result to the step whose transaction it references', () => {
+    // Simulates a rule that collects a violation in a `.transactions()` callback
+    // and returns it without failing the case, so the context recorded no
+    // placement — the result still references the executed transaction by edge id.
+    const result: RuleFnResult = {
+      location: { elementType: 'edge', elementId: 'tx-42' },
+      violation: {},
+      findings: [],
+    };
+    const step = {
+      type: 'single',
+      source: { transactionId: 'tx-42' },
+      transactions: [
+        {
+          request: { origin: 'http://localhost', path: '/x', method: 'GET' },
+          response: { statusCode: 200, headers: {} },
+          source: { transactionId: 'tx-42' },
+        },
+      ],
+    } as unknown as HttpTestCaseStep;
+    const cases: HttpTestCase[] = [
+      {
+        name: 'GET /x',
+        status: 'passed',
+        start: 0,
+        end: 5,
+        steps: [step],
+        results: [],
+      } as unknown as HttpTestCase,
+    ];
+    const diagnostics: HttpTesterRuleDiagnostics = [
+      { testResult: { name: 'run', duration: 0, cases }, placements: [] },
+    ];
+
+    const logger = makeLogger();
+    const [run] = createRuns(
+      PLUGIN,
+      ruleResults([result], diagnostics),
+      [rule],
+      FORMAT,
+      logger,
+    );
+    const cases2 = testCases(run!.executions);
+
+    // Attached to the matching case (now failed) — no extra unplaced fallback case.
+    expect(cases2).toHaveLength(1);
+    expect(cases2[0]!.name).toBe('GET /x');
+    expect(cases2[0]!.status.kind).toBe('failed');
+    expect(
+      cases2[0]!.steps[0]!.findings.some((f) => f.kind === 'rule-violation'),
+    ).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   describe('step locations', () => {
     function stepLocationFor(step: HttpTestCaseStep) {
       const cases = [makePassedCase('my-test', [step])];

--- a/packages/plugin-http-tester/test/result-to-finding-mapping.test.ts
+++ b/packages/plugin-http-tester/test/result-to-finding-mapping.test.ts
@@ -1,0 +1,210 @@
+import {
+  httpRule,
+  type HttpTestCase,
+  type HttpTestCaseResult,
+  type HttpTestCaseStep,
+  type Logger,
+  type TestCaseExecution,
+  ThymianFormat,
+  type ThymianHttpTransaction,
+} from '@thymian/core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRuns,
+  type HttpTesterRuleDiagnostics,
+  type RuleFnResultPlacement,
+} from '../src/index.js';
+
+const PLUGIN = 'test-plugin';
+const FORMAT = new ThymianFormat();
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+const rule = httpRule('test/rule')
+  .severity('warn')
+  .type('test')
+  .summary('Test rule')
+  .rule(() => [])
+  .done();
+
+/** A single step with one complete (request+response) transaction. */
+function stepWithTransaction(transactionId: string): HttpTestCaseStep {
+  return {
+    type: 'single',
+    source: { transactionId } as unknown as ThymianHttpTransaction,
+    transactions: [
+      {
+        request: { origin: 'http://localhost', path: '/x', method: 'GET' },
+        response: { statusCode: 500, headers: {} },
+      },
+    ],
+  } as unknown as HttpTestCaseStep;
+}
+
+function runFor(
+  cases: HttpTestCase[],
+  placements: RuleFnResultPlacement[],
+): TestCaseExecution[] {
+  const diagnostics: HttpTesterRuleDiagnostics = [
+    { testResult: { name: 'run', duration: 0, cases }, placements },
+  ];
+  const [run] = createRuns(
+    PLUGIN,
+    { [rule.meta.name]: { ruleFnResult: [], diagnostics } },
+    [rule],
+    FORMAT,
+    makeLogger(),
+  );
+  return (run?.executions ?? []) as TestCaseExecution[];
+}
+
+describe('HttpTestCaseResult → report finding mapping', () => {
+  it('maps every result kind onto the owning step, losslessly', () => {
+    const results: HttpTestCaseResult[] = [
+      {
+        type: 'assertion-success',
+        message: 'status is 200',
+        assertion: 'status',
+        location: { stepIdx: 0, transactionIdx: 0 },
+      },
+      {
+        type: 'assertion-failure',
+        message: 'status mismatch',
+        assertion: 'status',
+        expected: 200,
+        actual: 500,
+        location: { stepIdx: 0, transactionIdx: 0 },
+      },
+      {
+        type: 'info',
+        message: 'noted',
+        details: 'some detail',
+        location: { stepIdx: 1, transactionIdx: 0 },
+      },
+      {
+        type: 'warning',
+        message: 'careful',
+        details: 'heads up',
+        location: { stepIdx: 1, transactionIdx: 0 },
+      },
+    ];
+
+    const cases: HttpTestCase[] = [
+      {
+        name: 'case',
+        status: 'failed',
+        start: 0,
+        end: 10,
+        steps: [stepWithTransaction('tx-0'), stepWithTransaction('tx-1')],
+        results,
+      } as unknown as HttpTestCase,
+    ];
+
+    const [execution] = runFor(cases, []);
+    const step0 = execution!.steps[0]!;
+    const step1 = execution!.steps[1]!;
+
+    // Step 0: success + failure, each on the correct step.
+    expect(step0.findings.map((f) => f.kind).sort()).toEqual([
+      'assertion-failure',
+      'assertion-success',
+    ]);
+
+    const failure = step0.findings.find((f) => f.kind === 'assertion-failure')!;
+    expect(failure).toMatchObject({
+      kind: 'assertion-failure',
+      // The title is the human-readable message, not the assert operator/name.
+      title: 'status mismatch',
+      expected: 200,
+      actual: 500,
+      transactionIndex: 0,
+    });
+    // The transactionIndex resolves to a captured exchange on the step.
+    expect(step0.httpTransactions?.[failure.transactionIndex!]).toBeDefined();
+
+    // Step 1: info + warning both map to informational detail.
+    expect(step1.findings.map((f) => f.kind)).toEqual([
+      'informational',
+      'informational',
+    ]);
+    expect(step1.findings.map((f) => f.message?.text)).toEqual([
+      'some detail',
+      'heads up',
+    ]);
+  });
+
+  it('carries invalid-transaction detail with its transaction index', () => {
+    const cases: HttpTestCase[] = [
+      {
+        name: 'case',
+        status: 'failed',
+        start: 0,
+        steps: [stepWithTransaction('tx-0')],
+        results: [
+          {
+            type: 'invalid-transaction',
+            message: 'invalid transaction',
+            details: 'bad shape',
+            location: { stepIdx: 0, transactionIdx: 0 },
+          },
+        ] satisfies HttpTestCaseResult[],
+      } as unknown as HttpTestCase,
+    ];
+
+    const [execution] = runFor(cases, []);
+    const finding = execution!.steps[0]!.findings[0]!;
+
+    expect(finding).toMatchObject({
+      kind: 'informational',
+      transactionIndex: 0,
+    });
+  });
+
+  it('does not duplicate a violation marker when detail findings exist', () => {
+    const violationPlacement: RuleFnResultPlacement = {
+      result: {
+        location: { elementType: 'edge', elementId: 'tx-0' },
+        violation: {},
+        findings: [],
+      },
+      testCaseIndex: 0,
+      stepIndex: 0,
+    };
+
+    const cases: HttpTestCase[] = [
+      {
+        name: 'case',
+        status: 'failed',
+        start: 0,
+        steps: [stepWithTransaction('tx-0')],
+        results: [
+          {
+            type: 'assertion-failure',
+            message: 'bad',
+            assertion: 'status',
+            expected: 1,
+            actual: 2,
+            location: { stepIdx: 0, transactionIdx: 0 },
+          },
+        ] satisfies HttpTestCaseResult[],
+      } as unknown as HttpTestCase,
+    ];
+
+    const [execution] = runFor(cases, [violationPlacement]);
+
+    // Only the detailed assertion-failure — no extra generic rule-violation marker.
+    expect(execution!.steps[0]!.findings.map((f) => f.kind)).toEqual([
+      'assertion-failure',
+    ]);
+    expect(execution!.status.kind).toBe('failed');
+  });
+});

--- a/packages/plugin-reporter/src/formatter.ts
+++ b/packages/plugin-reporter/src/formatter.ts
@@ -50,7 +50,7 @@ export function analyze(reports: Report[], logger?: Logger): ReportAnalysis {
     for (const run of report.runs) {
       const ruleIndex = buildRuleIndex(run.rules);
 
-      for (const { execution } of walkExecutions(run.executions)) {
+      for (const execution of walkExecutions(run.executions)) {
         statusCounts[execution.status.kind] += 1;
 
         const severity = resolveExecutionSeverity(execution, ruleIndex, logger);

--- a/packages/plugin-reporter/src/formatters/csv.ts
+++ b/packages/plugin-reporter/src/formatters/csv.ts
@@ -109,7 +109,7 @@ export function reportToCsvLines(report: Report): string[] {
     const ruleIndex = buildRuleIndex(run.rules);
     const runVersion = run.thymianFormatVersion;
 
-    for (const { execution } of walkExecutions(run.executions)) {
+    for (const execution of walkExecutions(run.executions)) {
       const ruleId = execution.ruleId ?? '';
       const status = execution.status;
       const severity = resolveExecutionSeverity(execution, ruleIndex);

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -47,6 +47,23 @@ function escapeHtml(text: string): string {
     .replaceAll('>', '&gt;');
 }
 
+/**
+ * Renders the "Rule" cell: the rule id as inline code, linked to its `helpUri`
+ * when present. Uses an HTML anchor (not a markdown `[text](url)` link) so a
+ * `helpUri` containing `)`, whitespace, etc. cannot break out of the link.
+ * Callers placing this inside a `|`-delimited table cell must still run the
+ * result through `escapeCell` to neutralise any `|`.
+ */
+function renderRuleCell(
+  ruleId: string | undefined,
+  helpUri: string | undefined,
+): string {
+  const label = escapeHtml(ruleId ?? 'unnamed check');
+  return helpUri
+    ? `<a href="${escapeHtml(helpUri)}"><code>${label}</code></a>`
+    : `<code>${label}</code>`;
+}
+
 function severityWord(severity: Severity): string {
   return severity === 'warn' ? 'warning' : severity;
 }
@@ -184,11 +201,11 @@ function buildLintAnalyzeSection(
     }
 
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
-    const ruleCell = execution.ruleId
-      ? rule?.helpUri
-        ? `[\`${execution.ruleId}\`](${rule.helpUri})`
-        : `\`${execution.ruleId}\``
-      : 'unnamed check';
+    // HTML anchor (via renderRuleCell), then escapeCell so a `|` in the id/uri
+    // can't break the surrounding markdown table row.
+    const ruleCell = escapeCell(
+      renderRuleCell(execution.ruleId, rule?.helpUri),
+    );
 
     if (execution.status.kind === 'failed') {
       const severity =
@@ -302,10 +319,7 @@ function buildTestSection(
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
     const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
     const severityPrefix = severity ? `${severityWord(severity)} · ` : '';
-    const ruleLabel = escapeHtml(execution.ruleId ?? 'unnamed check');
-    const ruleCell = rule?.helpUri
-      ? `<a href="${escapeHtml(rule.helpUri)}"><code>${ruleLabel}</code></a>`
-      : `<code>${ruleLabel}</code>`;
+    const ruleCell = renderRuleCell(execution.ruleId, rule?.helpUri);
     const message =
       execution.status.kind === 'failed'
         ? (execution.status.reason ??

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -39,12 +39,19 @@ function escapeCell(text: string): string {
   return text.replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
-/** Escapes text interpolated into raw HTML (e.g. inside `<details><summary>`). */
+/**
+ * Escapes text interpolated into raw HTML — both element content
+ * (e.g. inside `<details><summary>`) and double/single-quoted attribute
+ * values (e.g. `href="…"`). Quotes are escaped so a value cannot break out
+ * of its attribute; escaping them in element content is harmless.
+ */
 function escapeHtml(text: string): string {
   return text
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;');
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 /**

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -134,7 +134,7 @@ function countOutcomes(executions: Execution[] | undefined): {
   let skipped = 0;
   let passed = 0;
 
-  for (const { execution } of walkExecutions(executions)) {
+  for (const execution of walkExecutions(executions)) {
     if (execution.status.kind === 'failed') {
       failed += 1;
     } else if (execution.status.kind === 'skipped') {
@@ -169,7 +169,7 @@ function buildLintAnalyzeSection(
   const ruleIndex = buildRuleIndex(run.rules);
   const groups = new Map<string, string[]>();
 
-  for (const { execution } of walkExecutions(run.executions)) {
+  for (const execution of walkExecutions(run.executions)) {
     if (execution.kind !== 'lint' && execution.kind !== 'analyze') {
       continue;
     }
@@ -185,7 +185,9 @@ function buildLintAnalyzeSection(
 
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
     const ruleCell = execution.ruleId
-      ? `\`${execution.ruleId}\``
+      ? rule?.helpUri
+        ? `[\`${execution.ruleId}\`](${rule.helpUri})`
+        : `\`${execution.ruleId}\``
       : 'unnamed check';
 
     if (execution.status.kind === 'failed') {
@@ -285,7 +287,7 @@ function buildTestSection(
 
   const ruleIndex = buildRuleIndex(run.rules);
 
-  for (const { execution } of walkExecutions(run.executions)) {
+  for (const execution of walkExecutions(run.executions)) {
     if (execution.kind !== 'test' || execution.status.kind === 'passed') {
       continue;
     }
@@ -300,7 +302,10 @@ function buildTestSection(
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
     const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
     const severityPrefix = severity ? `${severityWord(severity)} · ` : '';
-    const ruleCell = `<code>${escapeHtml(execution.ruleId ?? 'unnamed check')}</code>`;
+    const ruleLabel = escapeHtml(execution.ruleId ?? 'unnamed check');
+    const ruleCell = rule?.helpUri
+      ? `<a href="${escapeHtml(rule.helpUri)}"><code>${ruleLabel}</code></a>`
+      : `<code>${ruleLabel}</code>`;
     const message =
       execution.status.kind === 'failed'
         ? (execution.status.reason ??

--- a/packages/plugin-reporter/test/formatters-and-statistics.test.ts
+++ b/packages/plugin-reporter/test/formatters-and-statistics.test.ts
@@ -104,7 +104,7 @@ const report = createReport([
   }),
 ]);
 
-describe('analyze statistics (AC11)', () => {
+describe('analyze statistics', () => {
   it('counts statuses, resolved severities and surviving finding kinds', () => {
     const { statistics } = analyze([report]);
 
@@ -132,7 +132,7 @@ describe('analyze statistics (AC11)', () => {
   });
 });
 
-describe('CSV flattening (AC13)', () => {
+describe('CSV flattening', () => {
   it('emits a row per execution and per finding', () => {
     const lines = reportToCsvLines(report);
 
@@ -150,7 +150,7 @@ describe('CSV flattening (AC13)', () => {
   });
 });
 
-describe('MarkdownFormatter rendering (AC13)', () => {
+describe('MarkdownFormatter rendering', () => {
   it('renders the human layout for lint status rows and test step findings', async () => {
     const formatter = new MarkdownFormatter(new NoopLogger());
     formatter.init({ path: join(process.cwd(), 'tmp', 'formatters.md') });
@@ -158,19 +158,19 @@ describe('MarkdownFormatter rendering (AC13)', () => {
 
     const output = (await formatter.flush()) ?? '';
 
+    // The rule has a `helpUri`, so the rule cell renders as a markdown link.
+    const ruleLink = '[`rfc9110/host`](https://example.com/rules/host)';
     expect(output).toContain('### GET /pets');
-    expect(output).toContain(
-      '| error | `rfc9110/host` | Missing Host header |',
-    );
+    expect(output).toContain(`| error | ${ruleLink} | Missing Host header |`);
     expect(output).toContain('### GET /dogs');
     expect(output).toContain(
-      '| skipped | `rfc9110/host` | rule disabled in config |',
+      `| skipped | ${ruleLink} | rule disabled in config |`,
     );
     expect(output).toContain('### POST /pets fails · _✖ failed_');
     expect(output).toContain('— expected: 200, actual: 500');
     expect(output).not.toContain('GET /pets returns 200');
     // GET /cats' informational finding has no `message`; the Message cell
     // must fall back to the finding's (always-present) title.
-    expect(output).toContain('| info | `rfc9110/host` | noted |');
+    expect(output).toContain(`| info | ${ruleLink} | noted |`);
   });
 });

--- a/packages/plugin-reporter/test/formatters-and-statistics.test.ts
+++ b/packages/plugin-reporter/test/formatters-and-statistics.test.ts
@@ -158,8 +158,10 @@ describe('MarkdownFormatter rendering', () => {
 
     const output = (await formatter.flush()) ?? '';
 
-    // The rule has a `helpUri`, so the rule cell renders as a markdown link.
-    const ruleLink = '[`rfc9110/host`](https://example.com/rules/host)';
+    // The rule has a `helpUri`, so the rule cell renders as a linked code label
+    // (an HTML anchor, so a `helpUri` containing `)`/whitespace can't break out).
+    const ruleLink =
+      '<a href="https://example.com/rules/host"><code>rfc9110/host</code></a>';
     expect(output).toContain('### GET /pets');
     expect(output).toContain(`| error | ${ruleLink} | Missing Host header |`);
     expect(output).toContain('### GET /dogs');

--- a/packages/plugin-reporter/test/markdown.test.ts
+++ b/packages/plugin-reporter/test/markdown.test.ts
@@ -490,8 +490,35 @@ describe('MarkdownFormatter summary HTML escaping', () => {
     const output = await render(report);
 
     expect(output).toContain(
-      '<summary>error · <code>r&amp;&lt;&gt;ule</code> · &lt;b&gt;&amp;"bad"&lt;/b&gt;</summary>',
+      '<summary>error · <code>r&amp;&lt;&gt;ule</code> · &lt;b&gt;&amp;&quot;bad&quot;&lt;/b&gt;</summary>',
     );
     expect(output).not.toContain('<b>&"bad"</b>');
+  });
+
+  it('escapes quotes in a helpUri so it cannot break out of the href attribute', async () => {
+    const helpUri = 'https://x/rules"><script>alert(1)</script>';
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [{ id: 'quote-uri', severity: 'error', helpUri }],
+        executions: [
+          createLintExecution({
+            location: { type: 'custom', value: 'GET /x' },
+            ruleId: 'quote-uri',
+            status: { kind: 'failed', reason: 'boom' },
+          }),
+        ],
+      }),
+    ]);
+
+    const output = await render(report);
+
+    // The `"` must be entity-escaped so the attribute value stays intact and
+    // the injected `<script>` cannot escape into raw markup.
+    expect(output).toContain(
+      `<a href="https://x/rules&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"><code>quote-uri</code></a>`,
+    );
+    expect(output).not.toContain('"><script>alert(1)</script>');
   });
 });

--- a/packages/plugin-reporter/test/markdown.test.ts
+++ b/packages/plugin-reporter/test/markdown.test.ts
@@ -203,18 +203,49 @@ describe('MarkdownFormatter lint/analyze bodies (AC5-AC8)', () => {
     const output = await render(report);
 
     expect(output).toContain('### POST /orders');
-    expect(output).toContain('| warning | `content-type-charset` | msg |');
     expect(output).toContain(
-      '| info | `content-type-charset` | auth-scheme deprecated |',
+      '| warning | <code>content-type-charset</code> | msg |',
+    );
+    expect(output).toContain(
+      '| info | <code>content-type-charset</code> | auth-scheme deprecated |',
     );
     expect(output).toContain('### GET /widgets');
-    expect(output).toContain('| error | unnamed check | broken |');
+    expect(output).toContain('| error | <code>unnamed check</code> | broken |');
   });
 
   it('omits passed executions with no findings and their location (AC7)', async () => {
     const output = await render(report);
 
     expect(output).not.toContain('### GET /pets');
+  });
+
+  it('escapes a helpUri containing `)` so the table row is not corrupted', async () => {
+    const helpUri = 'https://x/rules?a=1)&b=2';
+    const linkedReport = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [{ id: 'tricky-uri', severity: 'error', helpUri }],
+        executions: [
+          createLintExecution({
+            location: { type: 'custom', value: 'GET /x' },
+            ruleId: 'tricky-uri',
+            status: { kind: 'failed', reason: 'boom' },
+          }),
+        ],
+      }),
+    ]);
+
+    const output = await render(linkedReport);
+
+    // Rendered as an HTML anchor (not a markdown `[text](url)` link), so the
+    // `)` stays inside the href instead of truncating the link and leaking the
+    // rest of the URL into the table row.
+    expect(output).toContain(
+      `| error | <a href="${helpUri.replaceAll('&', '&amp;')}"><code>tricky-uri</code></a> | boom |`,
+    );
+    // The corrupt markdown-link form must not appear.
+    expect(output).not.toContain(`](${helpUri})`);
   });
 });
 
@@ -254,7 +285,7 @@ describe('MarkdownFormatter lint/analyze assertion-failure findings', () => {
     const output = await render(report);
 
     expect(output).toContain(
-      '| failed | `schema-conforms` | unexpected status code — expected: 200, actual: 404 |',
+      '| failed | <code>schema-conforms</code> | unexpected status code — expected: 200, actual: 404 |',
     );
     // assertion-success stays omitted, consistent with the omit-passed policy.
     expect(output).not.toContain('headers ok');
@@ -287,7 +318,7 @@ describe('MarkdownFormatter lint/analyze assertion-failure findings', () => {
     const output = await render(report);
 
     expect(output).toContain(
-      '| failed | `schema-conforms` | missing required header |',
+      '| failed | <code>schema-conforms</code> | missing required header |',
     );
     expect(output).not.toContain('undefined');
   });

--- a/packages/plugin-sampler/test/generate-request-types.test.ts
+++ b/packages/plugin-sampler/test/generate-request-types.test.ts
@@ -10,7 +10,9 @@ import {
 describe('generateRequestTypes', () => {
   it(
     'should generate request type definitions as a string - small',
-    { timeout: 10000 },
+    // ts-morph pulls in the full TS compiler; its cold import can exceed 10s on
+    // slow (esp. Windows) CI runners, so give the import headroom.
+    { timeout: 30_000 },
     async () => {
       const format = new ThymianFormat();
 
@@ -77,7 +79,7 @@ describe('generateRequestTypes', () => {
 
   it(
     'should generate request type definitions as a string - large',
-    { timeout: 10_000 },
+    { timeout: 30_000 },
     async () => {
       const format = ThymianFormat.import(
         {

--- a/packages/rules-api-description-validation/src/rules/request-body-conforms-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/request-body-conforms-to-schema.rule.ts
@@ -65,7 +65,9 @@ export default httpRule('thymian/request-body-must-conform-to-schema')
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Request body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/request-headers-conform-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/request-headers-conform-to-schema.rule.ts
@@ -68,7 +68,9 @@ export default httpRule('thymian/request-headers-must-conform-to-schema')
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Request headers do not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/request-path-parameters-conform-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/request-path-parameters-conform-to-schema.rule.ts
@@ -72,7 +72,9 @@ export default httpRule(
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Request path parameters do not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/request-query-parameters-conform-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/request-query-parameters-conform-to-schema.rule.ts
@@ -74,7 +74,9 @@ export default httpRule(
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Request query parameters do not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/response-body-conforms-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/response-body-conforms-to-schema.rule.ts
@@ -71,7 +71,9 @@ export default httpRule('thymian/response-body-must-conforms-to-schema')
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Response body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/response-headers-conform-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/response-headers-conform-to-schema.rule.ts
@@ -71,7 +71,9 @@ export default httpRule('thymian/response-headers-must-conform-to-schema')
           return [
             {
               location,
-              violation: { message: `${failures.length} assertion(s) failed` },
+              violation: {
+                message: `Response headers do not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+              },
               findings: httpTestResultToRuleFindings(results),
             },
           ];


### PR DESCRIPTION
# Stabilize, widen, and harden the new report model


## Summary

This finalizes the new report model: a flat, per-runType execution model with an explicit status, richer schema-validation detail, and formatters adapted to it. On top of the feature work, it includes a round of review-driven correctness fixes to the http-tester → report mapping path.

## What changed

### Report model (@thymian/core)
- Flat, non-recursive Execution list per run with an explicit status (passed / failed / skipped) instead of nested visit wrappers.
- walkExecutions now yields Execution directly; the ExecutionVisit wrapper type was removed. ⚠️ Breaking for external consumers of the traversal API — all in-repo consumers (reporter, common-cli) are migrated in this PR.
- Wider, clearer schema-error reporting: describeSchemaError names the offending property path (incl. additionalProperties keys, e.g. property "user.extra" is not allowed), and schemaErrorDetail derives expected/actual pairs for renderers.
- validate-* helpers consolidated onto the shared schema-error detail path.

### Formatters (@thymian/plugin-reporter, @thymian/common-cli)
- Markdown / CSV / CLI adapted to the flat execution model and the new finding shape.

## Review hardening (correctness fixes)

Findings from a review of the report-model rework, each with tests:

- Schema-validation failures were dropped from the report — checkBody/checkHeaders/checkResponse failures were pushed without a location, so buildTestStep couldn't tie them to a step and their per-property detail vanished. Now tagged with { stepIdx, transactionIdx } like expectForTransactions. (the one genuine regression in the rework)
- Markdown table corruption — the lint/analyze rule cell interpolated helpUri into a raw [text](url) link; a )/whitespace in the URL broke the row. Unified both report sections onto a shared, escaped HTML-anchor helper.
- Schema boundary mislabeled as expected — maxLength: 3 on "abcd" rendered as expected: 3, actual: "abcd". Boundary keywords now emit no misleading pair (the message already states the bound).
- Failed top-level expect reported as skipped — an assertion failure with no transaction produced no violation signal; now surfaces as failed while genuine execution failures still map to skipped.
- Distinct violation.message dropped — the generic step marker was suppressed whenever failure detail existed, discarding a rule's own rationale; now retained when the violation carries its own message.
- Perf/readability — step placements are grouped once per case instead of re-filtered per step.

## Known limitation / follow-up

- When the same transactionId runs in multiple steps (e.g. a replayed step), an unplaced rule result can only be attached to the first occurrence — the result carries no step index to disambiguate. Documented in-code; tracked in #423.

## Testing

- All touched packages build clean; 588 tests pass across core, plugin-http-tester, plugin-reporter, common-cli.
- New regression tests: schema-validation detail routing, top-level-expect status, violation.message retention, helpUri escaping, schema-boundary labeling.