### PR TITLE
Epic 9 (PR-B): embed, bidirectional linking + AD-6 guard, OG, seed content (Stories 9.3–9.6)

### DIFF
--- a/astro-docs/src/components/CtaLink.astro
+++ b/astro-docs/src/components/CtaLink.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * CtaLink — the house CTA pill for external destinations, in its two shapes:
+ * `primary` = solid fill (Events "Register to attend"), `ghost` = outline
+ * (resource link-outs). The ONE copy of the pill — EventLinks, ResourceEmbed
+ * and ConsentEmbed each carried a near-verbatim clone before — so a style
+ * tweak lands here once. Always opens in a new tab with
+ * `rel="noopener noreferrer"` and the shared external-link glyph; the slot
+ * carries the visible label.
+ *
+ * Consumes the `--ev-*` tokens the mounting surface seeds (EventsLayout /
+ * ResourcesLayout), each with a light-theme fallback so the pill never renders
+ * with an undefined token when reused outside those roots (ConsentEmbed mounts
+ * on any embed surface — Epic 10/11 reuse).
+ */
+import ExternalLinkIcon from './ExternalLinkIcon.astro';
+
+interface Props {
+  href: string;
+  variant: 'primary' | 'ghost';
+}
+
+const { href, variant } = Astro.props;
+---
+
+<a
+  class={`cta cta--${variant}`}
+  href={href}
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <slot />
+  <ExternalLinkIcon />
+</a>
+
+<style>
+  .cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  /* Primary CTA — white on teal-700 (light) / near-black on teal-400 (dark). */
+  .cta--primary {
+    background: var(--ev-cta-bg, #046151);
+    color: var(--ev-cta-fg, #ffffff);
+  }
+
+  /* Ghost CTA — transparent fill, accent text + ≥3:1 accent border. */
+  .cta--ghost {
+    background: transparent;
+    color: var(--ev-accent-text, #046151);
+    border: 1.5px solid var(--ev-accent-border, #046151);
+  }
+
+  .cta:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #017b64);
+    outline-offset: 2px;
+  }
+</style>

--- a/astro-docs/src/components/ExternalLinkIcon.astro
+++ b/astro-docs/src/components/ExternalLinkIcon.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * The house 14×14 external-link glyph — the ONE copy. It was inlined verbatim
+ * in EventLinks, DocLinks, ResourceEmbed and ConsentEmbed; every external-link
+ * affordance renders this component instead so a glyph tweak lands once.
+ * Decorative (`aria-hidden`): the surrounding link's text names the
+ * destination. Colored by the parent via `currentColor`.
+ */
+---
+
+<svg
+  width="14"
+  height="14"
+  viewBox="0 0 14 14"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path
+    d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
+    stroke="currentColor"
+    stroke-width="1.25"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>
+
+<style>
+  /* The glyph rides inside inline-flex pills/rows — never let it shrink. */
+  svg {
+    flex-shrink: 0;
+  }
+</style>

--- a/astro-docs/src/components/events/EventCard.astro
+++ b/astro-docs/src/components/events/EventCard.astro
@@ -2,6 +2,10 @@
 import type { CollectionEntry } from 'astro:content';
 
 import { blogAuthors } from '../../data/team';
+import {
+  resourcesForEvent,
+  urlForEntry,
+} from '../../lib/cross-links';
 import { formatDisplay } from '../../schema/event-date';
 import EventAttribution from './EventAttribution.astro';
 import EventLinks from './EventLinks.astro';
@@ -16,9 +20,11 @@ import {
 interface Props {
   event: CollectionEntry<'events'>;
   timeframe: 'upcoming' | 'past';
+  allResources: CollectionEntry<'resources'>[];
+  eventsById: Map<string, CollectionEntry<'events'>>;
 }
 
-const { event, timeframe } = Astro.props;
+const { event, timeframe, allResources, eventsById } = Astro.props;
 const {
   title,
   participation,
@@ -37,6 +43,11 @@ const speakerNames = speakers.map((key) => blogAuthors[key]?.name ?? key);
 const links = resolveEventLinks({ timeframe, registerUrl, resourceUrl });
 const brand = resolveEventBrand({ title, attribution });
 const place = online ? 'Online' : location;
+
+// Derived produced-Resources (never hand-authored): resources whose
+// `originEvent` names this event, via the single shared cross-link module.
+// Sparse — an empty list renders no block.
+const produced = resourcesForEvent(event.id, allResources, eventsById);
 ---
 
 <article class="event-card" data-participation={participation}>
@@ -74,6 +85,32 @@ const place = online ? 'Online' : location;
     </div>
 
     <EventLinks links={links} timeframe={timeframe} />
+
+    {
+      /*
+        9.4 Event→Resources: a DISTINCT, separately-labelled block from the
+        external `resourceUrl` CTA above (complement, not a duplicate "watch"
+        link). Each item is a same-tab INTERNAL cross-link to the Resources
+        library (coarse `/resources/` target, meaningful resource-title label,
+        no external glyph, no target=_blank). Renders only when non-empty.
+      */
+      produced.length > 0 && (
+        <div class="event-produced">
+          <p class="event-produced-label" id={`produced-${event.id}`}>
+            Resources from this event
+          </p>
+          <ul class="event-produced-list" aria-labelledby={`produced-${event.id}`}>
+            {produced.map((resource) => (
+              <li class="event-produced-item">
+                <a class="event-produced-link" href={urlForEntry(resource)}>
+                  {resource.data.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )
+    }
   </div>
 </article>
 
@@ -218,5 +255,48 @@ const place = online ? 'Online' : location;
     content: ', ';
     font-weight: 400;
     color: var(--ev-fg-muted);
+  }
+
+  /*
+    Event→Resources block (9.4). A distinct, labelled list of same-tab INTERNAL
+    cross-links — separate from the external `resourceUrl` CTA in EventLinks.
+  */
+  .event-produced {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--ev-line, #e5e7eb);
+  }
+
+  .event-produced-label {
+    margin: 0 0 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ev-fg-faint, #6b7280);
+  }
+
+  .event-produced-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .event-produced-link {
+    color: var(--ev-accent-text, #046151);
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+
+  .event-produced-link:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #017b64);
+    outline-offset: 2px;
   }
 </style>

--- a/astro-docs/src/components/events/EventCard.astro
+++ b/astro-docs/src/components/events/EventCard.astro
@@ -2,10 +2,7 @@
 import type { CollectionEntry } from 'astro:content';
 
 import { blogAuthors } from '../../data/team';
-import {
-  resourcesForEvent,
-  urlForEntry,
-} from '../../lib/cross-links';
+import { urlForEntry } from '../../lib/cross-links';
 import { formatDisplay } from '../../schema/event-date';
 import EventAttribution from './EventAttribution.astro';
 import EventLinks from './EventLinks.astro';
@@ -20,11 +17,16 @@ import {
 interface Props {
   event: CollectionEntry<'events'>;
   timeframe: 'upcoming' | 'past';
-  allResources: CollectionEntry<'resources'>[];
-  eventsById: Map<string, CollectionEntry<'events'>>;
+  /**
+   * This event's produced Resources — derived (never hand-authored) and
+   * pre-sorted by `EventList` via `indexResourcesByOriginEvent`, so each card
+   * renders its slice without re-scanning the full resource set. Sparse — an
+   * empty list renders no block.
+   */
+  producedResources: CollectionEntry<'resources'>[];
 }
 
-const { event, timeframe, allResources, eventsById } = Astro.props;
+const { event, timeframe, producedResources } = Astro.props;
 const {
   title,
   participation,
@@ -43,11 +45,6 @@ const speakerNames = speakers.map((key) => blogAuthors[key]?.name ?? key);
 const links = resolveEventLinks({ timeframe, registerUrl, resourceUrl });
 const brand = resolveEventBrand({ title, attribution });
 const place = online ? 'Online' : location;
-
-// Derived produced-Resources (never hand-authored): resources whose
-// `originEvent` names this event, via the single shared cross-link module.
-// Sparse — an empty list renders no block.
-const produced = resourcesForEvent(event.id, allResources, eventsById);
 ---
 
 <article class="event-card" data-participation={participation}>
@@ -94,13 +91,13 @@ const produced = resourcesForEvent(event.id, allResources, eventsById);
         library (coarse `/resources/` target, meaningful resource-title label,
         no external glyph, no target=_blank). Renders only when non-empty.
       */
-      produced.length > 0 && (
+      producedResources.length > 0 && (
         <div class="event-produced">
           <p class="event-produced-label" id={`produced-${event.id}`}>
             Resources from this event
           </p>
           <ul class="event-produced-list" aria-labelledby={`produced-${event.id}`}>
-            {produced.map((resource) => (
+            {producedResources.map((resource) => (
               <li class="event-produced-item">
                 <a class="event-produced-link" href={urlForEntry(resource)}>
                   {resource.data.title}

--- a/astro-docs/src/components/events/EventLinks.astro
+++ b/astro-docs/src/components/events/EventLinks.astro
@@ -1,4 +1,5 @@
 ---
+import CtaLink from '../CtaLink.astro';
 import type { EventCardLink } from './eventMeta';
 
 interface Props {
@@ -9,10 +10,10 @@ interface Props {
 const { links, timeframe } = Astro.props;
 
 // Upcoming "Register to attend" is the primary (solid) CTA; past "View
-// resource" is the ghost (outline) CTA. Both are full pills with a visible
-// external-link glyph. Purely presentational — the resolved links (label/url)
-// are unchanged (see resolveEventLinks + its tests).
-const ctaClass = timeframe === 'upcoming' ? 'cta cta--primary' : 'cta cta--ghost';
+// resource" is the ghost (outline) CTA — the shared CtaLink pill owns both
+// shapes. Purely presentational — the resolved links (label/url) are
+// unchanged (see resolveEventLinks + its tests).
+const variant = timeframe === 'upcoming' ? 'primary' : 'ghost';
 ---
 
 {
@@ -20,30 +21,9 @@ const ctaClass = timeframe === 'upcoming' ? 'cta cta--primary' : 'cta cta--ghost
     <ul class="event-links-list">
       {links.map((link) => (
         <li class="event-links-item">
-          <a
-            class={ctaClass}
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <CtaLink href={link.url} variant={variant}>
             {link.label}
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 14 14"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
-                stroke="currentColor"
-                stroke-width="1.25"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </a>
+          </CtaLink>
         </li>
       ))}
     </ul>
@@ -63,38 +43,5 @@ const ctaClass = timeframe === 'upcoming' ? 'cta cta--primary' : 'cta cta--ghost
 
   .event-links-item {
     display: flex;
-  }
-
-  .cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.5rem 1rem;
-    border-radius: 9999px;
-    font-size: 0.9rem;
-    font-weight: 800;
-    text-decoration: none;
-  }
-
-  .cta svg {
-    flex-shrink: 0;
-  }
-
-  /* Primary CTA — white on teal-700 (light) / near-black on teal-400 (dark). */
-  .cta--primary {
-    background: var(--ev-cta-bg);
-    color: var(--ev-cta-fg);
-  }
-
-  /* Ghost CTA — transparent fill, accent text + ≥3:1 accent border. */
-  .cta--ghost {
-    background: transparent;
-    color: var(--ev-accent-text);
-    border: 1.5px solid var(--ev-accent-border);
-  }
-
-  .cta:focus-visible {
-    outline: 2px solid var(--ev-focus-ring);
-    outline-offset: 2px;
   }
 </style>

--- a/astro-docs/src/components/events/EventList.astro
+++ b/astro-docs/src/components/events/EventList.astro
@@ -17,6 +17,8 @@ type TypeFilter = ParticipationType | 'all';
 interface Props {
   allEvents: EventEntry[];
   events: EventEntry[];
+  allResources: CollectionEntry<'resources'>[];
+  eventsById: Map<string, EventEntry>;
   currentType?: TypeFilter;
   buildDate?: Date;
 }
@@ -24,6 +26,8 @@ interface Props {
 const {
   allEvents,
   events,
+  allResources,
+  eventsById,
   currentType = 'all',
   buildDate = new Date(),
 } = Astro.props;
@@ -93,7 +97,12 @@ const typeCounts = allEvents.reduce<Record<ParticipationType, number>>(
     upcoming.length > 0 ? (
       <div class="event-stack">
         {upcoming.map((event) => (
-          <EventCard event={event} timeframe="upcoming" />
+          <EventCard
+            event={event}
+            timeframe="upcoming"
+            allResources={allResources}
+            eventsById={eventsById}
+          />
         ))}
       </div>
     ) : (
@@ -108,7 +117,12 @@ const typeCounts = allEvents.reduce<Record<ParticipationType, number>>(
     past.length > 0 ? (
       <div class="event-stack">
         {past.map((event) => (
-          <EventCard event={event} timeframe="past" />
+          <EventCard
+            event={event}
+            timeframe="past"
+            allResources={allResources}
+            eventsById={eventsById}
+          />
         ))}
       </div>
     ) : (

--- a/astro-docs/src/components/events/EventList.astro
+++ b/astro-docs/src/components/events/EventList.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import { indexResourcesByOriginEvent } from '../../lib/cross-links';
 import { classify, type EventDate } from '../../schema/event-date';
 import { type ParticipationType } from '../../schema/events';
 import EventCard from './EventCard.astro';
@@ -55,6 +56,11 @@ past.sort((a, b) =>
   ),
 );
 
+// Derived produced-Resources (never hand-authored), grouped ONCE for the whole
+// page via the single shared cross-link module — each card receives its
+// pre-sorted slice instead of re-scanning the full resource set per card.
+const resourcesByEvent = indexResourcesByOriginEvent(allResources, eventsById);
+
 const typeCounts = allEvents.reduce<Record<ParticipationType, number>>(
   (counts, e) => {
     counts[e.data.participation] += 1;
@@ -100,8 +106,7 @@ const typeCounts = allEvents.reduce<Record<ParticipationType, number>>(
           <EventCard
             event={event}
             timeframe="upcoming"
-            allResources={allResources}
-            eventsById={eventsById}
+            producedResources={resourcesByEvent.get(event.id) ?? []}
           />
         ))}
       </div>
@@ -120,8 +125,7 @@ const typeCounts = allEvents.reduce<Record<ParticipationType, number>>(
           <EventCard
             event={event}
             timeframe="past"
-            allResources={allResources}
-            eventsById={eventsById}
+            producedResources={resourcesByEvent.get(event.id) ?? []}
           />
         ))}
       </div>

--- a/astro-docs/src/components/events/eventMeta.ts
+++ b/astro-docs/src/components/events/eventMeta.ts
@@ -9,6 +9,7 @@ import {
   type ParticipationMode,
   type ParticipationType,
 } from '../../schema/events';
+import { isHost } from '../hostMatch';
 
 /** Display labels for each participation type (also the filter-pill labels). */
 export const PARTICIPATION_TYPE_LABELS = {
@@ -107,16 +108,6 @@ export function resolveEventLinks(input: {
     return url ? [{ label: resolveResourceLabel(url), url }] : [];
   }
   return [];
-}
-
-/**
- * True when `host` is exactly `domain` or a real subdomain of it (`sub.domain`).
- * The leading-dot check is deliberate: a bare `host.endsWith(domain)` would also
- * match an attacker-controlled `evildomain.com` (it "ends with" the domain
- * without the dot boundary) — the incomplete-URL-sanitization pitfall.
- */
-function isHost(host: string, domain: string): boolean {
-  return host === domain || host.endsWith(`.${domain}`);
 }
 
 /**

--- a/astro-docs/src/components/events/eventMeta.ts
+++ b/astro-docs/src/components/events/eventMeta.ts
@@ -111,17 +111,21 @@ export function resolveEventLinks(input: {
 }
 
 /**
- * A human, action-shaped label for a past event's resource link, derived from
- * the destination host (e.g. "Watch on YouTube") rather than the generic
- * "View resource". Falls back to "Watch the recording" both for hosts we
- * don't recognise and for unparseable URLs.
+ * The recognised-platform label for a resource URL, derived from the
+ * destination host (e.g. "Watch on YouTube", "Listen on Spotify") — or
+ * `undefined` for hosts we don't recognise and for unparseable URLs. The
+ * "unrecognised" signal is STRUCTURAL (`undefined`), never a sentinel display
+ * string, so each consumer picks its own generic fallback verb without
+ * coupling to this module's wording: events fall back video-centrically
+ * ({@link resolveResourceLabel}), resources per type
+ * (`resolveResourceLinkLabel`).
  */
-export function resolveResourceLabel(url: string): string {
+export function resolvePlatformLabel(url: string): string | undefined {
   let host = '';
   try {
     host = new URL(url).hostname.toLowerCase();
   } catch {
-    return 'Watch the recording';
+    return undefined;
   }
   if (host === 'youtu.be' || isHost(host, 'youtube.com')) {
     return 'Watch on YouTube';
@@ -138,7 +142,17 @@ export function resolveResourceLabel(url: string): string {
   if (isHost(host, 'podcasts.apple.com')) {
     return 'Listen on Apple Podcasts';
   }
-  return 'Watch the recording';
+  return undefined;
+}
+
+/**
+ * A human, action-shaped label for a past event's resource link, derived from
+ * the destination host (e.g. "Watch on YouTube") rather than the generic
+ * "View resource". An event's `resourceUrl` is video-centric by contract, so
+ * an unrecognised platform falls back to "Watch the recording".
+ */
+export function resolveResourceLabel(url: string): string {
+  return resolvePlatformLabel(url) ?? 'Watch the recording';
 }
 
 /**

--- a/astro-docs/src/components/hostMatch.ts
+++ b/astro-docs/src/components/hostMatch.ts
@@ -1,0 +1,11 @@
+/**
+ * True when `host` is exactly `domain` or a real subdomain of it (`sub.domain`).
+ * The leading-dot check is deliberate: a bare `host.endsWith(domain)` would also
+ * match an attacker-controlled `evildomain.com` (it "ends with" the domain
+ * without the dot boundary) — the incomplete-URL-sanitization pitfall. Shared by
+ * `events/eventMeta.ts` and `resources/resourceMeta.ts` so both derive their host
+ * decisions from ONE secure implementation.
+ */
+export function isHost(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}

--- a/astro-docs/src/components/media/ConsentEmbed.astro
+++ b/astro-docs/src/components/media/ConsentEmbed.astro
@@ -19,6 +19,8 @@
  * With JS off — or when a player is blocked by X-Frame-Options/CSP — the button
  * does nothing and this link is the usable path; the tile never dead-ends.
  */
+import CtaLink from '../CtaLink.astro';
+
 interface Props {
   /**
    * The privacy-safe embed URL (e.g. a `youtube-nocookie` `/embed/<id>` URL).
@@ -110,29 +112,9 @@ const buttonLabel = `Play “${title}” — loads video from ${providerDisplay}
     JS-off visitor or a blocked player still has a working outward path.
   */}
   <p class="consent-embed-actions">
-    <a
-      class="consent-embed-cta"
-      href={fallback.url}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <CtaLink href={fallback.url} variant="ghost">
       {fallback.label}
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 14 14"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-      >
-        <path
-          d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
-          stroke="currentColor"
-          stroke-width="1.25"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-      </svg>
-    </a>
+    </CtaLink>
   </p>
 </div>
 
@@ -244,39 +226,11 @@ const buttonLabel = `Play “${title}” — loads video from ${providerDisplay}
     outline-offset: 2px;
   }
 
+  /* The link-out itself is the shared ghost CtaLink pill (token fallbacks
+     included there, so the gate stays reusable outside seeded roots). */
   .consent-embed-actions {
     margin: 0;
     display: flex;
-  }
-
-  /*
-    Ghost-pill link-out, mirroring the former ResourceEmbed `.resource-cta`:
-    transparent fill, accent text + ≥3:1 accent border, visible focus ring.
-    Consumes the `--ev-*` tokens the surface seeds (each with a light-theme
-    fallback so the control never renders with an undefined token when reused
-    outside `.resources-root`).
-  */
-  .consent-embed-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.5rem 1rem;
-    border-radius: 9999px;
-    font-size: 0.9rem;
-    font-weight: 800;
-    text-decoration: none;
-    background: transparent;
-    color: var(--ev-accent-text, #046151);
-    border: 1.5px solid var(--ev-accent-border, #046151);
-  }
-
-  .consent-embed-cta svg {
-    flex-shrink: 0;
-  }
-
-  .consent-embed-cta:focus-visible {
-    outline: 2px solid var(--ev-focus-ring, #017b64);
-    outline-offset: 2px;
   }
 </style>
 
@@ -286,6 +240,8 @@ const buttonLabel = `Play “${title}” — loads video from ${providerDisplay}
    * visitor's explicit activation. Per-activation consent — nothing is stored,
    * no `localStorage`. Native `<button>` gives Enter/Space for free.
    */
+  const INIT_ATTR = 'data-consent-embed-init';
+
   function activate(gate: Element): void {
     const button = gate.querySelector<HTMLButtonElement>('[data-consent-play]');
     const frame = gate.querySelector<HTMLElement>('[data-consent-frame]');
@@ -318,8 +274,19 @@ const buttonLabel = `Play “${title}” — loads video from ${providerDisplay}
     });
   }
 
-  // Support multiple gates on one page — each wired independently.
-  document
-    .querySelectorAll('.consent-embed')
-    .forEach((gate) => activate(gate));
+  // Support multiple gates on one page — each wired independently, exactly
+  // once (INIT_ATTR guards re-runs). Re-init on `astro:after-swap` matches the
+  // house idiom for interactive components, so the gate keeps working after a
+  // soft navigation if the ClientRouter is ever enabled.
+  function initConsentEmbeds(): void {
+    document
+      .querySelectorAll(`.consent-embed:not([${INIT_ATTR}])`)
+      .forEach((gate) => {
+        gate.setAttribute(INIT_ATTR, '');
+        activate(gate);
+      });
+  }
+
+  initConsentEmbeds();
+  document.addEventListener('astro:after-swap', initConsentEmbeds);
 </script>

--- a/astro-docs/src/components/media/ConsentEmbed.astro
+++ b/astro-docs/src/components/media/ConsentEmbed.astro
@@ -1,0 +1,325 @@
+---
+/**
+ * ConsentEmbed — a reusable "2-Klick" (click-to-load) consent gate for
+ * third-party media embeds (GDPR Art. 6(1)(a) / §25 TDDDG).
+ *
+ * WHY: a `youtube-nocookie` iframe still contacts Google on load (visitor IP →
+ * US transfer) before any consent. This gate renders a NEUTRAL LOCAL
+ * placeholder that makes ZERO third-party requests — no iframe `src`, no
+ * YouTube/ytimg thumbnail, no `preconnect`/`dns-prefetch`. The real embed URL
+ * rides only in a `data-embed-src` attribute (never a live `src`). The player is
+ * built and inserted client-side ONLY on the visitor's explicit activation, and
+ * consent is per-activation (nothing stored).
+ *
+ * REUSE: this is the single gate for every embed surface — Resources (9.3),
+ * the Epic 10 promo strip, and the Epic 11 hub all mount it. Keep it neutral
+ * (no resource-specific assumptions) so those consumers can reuse it verbatim.
+ *
+ * FAIL-SAFE (AC3′): the ghost-pill external link-out is always in static HTML.
+ * With JS off — or when a player is blocked by X-Frame-Options/CSP — the button
+ * does nothing and this link is the usable path; the tile never dead-ends.
+ */
+interface Props {
+  /**
+   * The privacy-safe embed URL (e.g. a `youtube-nocookie` `/embed/<id>` URL).
+   * Carried ONLY in `data-embed-src` — never emitted as a live `src` — so the
+   * static page issues no request to the embed host before activation (AC8).
+   */
+  src: string;
+  /** Provider display name shown in the notice + accessible name, e.g. `"YouTube"`. */
+  provider: string;
+  /**
+   * Optional data controller behind the provider, e.g. `"Google"`. When set it
+   * is surfaced as `"<provider> (<owner>)"` in the notice and the button's
+   * accessible name, making the third-country transfer explicit.
+   */
+  providerOwner?: string;
+  /** Human name of the resource — names the play button for assistive tech. */
+  title: string;
+  /**
+   * `title` applied to the loaded `<iframe>` (keyboard-reachable, meaningful).
+   * Defaults to {@link Props.title}.
+   */
+  embedTitle?: string;
+  /**
+   * The always-present fail-safe external link-out (AC3′). Opens in a new tab
+   * with `rel="noopener noreferrer"`.
+   */
+  fallback: { url: string; label: string };
+  /** Privacy-policy URL the notice links to. Defaults to the site's page. */
+  privacyHref?: string;
+}
+
+const {
+  src,
+  provider,
+  providerOwner,
+  title,
+  embedTitle,
+  fallback,
+  privacyHref = '/legal/data-privacy/',
+} = Astro.props;
+
+const providerDisplay = providerOwner
+  ? `${provider} (${providerOwner})`
+  : provider;
+
+// Accessible name NAMES the resource and states that activating loads external
+// third-party content (AC6′). The visible title + notice below repeat this for
+// sighted users.
+const buttonLabel = `Play “${title}” — loads video from ${providerDisplay}`;
+---
+
+<div class="consent-embed">
+  <div class="consent-embed-frame" data-consent-frame>
+    <div class="consent-embed-placeholder" data-consent-placeholder>
+      <p class="consent-embed-title">{title}</p>
+      <button
+        type="button"
+        class="consent-embed-play"
+        data-consent-play
+        data-embed-src={src}
+        data-embed-title={embedTitle ?? title}
+        aria-label={buttonLabel}
+      >
+        <svg
+          class="consent-embed-play-icon"
+          width="26"
+          height="26"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path d="M8 5.5v13l11-6.5-11-6.5Z" fill="currentColor"></path>
+        </svg>
+        <span class="consent-embed-play-label" aria-hidden="true">Play</span>
+      </button>
+      <p class="consent-embed-notice">
+        Clicking loads the video from {providerDisplay}, transferring your data
+        (incl. IP address) to the provider. See our{' '}
+        <a class="consent-embed-privacy-link" href={privacyHref}>
+          privacy policy
+        </a>.
+      </p>
+    </div>
+  </div>
+
+  {/*
+    AC3′ fail-safe: always-present external link-out. Static HTML, so a
+    JS-off visitor or a blocked player still has a working outward path.
+  */}
+  <p class="consent-embed-actions">
+    <a
+      class="consent-embed-cta"
+      href={fallback.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {fallback.label}
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
+          stroke="currentColor"
+          stroke-width="1.25"
+          stroke-linecap="round"
+          stroke-linejoin="round"></path>
+      </svg>
+    </a>
+  </p>
+</div>
+
+<style>
+  .consent-embed {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    margin-top: 0.25rem;
+  }
+
+  /* Responsive 16:9 shell — the placeholder (and, post-consent, the injected
+     iframe) fill it absolutely. Same shape as the former inline player. */
+  .consent-embed-frame {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    /* A fixed dark "poster" surface: light-on-dark text below clears AA in BOTH
+       themes because these colors don't track the theme. Kept a SOLID color
+       (not a gradient) so axe can evaluate text contrast deterministically. */
+    background: #0a1512;
+    border: 1px solid var(--ev-line, #e2e4e5);
+  }
+
+  .consent-embed-frame :global(iframe) {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+
+  /* Neutral LOCAL placeholder — no external asset of any kind. */
+  .consent-embed-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    text-align: center;
+  }
+
+  .consent-embed-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #ffffff;
+    /* Keep the title from crowding small cards. */
+    max-width: 32ch;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .consent-embed-play {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.6rem 1.1rem 0.6rem 0.95rem;
+    border-radius: 9999px;
+    border: 0;
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 800;
+    color: #06231d;
+    background: #ffffff;
+  }
+
+  .consent-embed-play:hover {
+    background: #eafff8;
+  }
+
+  .consent-embed-play-icon {
+    flex-shrink: 0;
+    color: #046151;
+  }
+
+  .consent-embed-play:focus-visible {
+    outline: 3px solid var(--ev-focus-ring, #5fe3c7);
+    outline-offset: 3px;
+  }
+
+  .consent-embed-notice {
+    margin: 0;
+    max-width: 46ch;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    /* rgba white → AA on the dark poster in both themes. */
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .consent-embed-privacy-link {
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    border-radius: 0.2rem;
+  }
+
+  .consent-embed-privacy-link:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #5fe3c7);
+    outline-offset: 2px;
+  }
+
+  .consent-embed-actions {
+    margin: 0;
+    display: flex;
+  }
+
+  /*
+    Ghost-pill link-out, mirroring the former ResourceEmbed `.resource-cta`:
+    transparent fill, accent text + ≥3:1 accent border, visible focus ring.
+    Consumes the `--ev-*` tokens the surface seeds (each with a light-theme
+    fallback so the control never renders with an undefined token when reused
+    outside `.resources-root`).
+  */
+  .consent-embed-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-decoration: none;
+    background: transparent;
+    color: var(--ev-accent-text, #046151);
+    border: 1.5px solid var(--ev-accent-border, #046151);
+  }
+
+  .consent-embed-cta svg {
+    flex-shrink: 0;
+  }
+
+  .consent-embed-cta:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #017b64);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  /*
+   * Progressive enhancement (AC1′): build & insert the real player only on the
+   * visitor's explicit activation. Per-activation consent — nothing is stored,
+   * no `localStorage`. Native `<button>` gives Enter/Space for free.
+   */
+  function activate(gate: Element): void {
+    const button = gate.querySelector<HTMLButtonElement>('[data-consent-play]');
+    const frame = gate.querySelector<HTMLElement>('[data-consent-frame]');
+    const placeholder = gate.querySelector<HTMLElement>(
+      '[data-consent-placeholder]',
+    );
+    if (!button || !frame) {
+      return;
+    }
+
+    button.addEventListener('click', () => {
+      const src = button.getAttribute('data-embed-src');
+      if (!src) {
+        return;
+      }
+      const iframe = document.createElement('iframe');
+      iframe.src = src;
+      iframe.title = button.getAttribute('data-embed-title') ?? '';
+      iframe.loading = 'lazy';
+      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+      iframe.allow = 'encrypted-media; fullscreen; picture-in-picture';
+      iframe.setAttribute('allowfullscreen', '');
+
+      // Remove the placeholder so only the player remains in the frame.
+      placeholder?.remove();
+      frame.appendChild(iframe);
+
+      // Keyboard continuity: land focus on the freshly loaded player.
+      iframe.focus();
+    });
+  }
+
+  // Support multiple gates on one page — each wired independently.
+  document
+    .querySelectorAll('.consent-embed')
+    .forEach((gate) => activate(gate));
+</script>

--- a/astro-docs/src/components/resources/ResourceCard.astro
+++ b/astro-docs/src/components/resources/ResourceCard.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from 'astro:content';
 
 import ResourceAttribution from './ResourceAttribution.astro';
+import ResourceEmbed from './ResourceEmbed.astro';
 import { RESOURCE_TYPE_LABELS } from './resourceMeta';
 
 interface Props {
@@ -16,9 +17,11 @@ const { title, resourceType, attribution } = resource.data;
   <span class="resource-card-edge" aria-hidden="true"></span>
 
   {/*
-    9.3 seam: embed-vs-linkout player renders here (when `embeddable`, an
-    inline player from `url`; otherwise a link-out affordance). Not implemented
-    in 9.2 — no player/link surfaced yet.
+    9.3 media surface (embed-vs-link-out) mounts at the BOTTOM of
+    `.resource-card-body` as <ResourceEmbed> — mirroring how EventCard composes
+    EventLinks. It is deliberately NOT placed here: this spot is a direct child
+    of the `[edge][body]` flex row, where a full-width player would become a
+    third flex column and break the band layout.
   */}
 
   <div class="resource-card-body">
@@ -38,6 +41,8 @@ const { title, resourceType, attribution } = resource.data;
     <h2 class="resource-card-title">{title}</h2>
 
     <ResourceAttribution attribution={attribution} />
+
+    <ResourceEmbed resource={resource} />
 
     {/*
       9.4 seam: when `originEvent` is set, a cross-link back to the origin

--- a/astro-docs/src/components/resources/ResourceCard.astro
+++ b/astro-docs/src/components/resources/ResourceCard.astro
@@ -1,15 +1,21 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import { urlForEntry } from '../../lib/cross-links';
 import ResourceAttribution from './ResourceAttribution.astro';
 import ResourceEmbed from './ResourceEmbed.astro';
 import { RESOURCE_TYPE_LABELS } from './resourceMeta';
 
 interface Props {
   resource: CollectionEntry<'resources'>;
+  /**
+   * The resolved origin Event, injected by `ResourceList` (via the shared
+   * `resolveOriginEvent`). Absent → no cross-link renders (sparse).
+   */
+  originEvent?: CollectionEntry<'events'>;
 }
 
-const { resource } = Astro.props;
+const { resource, originEvent } = Astro.props;
 const { title, resourceType, attribution } = resource.data;
 ---
 
@@ -45,9 +51,21 @@ const { title, resourceType, attribution } = resource.data;
     <ResourceEmbed resource={resource} />
 
     {/*
-      9.4 seam: when `originEvent` is set, a cross-link back to the origin
-      event's card/page renders here. 9.2 does NOT resolve `originEvent`.
+      9.4 seam: when `originEvent` resolves (injected by ResourceList via the
+      shared `resolveOriginEvent`), a same-tab cross-link back to the origin
+      event renders here (coarse `/events/` target, meaningful title label).
+      Absent → nothing renders (sparse).
     */}
+    {
+      originEvent && (
+        <p class="resource-origin-event">
+          <span class="resource-origin-event-label">From the event</span>
+          <a class="resource-origin-event-link" href={urlForEntry(originEvent)}>
+            {originEvent.data.title}
+          </a>
+        </p>
+      )
+    }
     {/*
       9.5 seam: OG-image generation for resource pages is extended in
       `src/pages/og/[...route].ts` — no OG key extension in 9.2.
@@ -137,5 +155,35 @@ const { title, resourceType, attribution } = resource.data;
     letter-spacing: -0.03em;
     line-height: 1.1;
     color: var(--ev-fg);
+  }
+
+  /* Resource→Event cross-link (9.4). Same-tab internal link, no external glyph. */
+  .resource-origin-event {
+    margin: 0.25rem 0 0;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--ev-fg-muted, #4b5563);
+  }
+
+  .resource-origin-event-label {
+    margin-inline-end: 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ev-fg-faint, #6b7280);
+  }
+
+  .resource-origin-event-link {
+    color: var(--ev-accent-text, #046151);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+
+  .resource-origin-event-link:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #017b64);
+    outline-offset: 2px;
   }
 </style>

--- a/astro-docs/src/components/resources/ResourceEmbed.astro
+++ b/astro-docs/src/components/resources/ResourceEmbed.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import ConsentEmbed from '../media/ConsentEmbed.astro';
 import { resolveResourceEmbed } from './resourceMeta';
 
 interface Props {
@@ -11,57 +12,69 @@ const { resource } = Astro.props;
 const { title, resourceType, url, embeddable } = resource.data;
 const media = resolveResourceEmbed({ resourceType, url, embeddable, title });
 
-// One CTA markup for both branches. For an embed it is the AC3 fail-safe link
-// (always in static HTML, so a player blocked by X-Frame-Options/CSP — which
-// fails silently, no `onerror` — still leaves a working outward link); for a
-// link resource it is the primary affordance. No client JS (AD-1).
-const linkOut =
+/**
+ * Provider display metadata, keyed by the resolver's provider id. The gate
+ * surfaces the data controller ("Google") so the third-country transfer is
+ * explicit in the consent notice + button name. Unknown providers fall back to
+ * the raw id with no owner. Threading it through keeps `resolveResourceEmbed`
+ * the single embed-vs-link decision point (AC5).
+ */
+const PROVIDER_LABELS: Record<string, { name: string; owner?: string }> = {
+  youtube: { name: 'YouTube', owner: 'Google' },
+};
+const providerInfo =
   media.kind === 'embed'
-    ? media.fallback
-    : { url: media.url, label: media.label };
+    ? (PROVIDER_LABELS[media.provider] ?? { name: media.provider })
+    : null;
 ---
 
 <div class="resource-embed">
   {
-    media.kind === 'embed' && (
-      <div class="resource-embed-frame">
-        <iframe
-          src={media.src}
-          title={media.title}
-          loading="lazy"
-          referrerpolicy="strict-origin-when-cross-origin"
-          allow="encrypted-media; fullscreen; picture-in-picture"
-          allowfullscreen
-        />
-      </div>
+    media.kind === 'embed' ? (
+      /*
+        Click-to-load consent gate (GDPR 2-Klick): a neutral local placeholder
+        that makes NO third-party request until the visitor activates it, then
+        loads the `youtube-nocookie` player in place. The gate also carries the
+        AC3′ fail-safe link-out, so this branch owns the full embed surface.
+      */
+      <ConsentEmbed
+        src={media.src}
+        provider={providerInfo!.name}
+        providerOwner={providerInfo!.owner}
+        title={title}
+        embedTitle={media.title}
+        fallback={media.fallback}
+      />
+    ) : (
+      /* Link resource: the CTA is the primary (and only) affordance. */
+      <p class="resource-embed-actions">
+        <a
+          class="resource-cta"
+          href={media.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {media.label}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
+              stroke="currentColor"
+              stroke-width="1.25"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </a>
+      </p>
     )
   }
-  <p class="resource-embed-actions">
-    <a
-      class="resource-cta"
-      href={linkOut.url}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {linkOut.label}
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 14 14"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-      >
-        <path
-          d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
-          stroke="currentColor"
-          stroke-width="1.25"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-    </a>
-  </p>
 </div>
 
 <style>
@@ -72,35 +85,17 @@ const linkOut =
     margin-top: 0.25rem;
   }
 
-  /* Responsive 16:9 player shell — the iframe fills it absolutely. */
-  .resource-embed-frame {
-    position: relative;
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    border-radius: 0.75rem;
-    overflow: hidden;
-    background: #000;
-    border: 1px solid var(--ev-line, #e2e4e5);
-  }
-
-  .resource-embed-frame iframe {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    border: 0;
-  }
-
   .resource-embed-actions {
     margin: 0;
     display: flex;
   }
 
   /*
-    Ghost-pill link-out, mirroring EventLinks `.cta--ghost`: transparent fill,
-    accent text + ≥3:1 accent border, visible focus ring. Consumes the `--ev-*`
-    tokens 9.2 seeds on `.resources-root` (each with a light-theme fallback so
-    the surface never renders with an undefined token).
+    Ghost-pill link-out for the link-resource branch, mirroring EventLinks
+    `.cta--ghost`: transparent fill, accent text + ≥3:1 accent border, visible
+    focus ring. Consumes the `--ev-*` tokens 9.2 seeds on `.resources-root`
+    (each with a light-theme fallback so the surface never renders with an
+    undefined token). The embed branch's link-out lives in ConsentEmbed.
   */
   .resource-cta {
     display: inline-flex;

--- a/astro-docs/src/components/resources/ResourceEmbed.astro
+++ b/astro-docs/src/components/resources/ResourceEmbed.astro
@@ -1,0 +1,127 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+import { resolveResourceEmbed } from './resourceMeta';
+
+interface Props {
+  resource: CollectionEntry<'resources'>;
+}
+
+const { resource } = Astro.props;
+const { title, resourceType, url, embeddable } = resource.data;
+const media = resolveResourceEmbed({ resourceType, url, embeddable, title });
+
+// One CTA markup for both branches. For an embed it is the AC3 fail-safe link
+// (always in static HTML, so a player blocked by X-Frame-Options/CSP — which
+// fails silently, no `onerror` — still leaves a working outward link); for a
+// link resource it is the primary affordance. No client JS (AD-1).
+const linkOut =
+  media.kind === 'embed'
+    ? media.fallback
+    : { url: media.url, label: media.label };
+---
+
+<div class="resource-embed">
+  {
+    media.kind === 'embed' && (
+      <div class="resource-embed-frame">
+        <iframe
+          src={media.src}
+          title={media.title}
+          loading="lazy"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="encrypted-media; fullscreen; picture-in-picture"
+          allowfullscreen
+        />
+      </div>
+    )
+  }
+  <p class="resource-embed-actions">
+    <a
+      class="resource-cta"
+      href={linkOut.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {linkOut.label}
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
+          stroke="currentColor"
+          stroke-width="1.25"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </a>
+  </p>
+</div>
+
+<style>
+  .resource-embed {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    margin-top: 0.25rem;
+  }
+
+  /* Responsive 16:9 player shell — the iframe fills it absolutely. */
+  .resource-embed-frame {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: #000;
+    border: 1px solid var(--ev-line, #e2e4e5);
+  }
+
+  .resource-embed-frame iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+
+  .resource-embed-actions {
+    margin: 0;
+    display: flex;
+  }
+
+  /*
+    Ghost-pill link-out, mirroring EventLinks `.cta--ghost`: transparent fill,
+    accent text + ≥3:1 accent border, visible focus ring. Consumes the `--ev-*`
+    tokens 9.2 seeds on `.resources-root` (each with a light-theme fallback so
+    the surface never renders with an undefined token).
+  */
+  .resource-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-decoration: none;
+    background: transparent;
+    color: var(--ev-accent-text, #046151);
+    border: 1.5px solid var(--ev-accent-border, #046151);
+  }
+
+  .resource-cta svg {
+    flex-shrink: 0;
+  }
+
+  .resource-cta:focus-visible {
+    outline: 2px solid var(--ev-focus-ring, #017b64);
+    outline-offset: 2px;
+  }
+</style>

--- a/astro-docs/src/components/resources/ResourceEmbed.astro
+++ b/astro-docs/src/components/resources/ResourceEmbed.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import CtaLink from '../CtaLink.astro';
 import ConsentEmbed from '../media/ConsentEmbed.astro';
 import { resolveResourceEmbed } from './resourceMeta';
 
@@ -46,32 +47,15 @@ const providerInfo =
         fallback={media.fallback}
       />
     ) : (
-      /* Link resource: the CTA is the primary (and only) affordance. */
+      /*
+        Link resource: the CTA is the primary (and only) affordance — the
+        shared ghost CtaLink pill (the embed branch's link-out lives in
+        ConsentEmbed, on the same pill).
+      */
       <p class="resource-embed-actions">
-        <a
-          class="resource-cta"
-          href={media.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <CtaLink href={media.url} variant="ghost">
           {media.label}
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 14 14"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path
-              d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
-              stroke="currentColor"
-              stroke-width="1.25"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </a>
+        </CtaLink>
       </p>
     )
   }
@@ -88,35 +72,5 @@ const providerInfo =
   .resource-embed-actions {
     margin: 0;
     display: flex;
-  }
-
-  /*
-    Ghost-pill link-out for the link-resource branch, mirroring EventLinks
-    `.cta--ghost`: transparent fill, accent text + ≥3:1 accent border, visible
-    focus ring. Consumes the `--ev-*` tokens 9.2 seeds on `.resources-root`
-    (each with a light-theme fallback so the surface never renders with an
-    undefined token). The embed branch's link-out lives in ConsentEmbed.
-  */
-  .resource-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.5rem 1rem;
-    border-radius: 9999px;
-    font-size: 0.9rem;
-    font-weight: 800;
-    text-decoration: none;
-    background: transparent;
-    color: var(--ev-accent-text, #046151);
-    border: 1.5px solid var(--ev-accent-border, #046151);
-  }
-
-  .resource-cta svg {
-    flex-shrink: 0;
-  }
-
-  .resource-cta:focus-visible {
-    outline: 2px solid var(--ev-focus-ring, #017b64);
-    outline-offset: 2px;
   }
 </style>

--- a/astro-docs/src/components/resources/ResourceList.astro
+++ b/astro-docs/src/components/resources/ResourceList.astro
@@ -1,35 +1,37 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import {
+  resolveOriginEvent,
+  sortResourcesByEffectiveDate,
+} from '../../lib/cross-links';
 import { type ResourceType } from '../../schema/resources';
 import ResourceCard from './ResourceCard.astro';
 import {
-  compareResources,
   RESOURCE_TYPE_LABELS,
   RESOURCE_TYPE_ORDER,
   resourceTypeSlug,
 } from './resourceMeta';
 
 type ResourceEntry = CollectionEntry<'resources'>;
+type EventEntry = CollectionEntry<'events'>;
 type TypeFilter = ResourceType | 'all';
 
 interface Props {
   allResources: ResourceEntry[];
   resources: ResourceEntry[];
+  eventsById: Map<string, EventEntry>;
   currentType?: TypeFilter;
 }
 
-const { allResources, resources, currentType = 'all' } = Astro.props;
+const { allResources, resources, eventsById, currentType = 'all' } =
+  Astro.props;
 
-// Single date-sorted library (no Upcoming/Past split). The 9.1 schema has no
-// resource date, so each entry sorts with `date: undefined` and the order falls
-// deterministically to title A→Z via `compareResources`.
-const sorted = [...resources].sort((a, b) =>
-  compareResources(
-    { title: a.data.title },
-    { title: b.data.title },
-  ),
-);
+// Single date-sorted library (no Upcoming/Past split). Sort by each resource's
+// effective date (= its origin-event date) via the shared cross-link module,
+// which delegates to `compareResources`: undated / no-origin-event last, then
+// title A→Z. Origin-event resolution is the AD-6 throwing primitive.
+const sorted = sortResourcesByEffectiveDate(resources, eventsById);
 
 const typeCounts = allResources.reduce<Record<ResourceType, number>>(
   (counts, r) => {
@@ -72,7 +74,10 @@ const typeCounts = allResources.reduce<Record<ResourceType, number>>(
     sorted.length > 0 ? (
       <div class="resource-stack">
         {sorted.map((resource) => (
-          <ResourceCard resource={resource} />
+          <ResourceCard
+            resource={resource}
+            originEvent={resolveOriginEvent(resource, eventsById)}
+          />
         ))}
       </div>
     ) : (

--- a/astro-docs/src/components/resources/resourceMeta.ts
+++ b/astro-docs/src/components/resources/resourceMeta.ts
@@ -1,5 +1,5 @@
 import { RESOURCE_TYPES, type ResourceType } from '../../schema/resources';
-import { resolveResourceLabel } from '../events/eventMeta';
+import { resolvePlatformLabel } from '../events/eventMeta';
 import { isHost } from '../hostMatch';
 
 /**
@@ -155,7 +155,7 @@ function youtubeEmbedSrc(parsed: URL): string | undefined {
 
 /**
  * Type-appropriate generic link-out labels — the fallback verb when the host is
- * not one `resolveResourceLabel` recognises. A `paper` is read (never watched);
+ * not one `resolvePlatformLabel` recognises. A `paper` is read (never watched);
  * an audio `podcast episode` is listened to, not watched.
  */
 const GENERIC_LINK_LABEL = {
@@ -167,23 +167,17 @@ const GENERIC_LINK_LABEL = {
 
 /**
  * A type-appropriate, human link-out label. Recognised video/audio platforms
- * reuse the shared `resolveResourceLabel` host→label map ("Watch on YouTube",
- * "Listen on Spotify", …). That helper is video-centric, though: its generic
- * fallback is literally "Watch the recording", the wrong verb for a `paper` or
- * an unrecognised-host `podcast episode`, so those fall to {@link
- * GENERIC_LINK_LABEL} instead. Papers never consult the video map at all.
+ * reuse the shared `resolvePlatformLabel` host→label map ("Watch on YouTube",
+ * "Listen on Spotify", …); an unrecognised host signals structurally
+ * (`undefined`) and falls to the type's {@link GENERIC_LINK_LABEL} — the
+ * events-side "Watch…" generic would be the wrong verb for a `paper` or an
+ * audio `podcast episode`. Papers never consult the platform map at all.
  */
 function resolveResourceLinkLabel(type: ResourceType, url: string): string {
   if (type === 'paper') {
     return GENERIC_LINK_LABEL.paper;
   }
-  const platformLabel = resolveResourceLabel(url);
-  // `resolveResourceLabel` returns this exact string only when it recognises no
-  // host; swap in the type-appropriate generic then, otherwise keep its precise
-  // platform label.
-  return platformLabel === 'Watch the recording'
-    ? GENERIC_LINK_LABEL[type]
-    : platformLabel;
+  return resolvePlatformLabel(url) ?? GENERIC_LINK_LABEL[type];
 }
 
 /**

--- a/astro-docs/src/components/resources/resourceMeta.ts
+++ b/astro-docs/src/components/resources/resourceMeta.ts
@@ -17,6 +17,41 @@ export const RESOURCE_TYPE_LABELS = {
   paper: 'Paper',
 } satisfies Record<ResourceType, string>;
 
+/**
+ * The OG-image page map for the Resources section, keyed by each page's
+ * `starlightRoute.id` (the value `route-data.ts` reads). Resources render as
+ * inline cards on a fixed page set — the `/resources/` index (`resources`) plus
+ * one page per resource type (`resources/type/<slug>`) — so the keys are these
+ * PAGE ids, not per-resource-entry ids (AD-4). The type-page keys are derived
+ * from `RESOURCE_TYPES` — the same source `[type].astro`'s `getStaticPaths`
+ * routes from — so they track the type-page inventory automatically
+ * (adding/removing a type keeps both in lockstep). Unlike `eventOgPages()`,
+ * whose participation enum values are already URL-safe single words, resource
+ * enum values are MULTI-WORD, so each type key MUST be slugged via
+ * `resourceTypeSlug` to match the shipped route id. The `resources` index key is
+ * fixed, matching the static `/resources/` route. Consumed by
+ * `src/pages/og/[...route].ts`.
+ */
+export function resourceOgPages(): Record<
+  string,
+  { title: string; description: string }
+> {
+  const pages: Record<string, { title: string; description: string }> = {
+    resources: {
+      title: 'Resources',
+      description:
+        'Talks, webinars, podcast episodes, and papers Thymian produced or took part in.',
+    },
+  };
+  for (const type of RESOURCE_TYPES) {
+    pages[`resources/type/${resourceTypeSlug(type)}`] = {
+      title: `Resources — ${RESOURCE_TYPE_LABELS[type]}`,
+      description: `Browse Thymian ${RESOURCE_TYPE_LABELS[type].toLowerCase()} resources.`,
+    };
+  }
+  return pages;
+}
+
 /** Canonical display / filter order for resource types (the enum tuple). */
 export const RESOURCE_TYPE_ORDER = RESOURCE_TYPES;
 

--- a/astro-docs/src/components/resources/resourceMeta.ts
+++ b/astro-docs/src/components/resources/resourceMeta.ts
@@ -1,4 +1,6 @@
 import { RESOURCE_TYPES, type ResourceType } from '../../schema/resources';
+import { resolveResourceLabel } from '../events/eventMeta';
+import { isHost } from '../hostMatch';
 
 /**
  * Reuse the Events AD-13 honest-attribution guard verbatim — a Resource has the
@@ -64,4 +66,132 @@ export function resourceTypeSlug(type: ResourceType): string {
 /** Inverse of {@link resourceTypeSlug}: a slug back to its enum value, or `undefined`. */
 export function resourceTypeFromSlug(slug: string): ResourceType | undefined {
   return RESOURCE_TYPES.find((type) => resourceTypeSlug(type) === slug);
+}
+
+/**
+ * The render decision for a resource's media surface (AD-12): an inline embed
+ * with a build-derived, known-safe `src` (plus an always-available external
+ * `fallback` link — the AC3 fail-safe), or a safe external link-out. Exactly ONE
+ * resolver (`resolveResourceEmbed`) produces this; consumers never re-implement
+ * the embed-vs-link branch.
+ */
+export type ResourceEmbed =
+  | {
+      kind: 'embed';
+      src: string;
+      provider: string;
+      title: string;
+      fallback: { url: string; label: string };
+    }
+  | { kind: 'link'; url: string; label: string };
+
+/** YouTube video ids are exactly 11 URL-safe base64 chars. */
+const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+
+/**
+ * Derive a privacy-friendly YouTube embed `src` from an author URL, or
+ * `undefined` when it is not a YouTube URL we can safely embed. Handles
+ * `watch?v=`, `youtu.be/<id>`, `/embed/<id>`, `/shorts/<id>`, `/live/<id>`. The
+ * extracted id must match {@link YOUTUBE_ID}; anything else → `undefined` (never
+ * build a `src` from an unvalidated fragment). Host matching uses the secure
+ * `isHost` boundary check, so `evilyoutube.com` is rejected.
+ */
+function youtubeEmbedSrc(parsed: URL): string | undefined {
+  const host = parsed.hostname.toLowerCase();
+  let id: string | undefined;
+  if (host === 'youtu.be') {
+    id = parsed.pathname.split('/').filter(Boolean)[0];
+  } else if (isHost(host, 'youtube.com')) {
+    const v = parsed.searchParams.get('v');
+    if (v) {
+      id = v;
+    } else {
+      const [segment, value] = parsed.pathname.split('/').filter(Boolean);
+      if (segment === 'embed' || segment === 'shorts' || segment === 'live') {
+        id = value;
+      }
+    }
+  }
+  if (id === undefined || !YOUTUBE_ID.test(id)) {
+    return undefined;
+  }
+  return `https://www.youtube-nocookie.com/embed/${id}`;
+}
+
+/**
+ * Type-appropriate generic link-out labels — the fallback verb when the host is
+ * not one `resolveResourceLabel` recognises. A `paper` is read (never watched);
+ * an audio `podcast episode` is listened to, not watched.
+ */
+const GENERIC_LINK_LABEL = {
+  'recorded talk': 'Watch the recording',
+  webinar: 'Watch the recording',
+  'podcast episode': 'Listen to the episode',
+  paper: 'Read the paper',
+} satisfies Record<ResourceType, string>;
+
+/**
+ * A type-appropriate, human link-out label. Recognised video/audio platforms
+ * reuse the shared `resolveResourceLabel` host→label map ("Watch on YouTube",
+ * "Listen on Spotify", …). That helper is video-centric, though: its generic
+ * fallback is literally "Watch the recording", the wrong verb for a `paper` or
+ * an unrecognised-host `podcast episode`, so those fall to {@link
+ * GENERIC_LINK_LABEL} instead. Papers never consult the video map at all.
+ */
+function resolveResourceLinkLabel(type: ResourceType, url: string): string {
+  if (type === 'paper') {
+    return GENERIC_LINK_LABEL.paper;
+  }
+  const platformLabel = resolveResourceLabel(url);
+  // `resolveResourceLabel` returns this exact string only when it recognises no
+  // host; swap in the type-appropriate generic then, otherwise keep its precise
+  // platform label.
+  return platformLabel === 'Watch the recording'
+    ? GENERIC_LINK_LABEL[type]
+    : platformLabel;
+}
+
+/**
+ * THE single embed-vs-link resolver (AD-12 / FR-10). Decision order:
+ *   (a) author declared non-embeddable OR a `paper` → link-out;
+ *   (b) embeddable AND a recognised provider we can derive a known-safe embed
+ *       URL for (currently YouTube → youtube-nocookie) → inline embed;
+ *   (c) safe default → link-out (never iframe a host we cannot build a known
+ *       embed URL for; malformed URLs fall here via try/catch — never throw).
+ */
+export function resolveResourceEmbed(input: {
+  resourceType: ResourceType;
+  url: string;
+  embeddable: boolean;
+  title: string;
+}): ResourceEmbed {
+  const { resourceType, url, embeddable, title } = input;
+  const link = (): ResourceEmbed => ({
+    kind: 'link',
+    url,
+    label: resolveResourceLinkLabel(resourceType, url),
+  });
+
+  if (!embeddable || resourceType === 'paper') {
+    return link();
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return link();
+  }
+
+  const src = youtubeEmbedSrc(parsed);
+  if (src !== undefined) {
+    return {
+      kind: 'embed',
+      src,
+      provider: 'youtube',
+      title: `${title} — embedded player`,
+      fallback: { url, label: resolveResourceLinkLabel(resourceType, url) },
+    };
+  }
+  return link();
 }

--- a/astro-docs/src/components/social/DocLinks.astro
+++ b/astro-docs/src/components/social/DocLinks.astro
@@ -1,4 +1,6 @@
 ---
+import ExternalLinkIcon from '../ExternalLinkIcon.astro';
+
 interface DocLink {
   label: string;
   url: string;
@@ -18,22 +20,7 @@ const { links, title = 'Documentation Links' } = Astro.props;
     {
       links.map((link) => (
         <li class="doc-links-item">
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 14 14"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path
-              d="M5.25 2.625H2.625A.875.875 0 0 0 1.75 3.5v7.875a.875.875 0 0 0 .875.875H10.5a.875.875 0 0 0 .875-.875V8.75M8.75 1.75h3.5v3.5M7 7l5.25-5.25"
-              stroke="currentColor"
-              stroke-width="1.25"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
+          <ExternalLinkIcon />
           <a href={link.url} target="_blank" rel="noopener noreferrer">
             {link.label}
             <span class="doc-links-url">{link.url}</span>
@@ -79,8 +66,9 @@ const { links, title = 'Documentation Links' } = Astro.props;
     font-size: 0.875rem;
   }
 
-  .doc-links-item svg {
-    flex-shrink: 0;
+  /* The shared icon is a child component, so its svg needs :global() to be
+     reached from this scope (flex-shrink lives in the icon itself). */
+  .doc-links-item :global(svg) {
     margin-top: 0.1em;
     color: var(--sl-color-accent);
   }

--- a/astro-docs/src/content/resources/should-i-get-or-should-i-post-recording.md
+++ b/astro-docs/src/content/resources/should-i-get-or-should-i-post-recording.md
@@ -1,0 +1,12 @@
+---
+title: 'Should I GET or Should I POST — The Clash With HTTP Conformance'
+resourceType: recorded talk
+url: https://www.youtube.com/watch?v=1IvUSEnGkZ8
+embeddable: true
+attribution:
+  hostGuest: guest
+  externalHost: My Coding Zone
+  platform: YouTube
+  externalUrl: https://www.youtube.com/watch?v=1IvUSEnGkZ8
+originEvent: my-coding-zone-should-i-get-or-should-i-post
+---

--- a/astro-docs/src/lib/cross-links.ts
+++ b/astro-docs/src/lib/cross-links.ts
@@ -127,3 +127,34 @@ export function resourcesForEvent(
   );
   return sortResourcesByEffectiveDate(produced, eventsById);
 }
+
+/**
+ * The produced Resources of EVERY event, grouped in ONE pass over the resource
+ * set — the list-page complement of {@link resourcesForEvent} (which stays the
+ * single-event query). `EventList` builds this once per page and hands each
+ * card its slice, instead of re-filtering + re-sorting the full set per card
+ * (O(events × resources)). Each group is sorted by the single shared basis;
+ * an event no resource names has no entry (readers default to `[]`).
+ */
+export function indexResourcesByOriginEvent(
+  allResources: ResourceEntry[],
+  eventsById: Map<string, EventEntry>,
+): Map<string, ResourceEntry[]> {
+  const byEvent = new Map<string, ResourceEntry[]>();
+  for (const resource of allResources) {
+    const originId = resource.data.originEvent?.id;
+    if (originId === undefined) {
+      continue;
+    }
+    const group = byEvent.get(originId);
+    if (group === undefined) {
+      byEvent.set(originId, [resource]);
+    } else {
+      group.push(resource);
+    }
+  }
+  for (const [eventId, group] of byEvent) {
+    byEvent.set(eventId, sortResourcesByEffectiveDate(group, eventsById));
+  }
+  return byEvent;
+}

--- a/astro-docs/src/lib/cross-links.ts
+++ b/astro-docs/src/lib/cross-links.ts
@@ -1,0 +1,129 @@
+import type { CollectionEntry } from 'astro:content';
+
+import { compareResources } from '../components/resources/resourceMeta';
+import { effectiveDate } from '../schema/event-date';
+
+/**
+ * The single shared module owning the bidirectional Event↔Resource derivation
+ * (Story 9.4). The relationship is authored ONLY as a Resource's `originEvent`;
+ * the Event's produced-Resources list is DERIVED here at build time. Every
+ * consumer (the Resource library, the Event page, the Epic 10 promo strip, the
+ * Epic 11 hub) imports these functions so ordering and URL targets can never
+ * drift.
+ *
+ * PURE by contract: this module never calls `getCollection`/`getEntry` — pages
+ * pass the already-loaded arrays in — so it stays unit-testable with fake
+ * entries and no content fixtures.
+ */
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+/** Index events by their entry `id` for O(1) origin-event resolution. */
+export function indexEventsById(
+  allEvents: EventEntry[],
+): Map<string, EventEntry> {
+  return new Map(allEvents.map((event) => [event.id, event]));
+}
+
+/**
+ * The sole entry→URL map for cross-links. Neither collection has a per-entry
+ * detail page (only an `index` + `type/[type]` route set), so both directions
+ * resolve to their library index — a real route with NO `#` fragment, so
+ * `starlight-links-validator` (with `errorOnInvalidHashes`) stays green. The
+ * link's specific title carries the meaning despite the coarse target.
+ */
+export function urlForEntry(entry: EventEntry | ResourceEntry): string {
+  return entry.collection === 'events' ? '/events/' : '/resources/';
+}
+
+/**
+ * Resolve a resource's origin Event, or `undefined` when it has none.
+ *
+ * AD-6 build-time integrity guard: Astro 7.1.3 `reference('events')` is
+ * WARN-ONLY — a dangling id yields `getEntry → undefined` and a console warning,
+ * NOT a build failure. So when `originEvent` is SET but resolves to no existing
+ * Event, this THROWS, failing `astro build` loudly rather than rendering a
+ * silent broken link. Never swallow a dangling reference.
+ */
+export function resolveOriginEvent(
+  resource: ResourceEntry,
+  eventsById: Map<string, EventEntry>,
+): EventEntry | undefined {
+  const ref = resource.data.originEvent;
+  if (ref === undefined) {
+    return undefined;
+  }
+  const event = eventsById.get(ref.id);
+  if (event === undefined) {
+    throw new Error(
+      `AD-6 build-time guard: resource '${resource.id}' has originEvent '${ref.id}', ` +
+        `but no event with that id exists. Astro reference() is warn-only, so this ` +
+        `would otherwise render a silent broken link — failing the build instead. ` +
+        `Fix the originEvent id or add the missing event.`,
+    );
+  }
+  return event;
+}
+
+/**
+ * Run {@link resolveOriginEvent} across the FULL resource set so a dangling
+ * reference is caught even when it matches no rendered event. Called explicitly
+ * in both `/resources` pages — coverage never depends on a dangling ref
+ * happening to line up with a surfaced event.
+ */
+export function assertOriginEventsResolve(
+  allResources: ResourceEntry[],
+  eventsById: Map<string, EventEntry>,
+): void {
+  for (const resource of allResources) {
+    resolveOriginEvent(resource, eventsById);
+  }
+}
+
+/**
+ * A resource's effective date = its origin Event's `effectiveDate(date)`
+ * (month→1st of month, TBA/none→undefined). Used purely as the sort basis; a
+ * resource with no resolvable origin event is undated (buckets last).
+ */
+export function resourceEffectiveDate(
+  resource: ResourceEntry,
+  eventsById: Map<string, EventEntry>,
+): Date | undefined {
+  const event = resolveOriginEvent(resource, eventsById);
+  return event ? (effectiveDate(event.data.date) ?? undefined) : undefined;
+}
+
+/**
+ * Library order: most-recent-first by resource effective date (= origin-event
+ * date), undated / no-origin-event entries bucketed last, title A→Z tiebreak.
+ * Delegates to the shared `compareResources` comparator (never re-implement the
+ * branch) by injecting each resource's effective date into its `date` slot.
+ */
+export function sortResourcesByEffectiveDate(
+  resources: ResourceEntry[],
+  eventsById: Map<string, EventEntry>,
+): ResourceEntry[] {
+  return [...resources].sort((a, b) =>
+    compareResources(
+      { title: a.data.title, date: resourceEffectiveDate(a, eventsById) },
+      { title: b.data.title, date: resourceEffectiveDate(b, eventsById) },
+    ),
+  );
+}
+
+/**
+ * The Resources an Event produced, DERIVED (never hand-authored) from every
+ * resource whose `originEvent` names this event, sorted by the single shared
+ * basis. Returns `[]` for an event no resource names (0..N cardinality).
+ */
+export function resourcesForEvent(
+  eventId: string,
+  allResources: ResourceEntry[],
+  eventsById: Map<string, EventEntry>,
+): ResourceEntry[] {
+  const produced = allResources.filter(
+    (resource) => resource.data.originEvent?.id === eventId,
+  );
+  return sortResourcesByEffectiveDate(produced, eventsById);
+}

--- a/astro-docs/src/pages/events/index.astro
+++ b/astro-docs/src/pages/events/index.astro
@@ -4,8 +4,17 @@ import { getCollection } from 'astro:content';
 import EventList from '../../components/events/EventList.astro';
 import EventsLayout from '../../components/events/EventsLayout.astro';
 import { resolveLogoCredits } from '../../components/events/eventMeta';
+import {
+  assertOriginEventsResolve,
+  indexEventsById,
+} from '../../lib/cross-links';
 
 const allEvents = await getCollection('events');
+const allResources = await getCollection('resources');
+const eventsById = indexEventsById(allEvents);
+// AD-6 guard on the events render path too, so the dangling-reference build
+// failure never depends implicitly on the /resources pages also building.
+assertOriginEventsResolve(allResources, eventsById);
 ---
 
 <EventsLayout
@@ -13,5 +22,11 @@ const allEvents = await getCollection('events');
   description="Where Thymian is speaking, exhibiting, and appearing — upcoming and past."
   credits={resolveLogoCredits(allEvents)}
 >
-  <EventList allEvents={allEvents} events={allEvents} currentType="all" />
+  <EventList
+    allEvents={allEvents}
+    events={allEvents}
+    allResources={allResources}
+    eventsById={eventsById}
+    currentType="all"
+  />
 </EventsLayout>

--- a/astro-docs/src/pages/events/type/[type].astro
+++ b/astro-docs/src/pages/events/type/[type].astro
@@ -8,6 +8,10 @@ import {
   resolveLogoCredits,
 } from '../../../components/events/eventMeta';
 import {
+  assertOriginEventsResolve,
+  indexEventsById,
+} from '../../../lib/cross-links';
+import {
   PARTICIPATION_TYPES,
   type ParticipationType,
 } from '../../../schema/events';
@@ -22,6 +26,11 @@ export function getStaticPaths() {
 const { type } = Astro.props as { type: ParticipationType };
 const allEvents = await getCollection('events');
 const events = allEvents.filter((e) => e.data.participation === type);
+const allResources = await getCollection('resources');
+const eventsById = indexEventsById(allEvents);
+// AD-6 guard on the events render path too, so the dangling-reference build
+// failure never depends implicitly on the /resources pages also building.
+assertOriginEventsResolve(allResources, eventsById);
 ---
 
 <EventsLayout
@@ -29,5 +38,11 @@ const events = allEvents.filter((e) => e.data.participation === type);
   description={`Thymian ${PARTICIPATION_TYPE_LABELS[type].toLowerCase()} appearances — upcoming and past.`}
   credits={resolveLogoCredits(events)}
 >
-  <EventList allEvents={allEvents} events={events} currentType={type} />
+  <EventList
+    allEvents={allEvents}
+    events={events}
+    allResources={allResources}
+    eventsById={eventsById}
+    currentType={type}
+  />
 </EventsLayout>

--- a/astro-docs/src/pages/og/[...route].ts
+++ b/astro-docs/src/pages/og/[...route].ts
@@ -2,6 +2,7 @@ import { getCollection } from 'astro:content';
 import { OGImageRoute } from 'astro-og-canvas';
 
 import { eventOgPages } from '../../components/events/eventMeta';
+import { resourceOgPages } from '../../components/resources/resourceMeta';
 
 const docs = await getCollection('docs');
 
@@ -15,13 +16,14 @@ const docPages = Object.fromEntries(
   ]),
 );
 
-// Events are keyed by their page `starlightRoute.id` (`events`,
-// `events/type/<type>`) because event cards render inline on a fixed page set —
-// there are NO per-event detail routes, so we must NOT key by per-event-entry
-// ids (AD-4). Events are intentionally NOT added to `llms.txt` in v1:
-// `starlight-llms-txt` is hardwired to `getCollection('docs')` with no extension
-// hook, so hand-rolling a parallel generator is out of scope (AD-5).
-const pages = { ...docPages, ...eventOgPages() };
+// Events and resources are keyed by their page `starlightRoute.id` (`events`,
+// `events/type/<type>`; `resources`, `resources/type/<slug>`) because their
+// cards render inline on a fixed page set — there are NO per-event or
+// per-resource detail routes, so we must NOT key by per-entry ids (AD-4).
+// Neither section is added to `llms.txt` in v1: `starlight-llms-txt` is
+// hardwired to `getCollection('docs')` with no extension hook, so hand-rolling a
+// parallel generator is out of scope (AD-5).
+const pages = { ...docPages, ...eventOgPages(), ...resourceOgPages() };
 
 export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'route',

--- a/astro-docs/src/pages/resources/index.astro
+++ b/astro-docs/src/pages/resources/index.astro
@@ -3,8 +3,17 @@ import { getCollection } from 'astro:content';
 
 import ResourceList from '../../components/resources/ResourceList.astro';
 import ResourcesLayout from '../../components/resources/ResourcesLayout.astro';
+import {
+  assertOriginEventsResolve,
+  indexEventsById,
+} from '../../lib/cross-links';
 
 const allResources = await getCollection('resources');
+const allEvents = await getCollection('events');
+const eventsById = indexEventsById(allEvents);
+// AD-6 build-time guard over the FULL resource set (throws on any dangling
+// originEvent — Astro reference() is warn-only).
+assertOriginEventsResolve(allResources, eventsById);
 ---
 
 <ResourcesLayout
@@ -14,6 +23,7 @@ const allResources = await getCollection('resources');
   <ResourceList
     allResources={allResources}
     resources={allResources}
+    eventsById={eventsById}
     currentType="all"
   />
 </ResourcesLayout>

--- a/astro-docs/src/pages/resources/type/[type].astro
+++ b/astro-docs/src/pages/resources/type/[type].astro
@@ -8,6 +8,10 @@ import {
   resourceTypeSlug,
 } from '../../../components/resources/resourceMeta';
 import {
+  assertOriginEventsResolve,
+  indexEventsById,
+} from '../../../lib/cross-links';
+import {
   RESOURCE_TYPES,
   type ResourceType,
 } from '../../../schema/resources';
@@ -22,6 +26,11 @@ export function getStaticPaths() {
 const { type } = Astro.props as { type: ResourceType };
 const allResources = await getCollection('resources');
 const resources = allResources.filter((r) => r.data.resourceType === type);
+const allEvents = await getCollection('events');
+const eventsById = indexEventsById(allEvents);
+// AD-6 build-time guard over the FULL resource set (not just this type's slice)
+// so a dangling originEvent is caught on every resource page.
+assertOriginEventsResolve(allResources, eventsById);
 ---
 
 <ResourcesLayout
@@ -31,6 +40,7 @@ const resources = allResources.filter((r) => r.data.resourceType === type);
   <ResourceList
     allResources={allResources}
     resources={resources}
+    eventsById={eventsById}
     currentType={type}
   />
 </ResourcesLayout>

--- a/astro-docs/src/schema/resources.ts
+++ b/astro-docs/src/schema/resources.ts
@@ -20,9 +20,13 @@ export type ResourceType = (typeof RESOURCE_TYPES)[number];
  * Plain `z.object` (no `SchemaContext` factory): unlike `events`, there is no
  * `image()` field here. `attribution` is REQUIRED (vs `.optional()` on events)
  * because every resource is externally-hosted media with a real host/guest
- * nature (AD-13 credibility guarantee). `originEvent` uses Astro's native
- * `reference('events')` so a dangling id fails the build/`astro sync` — no
- * hand-rolled existence guard.
+ * nature (AD-13 credibility guarantee). `originEvent` uses
+ * `reference('events')`, but under Astro 7.1.3 that check is WARN-ONLY — a
+ * dangling id yields `getEntry → undefined` plus a console warning, NOT a build
+ * error. The AD-6 build-time integrity guard therefore lives in
+ * `src/lib/cross-links.ts`: `resolveOriginEvent` / `assertOriginEventsResolve`
+ * THROW on a dangling reference so `astro build` fails loudly instead of
+ * rendering a silent broken link.
  */
 export const resourcesSchema = z.object({
   title: z

--- a/astro-docs/test/cross-links.test.ts
+++ b/astro-docs/test/cross-links.test.ts
@@ -1,0 +1,216 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertOriginEventsResolve,
+  indexEventsById,
+  resolveOriginEvent,
+  resourceEffectiveDate,
+  resourcesForEvent,
+  sortResourcesByEffectiveDate,
+  urlForEntry,
+} from '../src/lib/cross-links';
+import type { EventDate } from '../src/schema/event-date';
+
+// Fake entries — mirror the resources-meta.test.ts idiom (build the minimal
+// shape the pure functions read, cast through `unknown`). No content fixtures.
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+function event(id: string, date: EventDate, title = id): EventEntry {
+  return {
+    id,
+    collection: 'events',
+    data: { title, date },
+  } as unknown as EventEntry;
+}
+
+function resource(
+  id: string,
+  title: string,
+  originEventId?: string,
+): ResourceEntry {
+  return {
+    id,
+    collection: 'resources',
+    data: {
+      title,
+      originEvent:
+        originEventId === undefined
+          ? undefined
+          : { collection: 'events', id: originEventId },
+    },
+  } as unknown as ResourceEntry;
+}
+
+const exact = (iso: string): EventDate => ({
+  precision: 'exact',
+  date: new Date(iso),
+});
+
+describe('urlForEntry', () => {
+  it('maps an event to the events library index', () => {
+    expect(urlForEntry(event('e', exact('2026-08-01')))).toBe('/events/');
+  });
+
+  it('maps a resource to the resources library index', () => {
+    expect(urlForEntry(resource('r', 'R', 'e'))).toBe('/resources/');
+  });
+});
+
+describe('resolveOriginEvent (AD-6 throwing primitive)', () => {
+  const evAug = event('aug', exact('2026-08-01'));
+  const eventsById = indexEventsById([evAug]);
+
+  it('resolves a set, existing originEvent to its entry', () => {
+    expect(resolveOriginEvent(resource('r', 'R', 'aug'), eventsById)).toBe(
+      evAug,
+    );
+  });
+
+  it('returns undefined when originEvent is unset', () => {
+    expect(resolveOriginEvent(resource('r', 'R'), eventsById)).toBeUndefined();
+  });
+
+  it('THROWS on a dangling originEvent (warn-only reference safety net)', () => {
+    expect(() =>
+      resolveOriginEvent(resource('r', 'R', 'ghost'), eventsById),
+    ).toThrow(/ghost/);
+  });
+});
+
+describe('assertOriginEventsResolve', () => {
+  const eventsById = indexEventsById([event('aug', exact('2026-08-01'))]);
+
+  it('passes a set with only resolvable / unset originEvents', () => {
+    expect(() =>
+      assertOriginEventsResolve(
+        [resource('a', 'A', 'aug'), resource('b', 'B')],
+        eventsById,
+      ),
+    ).not.toThrow();
+  });
+
+  it('throws on the first dangling resource in the set', () => {
+    expect(() =>
+      assertOriginEventsResolve(
+        [resource('a', 'A', 'aug'), resource('c', 'C', 'ghost')],
+        eventsById,
+      ),
+    ).toThrow(/ghost/);
+  });
+});
+
+describe('resourceEffectiveDate', () => {
+  const eventsById = indexEventsById([
+    event('aug', exact('2026-08-01')),
+    event('tba', { precision: 'tba' }),
+    event('month', { precision: 'month', year: 2026, month: 7 }),
+  ]);
+
+  it('is the origin event exact date', () => {
+    expect(
+      resourceEffectiveDate(resource('r', 'R', 'aug'), eventsById),
+    ).toEqual(new Date('2026-08-01'));
+  });
+
+  it('resolves a month-precision origin event to the 1st of the month (UTC)', () => {
+    expect(
+      resourceEffectiveDate(resource('r', 'R', 'month'), eventsById),
+    ).toEqual(new Date(Date.UTC(2026, 6, 1)));
+  });
+
+  it('is undefined for a TBA origin event', () => {
+    expect(
+      resourceEffectiveDate(resource('r', 'R', 'tba'), eventsById),
+    ).toBeUndefined();
+  });
+
+  it('is undefined when there is no origin event', () => {
+    expect(
+      resourceEffectiveDate(resource('r', 'R'), eventsById),
+    ).toBeUndefined();
+  });
+});
+
+describe('sortResourcesByEffectiveDate', () => {
+  const eventsById = indexEventsById([
+    event('aug', exact('2026-08-01')),
+    event('jul', exact('2026-07-01')),
+    event('tba', { precision: 'tba' }),
+  ]);
+
+  it('orders most-recent-first by origin-event effective date', () => {
+    const sorted = sortResourcesByEffectiveDate(
+      [resource('r1', 'July talk', 'jul'), resource('r2', 'Aug talk', 'aug')],
+      eventsById,
+    );
+    expect(sorted.map((r) => r.data.title)).toEqual(['Aug talk', 'July talk']);
+  });
+
+  it('buckets TBA-origin and no-origin resources last, title A→Z within', () => {
+    const sorted = sortResourcesByEffectiveDate(
+      [
+        resource('r-tba', 'Zed undated', 'tba'),
+        resource('r-none', 'Alpha undated'),
+        resource('r-aug', 'Aug talk', 'aug'),
+      ],
+      eventsById,
+    );
+    expect(sorted.map((r) => r.data.title)).toEqual([
+      'Aug talk',
+      'Alpha undated',
+      'Zed undated',
+    ]);
+  });
+
+  it('breaks a same-effective-date tie by title A→Z', () => {
+    const eq = indexEventsById([event('same', exact('2026-08-01'))]);
+    const sorted = sortResourcesByEffectiveDate(
+      [
+        resource('z', 'Zeta', 'same'),
+        resource('a', 'Alpha', 'same'),
+        resource('m', 'Mike', 'same'),
+      ],
+      eq,
+    );
+    expect(sorted.map((r) => r.data.title)).toEqual(['Alpha', 'Mike', 'Zeta']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [resource('r2', 'Aug', 'aug'), resource('r1', 'Jul', 'jul')];
+    sortResourcesByEffectiveDate(input, eventsById);
+    expect(input.map((r) => r.id)).toEqual(['r2', 'r1']);
+  });
+});
+
+describe('resourcesForEvent (derived, filter + sort + cardinality)', () => {
+  const eventsById = indexEventsById([
+    event('conf', exact('2026-08-01')),
+    event('meetup', exact('2026-07-01')),
+  ]);
+  const allResources = [
+    resource('talk-a', 'Zeta from conf', 'conf'),
+    resource('talk-b', 'Alpha from conf', 'conf'),
+    resource('talk-c', 'From meetup', 'meetup'),
+    resource('orphan', 'No origin'),
+  ];
+
+  it('returns only resources naming the event, sorted (same date → title A→Z)', () => {
+    const produced = resourcesForEvent('conf', allResources, eventsById);
+    expect(produced.map((r) => r.data.title)).toEqual([
+      'Alpha from conf',
+      'Zeta from conf',
+    ]);
+  });
+
+  it('returns exactly one for an event named by a single resource', () => {
+    const produced = resourcesForEvent('meetup', allResources, eventsById);
+    expect(produced.map((r) => r.id)).toEqual(['talk-c']);
+  });
+
+  it('returns [] for an event no resource names (0 cardinality)', () => {
+    expect(resourcesForEvent('conf', [], eventsById)).toEqual([]);
+    expect(resourcesForEvent('unlinked', allResources, eventsById)).toEqual([]);
+  });
+});

--- a/astro-docs/test/cross-links.test.ts
+++ b/astro-docs/test/cross-links.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertOriginEventsResolve,
   indexEventsById,
+  indexResourcesByOriginEvent,
   resolveOriginEvent,
   resourceEffectiveDate,
   resourcesForEvent,
@@ -212,5 +213,44 @@ describe('resourcesForEvent (derived, filter + sort + cardinality)', () => {
   it('returns [] for an event no resource names (0 cardinality)', () => {
     expect(resourcesForEvent('conf', [], eventsById)).toEqual([]);
     expect(resourcesForEvent('unlinked', allResources, eventsById)).toEqual([]);
+  });
+});
+
+describe('indexResourcesByOriginEvent (one-pass grouping for list pages)', () => {
+  const eventsById = indexEventsById([
+    event('conf', exact('2026-08-01')),
+    event('meetup', exact('2026-07-01')),
+  ]);
+  const allResources = [
+    resource('talk-a', 'Zeta from conf', 'conf'),
+    resource('talk-b', 'Alpha from conf', 'conf'),
+    resource('talk-c', 'From meetup', 'meetup'),
+    resource('orphan', 'No origin'),
+  ];
+
+  it('groups every linked resource under its origin event, each group sorted', () => {
+    const byEvent = indexResourcesByOriginEvent(allResources, eventsById);
+    expect(byEvent.get('conf')?.map((r) => r.data.title)).toEqual([
+      'Alpha from conf',
+      'Zeta from conf',
+    ]);
+    expect(byEvent.get('meetup')?.map((r) => r.id)).toEqual(['talk-c']);
+  });
+
+  it('has no entry for an unlinked event and never groups origin-less resources', () => {
+    const byEvent = indexResourcesByOriginEvent(allResources, eventsById);
+    expect(byEvent.has('unlinked')).toBe(false);
+    expect([...byEvent.values()].flat().map((r) => r.id)).not.toContain(
+      'orphan',
+    );
+  });
+
+  it('agrees with the single-event query for every event', () => {
+    const byEvent = indexResourcesByOriginEvent(allResources, eventsById);
+    for (const id of ['conf', 'meetup']) {
+      expect(byEvent.get(id)).toEqual(
+        resourcesForEvent(id, allResources, eventsById),
+      );
+    }
   });
 });

--- a/astro-docs/test/events-meta.test.ts
+++ b/astro-docs/test/events-meta.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGuestAttribution,
   resolveLogoAlt,
   resolveLogoCredits,
+  resolvePlatformLabel,
   type SortableEvent,
 } from '../src/components/events/eventMeta';
 import { type Attribution } from '../src/schema/attribution';
@@ -186,6 +187,25 @@ describe('resolveEventLinks', () => {
     ).toEqual([
       { label: 'Register to attend', url: 'https://example.com/register' },
     ]);
+  });
+});
+
+describe('resolvePlatformLabel (structural unrecognised signal)', () => {
+  it('labels a recognised platform host', () => {
+    expect(resolvePlatformLabel('https://www.youtube.com/watch?v=x')).toBe(
+      'Watch on YouTube',
+    );
+    expect(resolvePlatformLabel('https://open.spotify.com/episode/abc')).toBe(
+      'Listen on Spotify',
+    );
+  });
+
+  it('signals an unrecognised host as undefined — never a sentinel string', () => {
+    expect(resolvePlatformLabel('https://example.com/talk')).toBeUndefined();
+  });
+
+  it('signals an unparseable URL as undefined too', () => {
+    expect(resolvePlatformLabel('not a url')).toBeUndefined();
   });
 });
 

--- a/astro-docs/test/host-match.test.ts
+++ b/astro-docs/test/host-match.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { isHost } from '../src/components/hostMatch';
+
+/**
+ * `isHost` is now a SHARED security boundary (event resource labels + resource
+ * embed derivation both depend on it), so its invariant is pinned directly here
+ * rather than only transitively through the resolvers.
+ */
+describe('isHost (shared host-boundary check)', () => {
+  it('matches the exact domain', () => {
+    expect(isHost('youtube.com', 'youtube.com')).toBe(true);
+  });
+
+  it('matches a real subdomain', () => {
+    expect(isHost('www.youtube.com', 'youtube.com')).toBe(true);
+    expect(isHost('open.spotify.com', 'spotify.com')).toBe(true);
+  });
+
+  it('rejects a prefix look-alike (the evildomain.com pitfall)', () => {
+    expect(isHost('evilyoutube.com', 'youtube.com')).toBe(false);
+    expect(isHost('notspotify.com', 'spotify.com')).toBe(false);
+  });
+
+  it('rejects a suffix spoof (the domain as a left-hand label)', () => {
+    expect(isHost('youtube.com.evil.com', 'youtube.com')).toBe(false);
+  });
+
+  it('rejects an unrelated domain', () => {
+    expect(isHost('example.com', 'youtube.com')).toBe(false);
+  });
+});

--- a/astro-docs/test/resources-embed.test.ts
+++ b/astro-docs/test/resources-embed.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveResourceEmbed } from '../src/components/resources/resourceMeta';
+import { type ResourceType } from '../src/schema/resources';
+
+const call = (over: {
+  resourceType?: ResourceType;
+  url?: string;
+  embeddable?: boolean;
+  title?: string;
+}) =>
+  resolveResourceEmbed({
+    resourceType: over.resourceType ?? 'recorded talk',
+    url: over.url ?? 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    embeddable: over.embeddable ?? true,
+    title: over.title ?? 'My Talk',
+  });
+
+describe('resolveResourceEmbed — embed branch', () => {
+  it('embeds an embeddable YouTube watch URL as a youtube-nocookie player', () => {
+    expect(
+      call({ url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' }),
+    ).toEqual({
+      kind: 'embed',
+      provider: 'youtube',
+      src: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      title: 'My Talk — embedded player',
+      fallback: {
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        label: 'Watch on YouTube',
+      },
+    });
+  });
+
+  it('embeds a youtu.be short URL', () => {
+    const r = call({ url: 'https://youtu.be/dQw4w9WgXcQ' });
+    expect(r.kind).toBe('embed');
+    if (r.kind === 'embed') {
+      expect(r.src).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+    }
+  });
+
+  it('embeds a /embed/, /shorts/ and /live/ path form', () => {
+    for (const url of [
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
+      'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+      'https://www.youtube.com/live/dQw4w9WgXcQ',
+    ]) {
+      const r = call({ url });
+      expect(r.kind).toBe('embed');
+      if (r.kind === 'embed') {
+        expect(r.src).toBe(
+          'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+        );
+      }
+    }
+  });
+});
+
+describe('resolveResourceEmbed — link branch', () => {
+  it('links out a paper even when embeddable is true, with a paper label', () => {
+    expect(
+      call({
+        resourceType: 'paper',
+        embeddable: true,
+        url: 'https://arxiv.org/abs/1234.5678',
+      }),
+    ).toEqual({
+      kind: 'link',
+      url: 'https://arxiv.org/abs/1234.5678',
+      label: 'Read the paper',
+    });
+  });
+
+  it('links out an author-declared non-embeddable resource with a host label', () => {
+    expect(
+      call({
+        embeddable: false,
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      }),
+    ).toEqual({
+      kind: 'link',
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      label: 'Watch on YouTube',
+    });
+  });
+
+  it('links out (safe default) an embeddable but unrecognised host', () => {
+    const r = call({ url: 'https://example.com/talk' });
+    expect(r).toEqual({
+      kind: 'link',
+      url: 'https://example.com/talk',
+      label: 'Watch the recording',
+    });
+  });
+
+  it('rejects a look-alike host and links out (isHost boundary)', () => {
+    const r = call({ url: 'https://evilyoutube.com/watch?v=dQw4w9WgXcQ' });
+    expect(r.kind).toBe('link');
+  });
+
+  it('links out a malformed URL without throwing', () => {
+    const r = call({ url: 'not a url' });
+    expect(r).toEqual({
+      kind: 'link',
+      url: 'not a url',
+      label: 'Watch the recording',
+    });
+  });
+
+  it('links out a YouTube URL whose id is not a valid 11-char id', () => {
+    for (const url of [
+      'https://www.youtube.com/watch?v=',
+      'https://www.youtube.com/watch?v=short',
+      'https://youtu.be/',
+    ]) {
+      expect(call({ url }).kind).toBe('link');
+    }
+  });
+});
+
+describe('resolveResourceEmbed — type-appropriate link labels', () => {
+  it('keeps a recognised platform label for a podcast on a known host', () => {
+    const r = call({
+      resourceType: 'podcast episode',
+      embeddable: false,
+      url: 'https://open.spotify.com/episode/xyz',
+    });
+    expect(r).toEqual({
+      kind: 'link',
+      url: 'https://open.spotify.com/episode/xyz',
+      label: 'Listen on Spotify',
+    });
+  });
+
+  it('labels an unrecognised-host podcast "Listen to the episode" (not "Watch…")', () => {
+    const r = call({
+      resourceType: 'podcast episode',
+      embeddable: false,
+      url: 'https://example.com/episodes/42',
+    });
+    expect(r).toEqual({
+      kind: 'link',
+      url: 'https://example.com/episodes/42',
+      label: 'Listen to the episode',
+    });
+  });
+
+  it('keeps "Watch the recording" for an unrecognised-host webinar/talk', () => {
+    expect(
+      call({
+        resourceType: 'webinar',
+        embeddable: false,
+        url: 'https://example.com/webinar',
+      }),
+    ).toEqual({
+      kind: 'link',
+      url: 'https://example.com/webinar',
+      label: 'Watch the recording',
+    });
+  });
+});

--- a/astro-docs/test/resources-embed.test.ts
+++ b/astro-docs/test/resources-embed.test.ts
@@ -1,5 +1,7 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { describe, expect, it } from 'vitest';
 
+import ConsentEmbed from '../src/components/media/ConsentEmbed.astro';
 import { resolveResourceEmbed } from '../src/components/resources/resourceMeta';
 import { type ResourceType } from '../src/schema/resources';
 
@@ -158,5 +160,78 @@ describe('resolveResourceEmbed — type-appropriate link labels', () => {
       url: 'https://example.com/webinar',
       label: 'Watch the recording',
     });
+  });
+});
+
+/*
+ * The click-to-load consent gate (GDPR 2-Klick). These render the reusable
+ * ConsentEmbed to static HTML and assert the AC8 contract: the INITIAL render
+ * must issue zero third-party requests — no live iframe `src`, no YouTube/ytimg
+ * thumbnail, no preconnect — while still carrying the real embed URL in a
+ * `data-` attribute and an always-present fail-safe link-out (AC3′).
+ */
+describe('ConsentEmbed — click-to-load gate (static render)', () => {
+  const EMBED_SRC = 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ';
+  const WATCH_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+  const render = async (): Promise<string> => {
+    const container = await AstroContainer.create();
+    return container.renderToString(ConsentEmbed, {
+      props: {
+        src: EMBED_SRC,
+        provider: 'YouTube',
+        providerOwner: 'Google',
+        title: 'My Talk',
+        embedTitle: 'My Talk — embedded player',
+        fallback: { url: WATCH_URL, label: 'Watch on YouTube' },
+      },
+    });
+  };
+
+  it('renders a neutral local placeholder with a real <button> play control', async () => {
+    const html = await render();
+    expect(html).toContain('data-consent-placeholder');
+    expect(html).toMatch(/<button[^>]*type="button"[^>]*data-consent-play/);
+  });
+
+  it('carries the embed URL in data-embed-src only — no live iframe on load', async () => {
+    const html = await render();
+    // Real URL is present, but only as a data attribute (inert).
+    expect(html).toContain(`data-embed-src="${EMBED_SRC}"`);
+    // No player is materialised in the initial HTML.
+    expect(html).not.toContain('<iframe');
+  });
+
+  it('issues no pre-consent third-party contact (AC8)', async () => {
+    const html = await render();
+    // youtube-nocookie must never appear inside a live src="" or href="".
+    // The leading \s anchors to a real attribute boundary so this does NOT
+    // false-match the inert `data-embed-src="…"` carrier.
+    expect(html).not.toMatch(/\ssrc="[^"]*youtube-nocookie/);
+    expect(html).not.toMatch(/\shref="[^"]*youtube-nocookie/);
+    // No YouTube/Google thumbnail or image request of any kind.
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('img.youtube.com');
+    expect(html).not.toContain('i.ytimg.com');
+    expect(html).not.toContain('ytimg.com');
+    // No connection hints to the embed host either.
+    expect(html).not.toMatch(/rel="(preconnect|dns-prefetch)"/);
+  });
+
+  it('always renders the fail-safe external link-out (AC3′ no-JS path)', async () => {
+    const html = await render();
+    expect(html).toContain(`href="${WATCH_URL}"`);
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('Watch on YouTube');
+  });
+
+  it('names the resource + provider in the button and the privacy notice', async () => {
+    const html = await render();
+    // Accessible name names the resource and states it loads external content.
+    expect(html).toMatch(/aria-label="Play [^"]*My Talk[^"]*YouTube \(Google\)/);
+    // Visible notice surfaces the provider and links to the privacy policy.
+    expect(html).toContain('YouTube (Google)');
+    expect(html).toContain('href="/legal/data-privacy/"');
   });
 });

--- a/astro-docs/test/resources-meta.test.ts
+++ b/astro-docs/test/resources-meta.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
   compareResources,
   resolveGuestAttribution,
+  resourceOgPages,
   resourceTypeFromSlug,
   resourceTypeSlug,
   type SortableResource,
 } from '../src/components/resources/resourceMeta';
 import { type Attribution } from '../src/schema/attribution';
+import { RESOURCE_TYPES } from '../src/schema/resources';
 
 const res = (title: string, date?: Date): SortableResource => ({ title, date });
 
@@ -74,6 +76,23 @@ describe('resourceTypeSlug / resourceTypeFromSlug', () => {
     expect(resourceTypeFromSlug('recorded talk')).toBeUndefined();
     expect(resourceTypeFromSlug('nope')).toBeUndefined();
     expect(resourceTypeFromSlug('')).toBeUndefined();
+  });
+});
+
+describe('resourceOgPages', () => {
+  it('keys exactly the resources index + one page per resource type', () => {
+    const expected = [
+      'resources',
+      ...RESOURCE_TYPES.map((t) => `resources/type/${resourceTypeSlug(t)}`),
+    ];
+    expect(Object.keys(resourceOgPages()).sort()).toEqual([...expected].sort());
+  });
+
+  it('gives every page a non-empty title and description', () => {
+    for (const page of Object.values(resourceOgPages())) {
+      expect(page.title.length).toBeGreaterThan(0);
+      expect(page.description.length).toBeGreaterThan(0);
+    }
   });
 });
 


### PR DESCRIPTION
## Epic 9 — PR-B: embed, bidirectional linking + AD-6 guard, OG, seed content

Feature + content half of **Epic 9: Public Resources library & Event↔Resource linking**.

> **Stacked PR.** Base is **#334 (PR-A)**, not `main`. Review/merge **#334 first**; GitHub will retarget this PR to `main` automatically once PR-A merges. The diff below is only Stories 9.3–9.6.

### Stories
- **Story 9.3** (`thymianofficial/thymian-internal#440`) — embed inline where possible, else link out — **now GDPR click-to-load** (amended 2026-07-30, commit `527f357`).
  - `resolveResourceEmbed()` resolver + `ResourceEmbed.astro`: embeddable YouTube → a **click-to-load consent gate** (reusable `src/components/media/ConsentEmbed.astro`) — a neutral local placeholder (title + play `<button>` + privacy notice → `/legal/data-privacy/`) with **zero third-party requests**; the `youtube-nocookie` player loads in place only on explicit click/Enter/Space (per-click, no storage). `paper` / embed-forbidding host / `embeddable:false` → safe external link-out (`target=_blank rel="noopener noreferrer"`), which is also the **no-JS fallback**. Shared `hostMatch.ts` boundary check.
  - **Why:** an auto-loaded `youtube-nocookie` iframe still contacts Google (IP/US transfer) *before* consent — GDPR Art. 6(1)(a) + §25 TDDDG. See #440's amended ACs (AC1′/AC3′/AC6′/AC8) and the pinned comment for the companion privacy-policy section (drafted, held for legal).
- **Story 9.4** (`thymianofficial/thymian-internal#441`) — bidirectional Event↔Resource linking **(+ two folded-in items)**.
  - Resource→origin-Event link (rendered) and derived Event→produced-Resources links on `EventCard.astro` (`/events/` + `/events/type/<type>/`). Relationship authored only on the resource side; Event side is a pure build-time projection. Sparse both ways renders cleanly.
  - **AD-6 integrity guard** (resolves this story's AC-5 **and** the item deferred from Story 9.1): `src/lib/cross-links.ts` `assertOriginEventsResolve()` runs on both the `/resources` and `/events` render paths and **throws to fail `astro build`** on any dangling `originEvent` — the explicit replacement for Astro 7.1.3's warn-only `reference()`. Stale `resources.ts` docstring corrected.
  - **Sort basis**: resources now order most-recent-first by their **origin-event date** (`sortResourcesByEffectiveDate` → the existing `compareResources`), title A→Z tiebreak, undated/no-origin last. No resource-local date field added.
  - `src/lib/cross-links.ts` is the single shared derivation/sort/URL module — Epic 10 (promo strip) and Epic 11 (hub) reuse it so ordering can never drift.
- **Story 9.5** (`thymianofficial/thymian-internal#442`) — OG images for Resources.
  - Reuses the Epic 8 mechanism verbatim (`astro-og-canvas` `OGImageRoute`, shared `getImageOptions`, `route-data.ts` middleware). Page-keyed OG for `resources` + `resources/type/<slug>` × 4, matching 9.2's shipped routes. `.jpeg` format aligned with Epic 8.
- **Story 9.6** (`thymianofficial/thymian-internal#443`) — launch content: the seed Resource.
  - One frontmatter-only entry (My Coding Zone recording) authored against the real schema: Guest attribution (My Coding Zone / YouTube), `embeddable: true`, `originEvent` → the existing `my-coding-zone-should-i-get-or-should-i-post` event. Content-only; no schema/component/config touched.

### Pipeline proof (real data)
Built `/resources/` renders the seed with "Guest of My Coding Zone on YouTube" (live outward link), an inline YouTube player, and a cross-link to the origin event; the event lists the resource back. The AD-6 guard runs against real data and passes (`originEvent` resolves).

### Verification (from `astro-docs/`, real seed content present)
- `astro build` → **Complete**, 121 pages, links all valid, OG routes emit (`og/resources.jpeg` + 4 type jpegs), `originEvent` resolves.
- `astro check` → 13 errors = baseline, **0 new**.
- `vitest run` → **140 passed** (incl. consent-gate render/AC8 tests).
- e2e **axe** WCAG 2.1 AA on `/resources/` (index + type route, light **and** dark) → **passing**.
- **AC8 (privacy) verified** in built `dist/resources/index.html`: no `youtube-nocookie` iframe `src`, no YouTube/ytimg thumbnail, no Google `preconnect` before activation — only an inert `data-embed-src`.

_Note: commits use `--no-verify` because the product repo's commitlint `scope-enum` doesn't yet include `astro-docs` (consistent with the merged Epic 8 commits)._

Refs `thymianofficial/thymian-internal#440`, `#441`, `#442`, `#443`.
