### PR TITLE
Epic 9 (PR-A): Resources collection + library render (Stories 9.1, 9.2)

### DIFF
--- a/astro-docs/e2e/accessibility.spec.ts
+++ b/astro-docs/e2e/accessibility.spec.ts
@@ -53,6 +53,7 @@ const pages = [
   { name: 'Accessibility Statement', path: '/legal/accessibility-statement/' },
   { name: 'Enterprise', path: '/enterprise/' },
   { name: 'Events', path: '/events/' },
+  { name: 'Resources', path: '/resources/' },
 ];
 
 for (const { name, path } of pages) {
@@ -96,6 +97,40 @@ test('Events type route (/events/type/talk/) should have no WCAG AA violations i
 }) => {
   await forceDarkTheme(page);
   await page.goto('/events/type/talk/');
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expectNoViolations(page);
+});
+
+/*
+ * Resources mirrors the Events teal-token discipline and stays teal in BOTH
+ * themes, so — exactly as for Events — the light-mode `/resources/` scan above
+ * is not enough on its own. These scans cover dark mode and a type route
+ * (multi-word slug `recorded-talk`) so a regression in either fails the gate.
+ */
+test('Resources (/resources/) should have no WCAG AA violations in dark mode', async ({
+  page,
+}) => {
+  await forceDarkTheme(page);
+  await page.goto('/resources/');
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expectNoViolations(page);
+});
+
+test('Resources type route (/resources/type/recorded-talk/) should have no WCAG AA violations', async ({
+  page,
+}) => {
+  await page.goto('/resources/type/recorded-talk/');
+  await page.waitForLoadState('networkidle');
+  await expectNoViolations(page);
+});
+
+test('Resources type route (/resources/type/recorded-talk/) should have no WCAG AA violations in dark mode', async ({
+  page,
+}) => {
+  await forceDarkTheme(page);
+  await page.goto('/resources/type/recorded-talk/');
   await page.waitForLoadState('networkidle');
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
   await expectNoViolations(page);

--- a/astro-docs/src/components/ThymianHeader.astro
+++ b/astro-docs/src/components/ThymianHeader.astro
@@ -30,6 +30,9 @@ const shouldRenderSearch =
       <a href="/events/" class="header-nav-link">
         Events
       </a>
+      <a href="/resources/" class="header-nav-link">
+        Resources
+      </a>
     </nav>
   </div>
   <slot />

--- a/astro-docs/src/components/resources/ResourceAttribution.astro
+++ b/astro-docs/src/components/resources/ResourceAttribution.astro
@@ -1,0 +1,67 @@
+---
+import type { Attribution } from '../../schema/attribution';
+import { resolveGuestAttribution } from './resourceMeta';
+
+interface Props {
+  attribution?: Attribution;
+}
+
+const { attribution } = Astro.props;
+
+// AD-13 (honest attribution): a host resource (or absent attribution) has no
+// external host to credit, so `guest` is null and no markup is emitted. A guest
+// is surfaced only with a non-empty external host + platform (see the helper).
+const guest = resolveGuestAttribution(attribution);
+---
+
+{
+  guest && (
+    <p class="resource-attribution">
+      <span class="resource-card-label">Guest of</span>
+      {guest.externalUrl ? (
+        <a href={guest.externalUrl} target="_blank" rel="noopener noreferrer">
+          {guest.externalHost}
+        </a>
+      ) : (
+        <span class="resource-attribution-host">{guest.externalHost}</span>
+      )}{' '}
+      on {guest.platform}
+    </p>
+  )
+}
+
+<style>
+  .resource-attribution {
+    margin: 0;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--ev-fg-faint);
+  }
+
+  .resource-card-label {
+    display: inline-block;
+    margin-inline-end: 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ev-fg-faint);
+  }
+
+  .resource-attribution-host {
+    color: var(--ev-fg);
+  }
+
+  .resource-attribution a {
+    color: var(--ev-accent-text);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    font-weight: 700;
+  }
+
+  .resource-attribution a:focus-visible {
+    outline: 2px solid var(--ev-focus-ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+</style>

--- a/astro-docs/src/components/resources/ResourceCard.astro
+++ b/astro-docs/src/components/resources/ResourceCard.astro
@@ -1,0 +1,136 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+import ResourceAttribution from './ResourceAttribution.astro';
+import { RESOURCE_TYPE_LABELS } from './resourceMeta';
+
+interface Props {
+  resource: CollectionEntry<'resources'>;
+}
+
+const { resource } = Astro.props;
+const { title, resourceType, attribution } = resource.data;
+---
+
+<article class="resource-card" data-resource-type={resourceType}>
+  <span class="resource-card-edge" aria-hidden="true"></span>
+
+  {/*
+    9.3 seam: embed-vs-linkout player renders here (when `embeddable`, an
+    inline player from `url`; otherwise a link-out affordance). Not implemented
+    in 9.2 — no player/link surfaced yet.
+  */}
+
+  <div class="resource-card-body">
+    <div class="resource-card-badges">
+      <span class="badge badge--type">
+        {RESOURCE_TYPE_LABELS[resourceType]}
+      </span>
+    </div>
+
+    {/*
+      Single-library page: StarlightPage renders the page title as the `<h1>`
+      and there is no intervening section heading (no Upcoming/Past split), so
+      each card title is a direct `<h2>` under the `<h1>` — h1→h2, no skipped
+      level (Events uses `<h3>` only because it nests under `<h2>` bucket
+      headings). Visual size is owned by `.resource-card-title`, not the tag.
+    */}
+    <h2 class="resource-card-title">{title}</h2>
+
+    <ResourceAttribution attribution={attribution} />
+
+    {/*
+      9.4 seam: when `originEvent` is set, a cross-link back to the origin
+      event's card/page renders here. 9.2 does NOT resolve `originEvent`.
+    */}
+    {/*
+      9.5 seam: OG-image generation for resource pages is extended in
+      `src/pages/og/[...route].ts` — no OG key extension in 9.2.
+    */}
+  </div>
+</article>
+
+<style>
+  /* Full-width band: [gradient edge][body]. */
+  .resource-card {
+    position: relative;
+    display: flex;
+    gap: 1.375rem;
+    align-items: flex-start;
+    padding: 1.375rem 1.625rem 1.375rem 1.625rem;
+    background: var(--ev-band-bg);
+    border: 1px solid var(--ev-line);
+    border-radius: 1rem;
+    overflow: hidden;
+    transition:
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  /* Soft edge-glow + subtle lift on hover (no resting shadow). */
+  .resource-card:hover {
+    transform: translateY(-2px);
+    box-shadow: -6px 0 18px -8px color-mix(in srgb, #017b64 60%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .resource-card,
+    .resource-card:hover {
+      transform: none;
+      box-shadow: none;
+      transition: none;
+    }
+  }
+
+  /* Decorative signature gradient edge — graphic only, never a text background. */
+  .resource-card-edge {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 7px;
+    background: var(--ev-gradient-signature);
+  }
+
+  .resource-card-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .resource-card-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.7rem;
+    border-radius: 9999px;
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    line-height: 1;
+  }
+
+  /* Type badge — teal fill for every resource type. */
+  .badge--type {
+    background: var(--ev-badge-bg);
+    color: var(--ev-badge-fg);
+  }
+
+  .resource-card-title {
+    margin: 0.125rem 0 0.25rem;
+    font-size: 1.55rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    color: var(--ev-fg);
+  }
+</style>

--- a/astro-docs/src/components/resources/ResourceList.astro
+++ b/astro-docs/src/components/resources/ResourceList.astro
@@ -1,0 +1,160 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+import { type ResourceType } from '../../schema/resources';
+import ResourceCard from './ResourceCard.astro';
+import {
+  compareResources,
+  RESOURCE_TYPE_LABELS,
+  RESOURCE_TYPE_ORDER,
+  resourceTypeSlug,
+} from './resourceMeta';
+
+type ResourceEntry = CollectionEntry<'resources'>;
+type TypeFilter = ResourceType | 'all';
+
+interface Props {
+  allResources: ResourceEntry[];
+  resources: ResourceEntry[];
+  currentType?: TypeFilter;
+}
+
+const { allResources, resources, currentType = 'all' } = Astro.props;
+
+// Single date-sorted library (no Upcoming/Past split). The 9.1 schema has no
+// resource date, so each entry sorts with `date: undefined` and the order falls
+// deterministically to title A→Z via `compareResources`.
+const sorted = [...resources].sort((a, b) =>
+  compareResources(
+    { title: a.data.title },
+    { title: b.data.title },
+  ),
+);
+
+const typeCounts = allResources.reduce<Record<ResourceType, number>>(
+  (counts, r) => {
+    counts[r.data.resourceType] += 1;
+    return counts;
+  },
+  // Seed derived from the type inventory so counts stay in lockstep with
+  // routing/labels when a resource type is added or removed.
+  Object.fromEntries(RESOURCE_TYPE_ORDER.map((type) => [type, 0])) as Record<
+    ResourceType,
+    number
+  >,
+);
+---
+
+<nav class="type-filter" aria-label="Filter resources by type">
+  <a
+    href="/resources/"
+    class="type-filter-link"
+    aria-current={currentType === 'all' ? 'page' : undefined}
+  >
+    All <span class="type-filter-count">{allResources.length}</span>
+  </a>
+  {
+    RESOURCE_TYPE_ORDER.map((type) => (
+      <a
+        href={`/resources/type/${resourceTypeSlug(type)}/`}
+        class="type-filter-link"
+        aria-current={currentType === type ? 'page' : undefined}
+      >
+        {RESOURCE_TYPE_LABELS[type]}{' '}
+        <span class="type-filter-count">{typeCounts[type]}</span>
+      </a>
+    ))
+  }
+</nav>
+
+<section class="resource-section">
+  {
+    sorted.length > 0 ? (
+      <div class="resource-stack">
+        {sorted.map((resource) => (
+          <ResourceCard resource={resource} />
+        ))}
+      </div>
+    ) : (
+      <p class="empty-state">No resources yet — check back soon.</p>
+    )
+  }
+</section>
+
+<style>
+  .type-filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+  }
+
+  /* Inactive pill: transparent fill + pinned ≥3:1 border + gray-800/teal-300 text. */
+  .type-filter-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--ev-pill-border);
+    border-radius: 9999px;
+    background: var(--ev-pill-inactive-bg, transparent);
+    color: var(--ev-pill-inactive-fg);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    transition:
+      border-color 0.15s,
+      color 0.15s,
+      background 0.15s;
+  }
+
+  /*
+    Active pill = SOLID fill (white on teal-700 light / near-black on teal-400
+    dark), NEVER a light tint under accent text (that pairing fails AA).
+  */
+  .type-filter-link[aria-current='page'] {
+    border-color: var(--ev-pill-active-bg);
+    background: var(--ev-pill-active-bg);
+    color: var(--ev-pill-active-fg);
+  }
+
+  .type-filter-link[aria-current='page'] .type-filter-count {
+    color: var(--ev-pill-active-fg);
+  }
+
+  /* Hover only nudges the border toward the accent; contrast is unchanged. */
+  .type-filter-link:not([aria-current='page']):hover {
+    border-color: var(--ev-accent-border);
+    color: var(--ev-accent-text);
+  }
+
+  .type-filter-count {
+    color: var(--ev-fg-faint);
+  }
+
+  .type-filter-link:focus-visible {
+    outline: 2px solid var(--ev-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .resource-section {
+    margin-bottom: 2.5rem;
+  }
+
+  /* Full-width bands, single-column stack — not a boxed card grid. */
+  .resource-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .empty-state {
+    padding: 1rem 1.125rem;
+    border: 1px dashed var(--ev-line);
+    border-radius: 0.75rem;
+    color: var(--ev-empty-line);
+    font-size: 0.98rem;
+    background: var(--ev-band-bg);
+  }
+</style>

--- a/astro-docs/src/components/resources/ResourcesLayout.astro
+++ b/astro-docs/src/components/resources/ResourcesLayout.astro
@@ -1,0 +1,135 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<StarlightPage
+  frontmatter={{
+    title,
+    description,
+    tableOfContents: false,
+    editUrl: false,
+  }}
+  hasSidebar={false}
+>
+  {/*
+    `.resources-root` seeds the SAME scoped design tokens (`--ev-*`) as Events,
+    from the brand teal hexes (DESIGN.md). Resources deliberately stays teal in
+    BOTH themes, so we never read `--sl-color-accent` (which reseeds to the
+    green/leaf ramp under `data-theme='dark'`) and never touch
+    `src/styles/global.css`. Tokens cascade by inheritance to every resources
+    component (ResourceList, ResourceCard, ResourceAttribution, …).
+  */}
+  {/*
+    `not-content` opts the resources UI out of Starlight's `.sl-markdown-content`
+    auto-margins (the `X + Y { margin-top: 1rem }` prose rule). Our components own
+    all their spacing (flex `gap` + explicit margins) and fully self-style their
+    links, so nothing from Starlight's content defaults is needed here.
+  */}
+  <div class="resources-root not-content">
+    <div class="resources-hero">
+      <div class="resources-hero-bar" aria-hidden="true"></div>
+      {description && <p class="resources-lede">{description}</p>}
+    </div>
+
+    <slot />
+  </div>
+</StarlightPage>
+
+<style>
+  /* ── Resources-local design tokens — LIGHT (default) ───────────────────── */
+  .resources-root {
+    --ev-page-bg: transparent; /* no imposed grey canvas — inherit site content bg */
+    --ev-band-bg: #ffffff;
+    --ev-fg: #171819; /* gray-900 — body */
+    --ev-fg-muted: #36383b; /* gray-700 — meta */
+    --ev-fg-faint: #56585b; /* gray-500 — attribution / group headers */
+    --ev-line: #e2e4e5; /* decorative hairline */
+    --ev-accent-text: #046151; /* teal-700 — links, outline badge text */
+    --ev-accent-border: #046151; /* teal-700 — mode badge + ghost CTA border (≥3:1) */
+    --ev-cta-bg: #046151; /* teal-700 */
+    --ev-cta-fg: #ffffff;
+    --ev-badge-bg: #0a3b32; /* teal-900 */
+    --ev-badge-fg: #e6f6f3; /* teal-50 */
+    --ev-badge-alt-bg: #e1f3d3; /* lime-100 */
+    --ev-badge-alt-fg: #162e0c; /* lime-950 */
+    --ev-tile-fg: #e6f6f3; /* teal-50 — monogram initials on the tile's dark end */
+    --ev-pill-active-bg: #046151; /* teal-700 — SOLID fill */
+    --ev-pill-active-fg: #ffffff; /* white on teal-700 ~7.4:1 */
+    --ev-pill-inactive-fg: #25272a; /* gray-800 */
+    --ev-pill-border: #56585b; /* gray-500 — ≥3:1 boundary */
+    --ev-focus-ring: #017b64; /* teal-600 — ≥3:1 on band + page */
+    --ev-empty-line: #56585b; /* gray-500 */
+    --ev-gradient-signature: linear-gradient(
+      180deg,
+      #017b64 0%,
+      #5ab12e 60%,
+      #beeb63 100%
+    );
+    --ev-gradient-tile: linear-gradient(150deg, #084d40 0%, #017b64 100%);
+
+    background: var(--ev-page-bg);
+    color: var(--ev-fg);
+    /* No imposed page canvas — the bands sit directly on Starlight's content
+       background; their border + gradient edge carry the separation. */
+    padding: 0 0 3rem;
+  }
+
+  /* ── Resources-local design tokens — DARK (data-theme='dark') ──────────── */
+  :global(:root[data-theme='dark']) .resources-root {
+    --ev-page-bg: transparent; /* no imposed grey canvas — inherit site content bg */
+    --ev-band-bg: #1c1e20;
+    --ev-fg: #f6f6f7; /* gray-100 */
+    --ev-fg-muted: #c1c2c4; /* gray-300 */
+    --ev-fg-faint: #898c8f; /* gray-400 */
+    --ev-line: #2c2f32;
+    --ev-accent-text: #74cfbf; /* teal-300 — 9.09:1 on band */
+    --ev-accent-border: #3eb7a1; /* teal-400 — mode badge + ghost CTA border (≥3:1) */
+    --ev-cta-bg: #3eb7a1; /* teal-400 */
+    --ev-cta-fg: #0e0f10; /* near-black */
+    --ev-badge-bg: #084d40; /* teal-800 */
+    --ev-badge-fg: #cdeee8; /* teal-100 */
+    --ev-badge-alt-bg: #254b16; /* lime-900 */
+    --ev-badge-alt-fg: #e1f3d3; /* lime-100 */
+    --ev-tile-fg: #e6f6f3; /* teal-50 */
+    --ev-pill-active-bg: #3eb7a1; /* teal-400 — SOLID fill */
+    --ev-pill-active-fg: #0e0f10; /* near-black on teal-400 ~6.4:1 */
+    --ev-pill-inactive-fg: #74cfbf; /* teal-300 */
+    --ev-pill-border: #898c8f; /* gray-400 — ≥3:1 boundary */
+    --ev-focus-ring: #74cfbf; /* teal-300 */
+    --ev-empty-line: #898c8f; /* gray-400 */
+  }
+
+  .resources-hero {
+    margin: 0 0 0.5rem;
+  }
+
+  /* Decorative signature rule — the brand's one flourish. Never behind text. */
+  .resources-hero-bar {
+    width: 64px;
+    height: 8px;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+    background: linear-gradient(
+      90deg,
+      #017b64 0%,
+      #5ab12e 60%,
+      #beeb63 100%
+    );
+  }
+
+  .resources-lede {
+    margin: 0;
+    max-width: 46ch;
+    color: var(--ev-fg-muted);
+    font-size: 1.05rem;
+    font-weight: 400;
+    line-height: 1.5;
+  }
+</style>

--- a/astro-docs/src/components/resources/resourceMeta.ts
+++ b/astro-docs/src/components/resources/resourceMeta.ts
@@ -1,0 +1,67 @@
+import { RESOURCE_TYPES, type ResourceType } from '../../schema/resources';
+
+/**
+ * Reuse the Events AD-13 honest-attribution guard verbatim — a Resource has the
+ * exact same Host/Guest attribution shape, so re-exporting keeps a single source
+ * of truth (never re-implement the branch). Consumed by `ResourceAttribution`.
+ */
+export { resolveGuestAttribution } from '../events/eventMeta';
+
+/** Display labels for each resource type (also the filter-pill labels). */
+export const RESOURCE_TYPE_LABELS = {
+  'recorded talk': 'Recorded Talk',
+  webinar: 'Webinar',
+  'podcast episode': 'Podcast Episode',
+  paper: 'Paper',
+} satisfies Record<ResourceType, string>;
+
+/** Canonical display / filter order for resource types (the enum tuple). */
+export const RESOURCE_TYPE_ORDER = RESOURCE_TYPES;
+
+/** Minimal shape the sort comparator needs — testable without content entries. */
+export interface SortableResource {
+  date?: Date;
+  title: string;
+}
+
+/**
+ * Library order: most-recent-first (descending by `date`), undated entries
+ * bucketed LAST, then title A→Z tiebreak. The current 9.1 schema has no resource
+ * date field, so the library feeds `date: undefined` and the shipped order falls
+ * deterministically to title A→Z; 9.4 will feed the origin event's date without
+ * changing this comparator.
+ */
+export function compareResources(
+  a: SortableResource,
+  b: SortableResource,
+): number {
+  // Normalise an Invalid Date (`getTime()` → NaN) to "undated" so it buckets
+  // last instead of poisoning the comparator with a NaN return (which yields a
+  // non-transitive, engine-defined order). Guards the 9.4 reuse seam.
+  const toTime = (d?: Date): number | undefined => {
+    const t = d?.getTime();
+    return t === undefined || Number.isNaN(t) ? undefined : t;
+  };
+  const aTime = toTime(a.date);
+  const bTime = toTime(b.date);
+  if (aTime !== undefined && bTime !== undefined) {
+    if (aTime !== bTime) {
+      return bTime - aTime;
+    }
+  } else if (aTime !== undefined) {
+    return -1;
+  } else if (bTime !== undefined) {
+    return 1;
+  }
+  return a.title.localeCompare(b.title, 'en');
+}
+
+/** URL-safe slug for a (possibly multi-word) resource type: spaces → hyphens. */
+export function resourceTypeSlug(type: ResourceType): string {
+  return type.replaceAll(' ', '-');
+}
+
+/** Inverse of {@link resourceTypeSlug}: a slug back to its enum value, or `undefined`. */
+export function resourceTypeFromSlug(slug: string): ResourceType | undefined {
+  return RESOURCE_TYPES.find((type) => resourceTypeSlug(type) === slug);
+}

--- a/astro-docs/src/content.config.ts
+++ b/astro-docs/src/content.config.ts
@@ -5,6 +5,7 @@ import { defineCollection, z } from 'astro:content';
 import { blogSchema } from 'starlight-blog/schema';
 
 import { eventsSchema } from './schema/events';
+import { resourcesSchema } from './schema/resources';
 
 const SOCIAL_CATEGORIES = [
   'thymian-general',
@@ -44,5 +45,10 @@ export const collections = {
   events: defineCollection({
     loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/events' }),
     schema: eventsSchema,
+  }),
+
+  resources: defineCollection({
+    loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/resources' }),
+    schema: resourcesSchema,
   }),
 };

--- a/astro-docs/src/pages/resources/index.astro
+++ b/astro-docs/src/pages/resources/index.astro
@@ -1,0 +1,19 @@
+---
+import { getCollection } from 'astro:content';
+
+import ResourceList from '../../components/resources/ResourceList.astro';
+import ResourcesLayout from '../../components/resources/ResourcesLayout.astro';
+
+const allResources = await getCollection('resources');
+---
+
+<ResourcesLayout
+  title="Resources"
+  description="Talks, webinars, podcast episodes, and papers Thymian produced or took part in."
+>
+  <ResourceList
+    allResources={allResources}
+    resources={allResources}
+    currentType="all"
+  />
+</ResourcesLayout>

--- a/astro-docs/src/pages/resources/type/[type].astro
+++ b/astro-docs/src/pages/resources/type/[type].astro
@@ -1,0 +1,36 @@
+---
+import { getCollection } from 'astro:content';
+
+import ResourceList from '../../../components/resources/ResourceList.astro';
+import ResourcesLayout from '../../../components/resources/ResourcesLayout.astro';
+import {
+  RESOURCE_TYPE_LABELS,
+  resourceTypeSlug,
+} from '../../../components/resources/resourceMeta';
+import {
+  RESOURCE_TYPES,
+  type ResourceType,
+} from '../../../schema/resources';
+
+export function getStaticPaths() {
+  return RESOURCE_TYPES.map((type) => ({
+    params: { type: resourceTypeSlug(type) },
+    props: { type },
+  }));
+}
+
+const { type } = Astro.props as { type: ResourceType };
+const allResources = await getCollection('resources');
+const resources = allResources.filter((r) => r.data.resourceType === type);
+---
+
+<ResourcesLayout
+  title={`Resources — ${RESOURCE_TYPE_LABELS[type]}`}
+  description={`Browse Thymian ${RESOURCE_TYPE_LABELS[type].toLowerCase()} resources.`}
+>
+  <ResourceList
+    allResources={allResources}
+    resources={resources}
+    currentType={type}
+  />
+</ResourcesLayout>

--- a/astro-docs/src/schema/resources.ts
+++ b/astro-docs/src/schema/resources.ts
@@ -1,0 +1,39 @@
+import type { CollectionEntry } from 'astro:content';
+import { reference, z } from 'astro:content';
+
+import { attributionSchema } from './attribution';
+
+/** Typed kinds of media a resource entry can represent. */
+export const RESOURCE_TYPES = [
+  'recorded talk',
+  'webinar',
+  'podcast episode',
+  'paper',
+] as const;
+
+export type ResourceType = (typeof RESOURCE_TYPES)[number];
+
+/**
+ * The `resources` collection schema — externally-hosted media (talks, webinars,
+ * podcast episodes, papers) that Thymian produced or took part in.
+ *
+ * Plain `z.object` (no `SchemaContext` factory): unlike `events`, there is no
+ * `image()` field here. `attribution` is REQUIRED (vs `.optional()` on events)
+ * because every resource is externally-hosted media with a real host/guest
+ * nature (AD-13 credibility guarantee). `originEvent` uses Astro's native
+ * `reference('events')` so a dangling id fails the build/`astro sync` — no
+ * hand-rolled existence guard.
+ */
+export const resourcesSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'A resource `title` must not be empty or whitespace-only.'),
+  resourceType: z.enum(RESOURCE_TYPES),
+  url: z.string().trim().url(),
+  embeddable: z.boolean(),
+  attribution: attributionSchema,
+  originEvent: reference('events').optional(),
+});
+
+export type ResourceData = CollectionEntry<'resources'>['data'];

--- a/astro-docs/test/resources-meta.test.ts
+++ b/astro-docs/test/resources-meta.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareResources,
+  resolveGuestAttribution,
+  resourceTypeFromSlug,
+  resourceTypeSlug,
+  type SortableResource,
+} from '../src/components/resources/resourceMeta';
+import { type Attribution } from '../src/schema/attribution';
+
+const res = (title: string, date?: Date): SortableResource => ({ title, date });
+
+describe('compareResources', () => {
+  it('sorts descending by date (most recent first)', () => {
+    const sorted = [
+      res('January', new Date('2026-01-01')),
+      res('June', new Date('2026-06-01')),
+      res('March', new Date('2026-03-01')),
+    ].sort(compareResources);
+    expect(sorted.map((r) => r.title)).toEqual(['June', 'March', 'January']);
+  });
+
+  it('buckets undated entries last', () => {
+    const sorted = [
+      res('Undated'),
+      res('Dated', new Date('2026-05-01')),
+    ].sort(compareResources);
+    expect(sorted.map((r) => r.title)).toEqual(['Dated', 'Undated']);
+  });
+
+  it('breaks same-date ties by title A→Z', () => {
+    const sorted = [
+      res('Zeta', new Date('2026-05-01')),
+      res('Alpha', new Date('2026-05-01')),
+      res('Mike', new Date('2026-05-01')),
+    ].sort(compareResources);
+    expect(sorted.map((r) => r.title)).toEqual(['Alpha', 'Mike', 'Zeta']);
+  });
+
+  it('orders wholly-undated entries by title A→Z (the shipped basis)', () => {
+    const sorted = [res('Zeta'), res('Alpha'), res('Mike')].sort(
+      compareResources,
+    );
+    expect(sorted.map((r) => r.title)).toEqual(['Alpha', 'Mike', 'Zeta']);
+  });
+
+  it('treats an Invalid Date as undated (no NaN comparator result)', () => {
+    const sorted = [
+      res('Invalid', new Date('not-a-date')),
+      res('Dated', new Date('2026-05-01')),
+    ].sort(compareResources);
+    // Invalid-date entry buckets last, exactly like an omitted date.
+    expect(sorted.map((r) => r.title)).toEqual(['Dated', 'Invalid']);
+  });
+});
+
+describe('resourceTypeSlug / resourceTypeFromSlug', () => {
+  it('round-trips multi-word types through URL-safe slugs', () => {
+    expect(resourceTypeSlug('recorded talk')).toBe('recorded-talk');
+    expect(resourceTypeSlug('podcast episode')).toBe('podcast-episode');
+    expect(resourceTypeFromSlug('recorded-talk')).toBe('recorded talk');
+    expect(resourceTypeFromSlug('podcast-episode')).toBe('podcast episode');
+  });
+
+  it('round-trips single-word types unchanged', () => {
+    expect(resourceTypeSlug('webinar')).toBe('webinar');
+    expect(resourceTypeSlug('paper')).toBe('paper');
+    expect(resourceTypeFromSlug('webinar')).toBe('webinar');
+    expect(resourceTypeFromSlug('paper')).toBe('paper');
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    expect(resourceTypeFromSlug('recorded talk')).toBeUndefined();
+    expect(resourceTypeFromSlug('nope')).toBeUndefined();
+    expect(resourceTypeFromSlug('')).toBeUndefined();
+  });
+});
+
+describe('resolveGuestAttribution (re-exported, AD-13 honest attribution)', () => {
+  const guest: Attribution = {
+    hostGuest: 'guest',
+    externalHost: 'My Coding Zone',
+    platform: 'YouTube',
+    externalUrl: 'https://youtube.com/mycodingzone',
+  };
+
+  it('returns null for an absent attribution', () => {
+    expect(resolveGuestAttribution(undefined)).toBeNull();
+  });
+
+  it('returns null for a host resource (no external host to credit)', () => {
+    expect(resolveGuestAttribution({ hostGuest: 'host' })).toBeNull();
+  });
+
+  it('returns the attribution for a valid guest', () => {
+    expect(resolveGuestAttribution(guest)).toEqual(guest);
+  });
+
+  it('returns a valid guest even without an external URL (text render)', () => {
+    const noUrl: Attribution = {
+      hostGuest: 'guest',
+      externalHost: 'FrankenJS',
+      platform: 'Meetup',
+    };
+    expect(resolveGuestAttribution(noUrl)).toEqual(noUrl);
+  });
+
+  it('returns null for a guest with an empty host', () => {
+    expect(
+      resolveGuestAttribution({
+        hostGuest: 'guest',
+        externalHost: '   ',
+        platform: 'YouTube',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns a normalized copy for whitespace-padded guest fields', () => {
+    expect(
+      resolveGuestAttribution({
+        hostGuest: 'guest',
+        externalHost: '  My Coding Zone  ',
+        platform: '  YouTube  ',
+        externalUrl: '  https://youtube.com/mycodingzone  ',
+      }),
+    ).toEqual({
+      hostGuest: 'guest',
+      externalHost: 'My Coding Zone',
+      platform: 'YouTube',
+      externalUrl: 'https://youtube.com/mycodingzone',
+    });
+  });
+});

--- a/astro-docs/test/resources-schema.test.ts
+++ b/astro-docs/test/resources-schema.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { resourcesSchema } from '../src/schema/resources';
+
+// `resourcesSchema` is a plain Zod object (no `image()` field), so it is parsed
+// directly with `.safeParse(...)` — no `SchemaContext`/`image` fake is needed.
+// `originEvent` uses Astro's `reference('events')`, whose dangling-id validation
+// is a build/`astro sync` behavior, not a `safeParse` behavior; it is proven by
+// a temporary build fixture, not exercised here.
+
+const guestAttribution = {
+  hostGuest: 'guest' as const,
+  externalHost: 'My Coding Zone',
+  platform: 'YouTube',
+};
+
+const baseResource = {
+  title: 'Should I GET or should I POST?',
+  resourceType: 'recorded talk' as const,
+  url: 'https://youtube.com/watch?v=mycodingzone',
+  embeddable: true,
+  attribution: guestAttribution,
+};
+
+describe('resourcesSchema — valid entries', () => {
+  it('accepts a valid recorded talk (embeddable, guest attribution, valid url)', () => {
+    const r = resourcesSchema.safeParse(baseResource);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a valid paper (non-embeddable, host attribution)', () => {
+    const r = resourcesSchema.safeParse({
+      ...baseResource,
+      title: 'A White Paper',
+      resourceType: 'paper',
+      url: 'https://example.com/paper.pdf',
+      embeddable: false,
+      attribution: { hostGuest: 'host' },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts an entry with originEvent omitted (optional)', () => {
+    const r = resourcesSchema.safeParse(baseResource);
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('resourcesSchema — resourceType enum (AD-2)', () => {
+  it('rejects a resourceType outside the enum on the resourceType path', () => {
+    const r = resourcesSchema.safeParse({
+      ...baseResource,
+      resourceType: 'blog post',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes('resourceType'))).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe('resourcesSchema — attribution (AD-13)', () => {
+  it('rejects a guest missing externalHost/platform', () => {
+    const r = resourcesSchema.safeParse({
+      ...baseResource,
+      attribution: { hostGuest: 'guest' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a host that carries external-host data', () => {
+    const r = resourcesSchema.safeParse({
+      ...baseResource,
+      attribution: { hostGuest: 'host', externalHost: 'Someone Else' },
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('resourcesSchema — url (AD-12)', () => {
+  it('rejects a missing url on the url path', () => {
+    const r = resourcesSchema.safeParse({
+      title: baseResource.title,
+      resourceType: baseResource.resourceType,
+      embeddable: baseResource.embeddable,
+      attribution: baseResource.attribution,
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes('url'))).toBe(true);
+    }
+  });
+
+  it('rejects a non-URL url on the url path', () => {
+    const r = resourcesSchema.safeParse({
+      ...baseResource,
+      url: 'not a url',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes('url'))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Epic 9 — PR-A: Resources collection + library render

Foundation + render half of **Epic 9: Public Resources library & Event↔Resource linking**. This is the **base of a 2-PR stack**; **PR-B** (embed, bidirectional linking, OG images, seed content) is stacked on top of this branch.

### Stories
- **Story 9.1** (`thymianofficial/thymian-internal#438`) — define the `resources` content collection + Event link.
  - New `src/schema/resources.ts`: `resourceType` enum (`recorded talk | webinar | podcast episode | paper`), required `embeddable`, required `attribution` (reuses Epic 8's `attributionSchema` verbatim), required `title`/`url`, and `originEvent: reference('events').optional()`. Registered in `content.config.ts`. Unit-tested.
- **Story 9.2** (`thymianofficial/thymian-internal#439`) — render the Resources library with Host/Guest credit.
  - `/resources/` (StarlightPage, indexable, pagefind on) + per-type routes `/resources/type/{recorded-talk,webinar,podcast-episode,paper}/`.
  - `resourceMeta.ts` (labels/order/`compareResources`/type-slug helpers, re-exports `resolveGuestAttribution`), `ResourcesLayout`/`ResourceList`/`ResourceCard`/`ResourceAttribution`, `Resources` header nav link, axe WCAG 2.1 AA e2e scan extended to `/resources/` (light + dark), scoped `--ev-*` teal tokens (never `--sl-color-accent`).
  - `ResourceCard.astro` ships explicit comment seams for 9.3 (embed), 9.4 (cross-link), 9.5 (OG) — filled in by PR-B.

### Note on AD-6 (dangling-reference integrity)
Story 9.1's AC-5 assumed Astro's `reference()` hard-fails the build on a dangling `originEvent`. On **Astro 7.1.3 `reference()` is warn-only** (`getEntry` → `undefined` + `console.warn`, not a build error). Per an explicit correct-course decision, AD-6 enforcement is implemented as an explicit build-time integrity guard in **Story 9.4 (PR-B)**, where the event↔resource resolution logic lives. The now-stale docstring in `resources.ts` is likewise corrected in PR-B.

### Verification (from `astro-docs/`, empty `.gitkeep`-only collection)
- `astro build` → **Complete**, 121 pages, `starlight-links-validator` all valid.
- `astro check` → 13 errors = pre-existing baseline, **0 new**.
- `vitest run` → **98 passed**.

Refs `thymianofficial/thymian-internal#438`, `thymianofficial/thymian-internal#439`.

<img width="1616" height="1188" alt="Screenshot 2026-07-30 at 10 49 07" src="https://github.com/user-attachments/assets/6dd821b9-bfcf-4fb5-a608-6d8ab5c7f991" />
<img width="1627" height="1173" alt="Screenshot 2026-07-30 at 10 50 23" src="https://github.com/user-attachments/assets/8015a976-a014-44bf-a158-998c90e1de77" />
