### PR TITLE
feat: reintroduce --sort-reports-by flag

### DIFF
--- a/e2e-tests/src/cli-lint.test.ts
+++ b/e2e-tests/src/cli-lint.test.ts
@@ -126,6 +126,37 @@ describe('thymian lint', () => {
     expect(normalize(first.stdout)).toBe(normalize(second.stdout));
   }, 180_000);
 
+  it('should accept --sort-reports-by and still render the report', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'static-lint'), getTempDir());
+
+    const { stdout, exitCode } = execThymianResult(
+      ['lint', '--sort-reports-by', 'severity'],
+      { cwd: getTempDir() },
+    );
+
+    // Findings are present, so the exit code stays non-zero; the flag is
+    // accepted and the report is grouped/rendered as usual.
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain(
+      'rfc9110/origin-server-with-clock-must-generate-date-for-2xx-3xx-4xx',
+    );
+    expect(stdout).toContain('Summary: 1 error, 0 warnings, 0 hints, 0 infos.');
+  }, 90_000);
+
+  it('should reject an invalid --sort-reports-by value listing the options', () => {
+    copyFixturesToTempDir(join(fixturesDir, 'static-lint'), getTempDir());
+
+    const { exitCode, stderr } = execThymianResult(
+      ['lint', '--sort-reports-by', 'nonsense'],
+      { cwd: getTempDir() },
+    );
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('rule');
+    expect(stderr).toContain('endpoint');
+    expect(stderr).toContain('severity');
+  }, 90_000);
+
   it('should separate report content (stdout) from operational messages (stderr)', () => {
     copyFixturesToTempDir(join(fixturesDir, 'static-lint'), getTempDir());
 

--- a/packages/common-cli/src/apply-plugin-options.ts
+++ b/packages/common-cli/src/apply-plugin-options.ts
@@ -1,0 +1,52 @@
+import type { SortReportsBy } from '@thymian/core';
+
+import type { ThymianConfig } from './thymian-config.js';
+
+/** The reporter plugin whose file formatters honour `--sort-reports-by`. */
+export const REPORTER_PLUGIN_NAME = '@thymian/plugin-reporter';
+
+/**
+ * Sets a single option on a plugin's config — but ONLY when that plugin is
+ * already configured, so wiring a flag never auto-registers a plugin the user
+ * did not ask for. Overwrites any existing value for `key`.
+ */
+export function setConfiguredPluginOption(
+  config: ThymianConfig,
+  pluginName: string,
+  key: string,
+  value: unknown,
+): void {
+  const plugin = config.plugins[pluginName];
+  if (!plugin) {
+    return;
+  }
+
+  plugin.options ??= {};
+  (plugin.options as Record<string, unknown>)[key] = value;
+}
+
+/**
+ * Forwards an explicit `--sort-reports-by` flag to the reporter plugin so its
+ * file formatters group findings to match the CLI report.
+ *
+ * PRECEDENCE: this is called AFTER the `-o` overrides are applied, so an
+ * explicit flag intentionally WINS over — and overwrites — any
+ * `-o …options.sortReportsBy=…` or config-file value. When the flag is absent
+ * (`undefined`) nothing is written, so the `-o`/config value survives. If the
+ * reporter is not configured, this is a no-op (never auto-registers it).
+ */
+export function applyReporterSortReportsBy(
+  config: ThymianConfig,
+  sortReportsBy: SortReportsBy | undefined,
+): void {
+  if (sortReportsBy === undefined) {
+    return;
+  }
+
+  setConfiguredPluginOption(
+    config,
+    REPORTER_PLUGIN_NAME,
+    'sortReportsBy',
+    sortReportsBy,
+  );
+}

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -114,6 +114,12 @@ export abstract class BaseCliRunCommand<
       helpGroup: 'BASE',
       options: ['off', 'error', 'warn', 'hint'],
     }),
+    ['sort-reports-by']: Flags.string({
+      description:
+        'Group report findings by rule, endpoint, or severity (default: endpoint). Affects the CLI report and any configured reporter that supports grouping.',
+      helpGroup: 'BASE',
+      options: ['rule', 'endpoint', 'severity'],
+    }),
     timeout: Flags.integer({
       default: Thymian.DEFAULT_TIMEOUT,
       charAliases: ['t'],
@@ -302,6 +308,7 @@ export abstract class BaseCliRunCommand<
       this.debug('Autoloading Thymian plugins.');
       this.logger.info('Autoloading plugins from configuration...');
       await this.addPluginsToThymianConfig();
+      this.applyOptionsToPlugins();
       await this.registerPluginsFromConfig();
     }
 
@@ -438,6 +445,46 @@ export abstract class BaseCliRunCommand<
         override.value,
       );
     }
+  }
+
+  /**
+   * Maps CLI flags onto plugin options before plugins are registered — the one
+   * place where a flag is wired to a specific plugin's config. Add future
+   * flag→plugin mappings here.
+   *
+   * Currently: `--sort-reports-by` is forwarded to the reporter plugin so its
+   * file formatters group findings to match the CLI report. The terminal
+   * renderer receives the flag via a separate channel (`handleWorkflowOutcome`).
+   */
+  protected applyOptionsToPlugins(): void {
+    const sortReportsBy = this.flags['sort-reports-by'];
+    if (sortReportsBy !== undefined) {
+      this.setPluginOption(
+        '@thymian/plugin-reporter',
+        'sortReportsBy',
+        sortReportsBy,
+      );
+    }
+  }
+
+  /**
+   * Sets a single option on a plugin's config — but ONLY when that plugin is
+   * already configured, so wiring a flag never auto-registers a plugin the user
+   * did not ask for, and leaves any existing config/`-o` value untouched when
+   * the flag is absent (callers guard on that).
+   */
+  private setPluginOption(
+    pluginName: string,
+    key: string,
+    value: unknown,
+  ): void {
+    const plugin = this.thymianConfig.plugins[pluginName];
+    if (!plugin) {
+      return;
+    }
+
+    plugin.options ??= {};
+    (plugin.options as Record<string, unknown>)[key] = value;
   }
 
   /**

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -455,6 +455,12 @@ export abstract class BaseCliRunCommand<
    * Currently: `--sort-reports-by` is forwarded to the reporter plugin so its
    * file formatters group findings to match the CLI report. The terminal
    * renderer receives the flag via a separate channel (`handleWorkflowOutcome`).
+   *
+   * PRECEDENCE: this runs AFTER `overridePluginOptions()` (the `-o` path), so
+   * an explicitly-passed `--sort-reports-by` intentionally WINS over — and
+   * overwrites — any `-o …options.sortReportsBy=…` or config-file value. When
+   * the flag is absent (`undefined`) nothing is written, so the `-o`/config
+   * value is left in place.
    */
   protected applyOptionsToPlugins(): void {
     const sortReportsBy = this.flags['sort-reports-by'];
@@ -470,8 +476,9 @@ export abstract class BaseCliRunCommand<
   /**
    * Sets a single option on a plugin's config — but ONLY when that plugin is
    * already configured, so wiring a flag never auto-registers a plugin the user
-   * did not ask for, and leaves any existing config/`-o` value untouched when
-   * the flag is absent (callers guard on that).
+   * did not ask for. Overwrites any existing value for `key` (see
+   * {@link applyOptionsToPlugins} for the flag-wins precedence); callers guard
+   * on the flag being present.
    */
   private setPluginOption(
     pluginName: string,

--- a/packages/common-cli/src/base-cli-run-command.ts
+++ b/packages/common-cli/src/base-cli-run-command.ts
@@ -11,6 +11,8 @@ import {
   isPlugin,
   type Logger,
   type LogLevel,
+  SORT_REPORTS_BY_VALUES,
+  type SortReportsBy,
   type SpecificationInput,
   TextLogger,
   Thymian,
@@ -19,6 +21,7 @@ import {
   type TrafficInput,
 } from '@thymian/core';
 
+import { applyReporterSortReportsBy } from './apply-plugin-options.js';
 import { ErrorCache } from './error-cache.js';
 import { Feedback } from './feedback.js';
 import { deepSet, optionFlag } from './flags/option-flag.js';
@@ -114,12 +117,12 @@ export abstract class BaseCliRunCommand<
       helpGroup: 'BASE',
       options: ['off', 'error', 'warn', 'hint'],
     }),
-    ['sort-reports-by']: Flags.string({
+    ['sort-reports-by']: Flags.custom<SortReportsBy>({
       description:
         'Group report findings by rule, endpoint, or severity (default: endpoint). Affects the CLI report and any configured reporter that supports grouping.',
       helpGroup: 'BASE',
-      options: ['rule', 'endpoint', 'severity'],
-    }),
+      options: [...SORT_REPORTS_BY_VALUES],
+    })(),
     timeout: Flags.integer({
       default: Thymian.DEFAULT_TIMEOUT,
       charAliases: ['t'],
@@ -450,48 +453,19 @@ export abstract class BaseCliRunCommand<
   /**
    * Maps CLI flags onto plugin options before plugins are registered — the one
    * place where a flag is wired to a specific plugin's config. Add future
-   * flag→plugin mappings here.
+   * flag→plugin mappings here. The mapping logic lives in
+   * `apply-plugin-options.ts` so it can be unit-tested without a command.
    *
-   * Currently: `--sort-reports-by` is forwarded to the reporter plugin so its
-   * file formatters group findings to match the CLI report. The terminal
-   * renderer receives the flag via a separate channel (`handleWorkflowOutcome`).
-   *
-   * PRECEDENCE: this runs AFTER `overridePluginOptions()` (the `-o` path), so
-   * an explicitly-passed `--sort-reports-by` intentionally WINS over — and
-   * overwrites — any `-o …options.sortReportsBy=…` or config-file value. When
-   * the flag is absent (`undefined`) nothing is written, so the `-o`/config
-   * value is left in place.
+   * Currently: `--sort-reports-by` is forwarded to the reporter plugin (see
+   * `applyReporterSortReportsBy` for the flag-wins precedence over `-o`/config
+   * and the never-auto-register guard). The terminal renderer receives the flag
+   * via a separate channel (`handleWorkflowOutcome`).
    */
   protected applyOptionsToPlugins(): void {
-    const sortReportsBy = this.flags['sort-reports-by'];
-    if (sortReportsBy !== undefined) {
-      this.setPluginOption(
-        '@thymian/plugin-reporter',
-        'sortReportsBy',
-        sortReportsBy,
-      );
-    }
-  }
-
-  /**
-   * Sets a single option on a plugin's config — but ONLY when that plugin is
-   * already configured, so wiring a flag never auto-registers a plugin the user
-   * did not ask for. Overwrites any existing value for `key` (see
-   * {@link applyOptionsToPlugins} for the flag-wins precedence); callers guard
-   * on the flag being present.
-   */
-  private setPluginOption(
-    pluginName: string,
-    key: string,
-    value: unknown,
-  ): void {
-    const plugin = this.thymianConfig.plugins[pluginName];
-    if (!plugin) {
-      return;
-    }
-
-    plugin.options ??= {};
-    (plugin.options as Record<string, unknown>)[key] = value;
+    applyReporterSortReportsBy(
+      this.thymianConfig,
+      this.flags['sort-reports-by'],
+    );
   }
 
   /**

--- a/packages/common-cli/src/render/cli-report.ts
+++ b/packages/common-cli/src/render/cli-report.ts
@@ -8,18 +8,24 @@ import {
   resolveExecutionSeverity,
   type Severity,
   SEVERITY_COLORS,
+  type SortReportsBy,
   type TestCaseExecution,
   type ThymianFormat,
   walkExecutions,
 } from '@thymian/core';
 
-import { createExecutionsRenderer } from './create-execution-renderer.js';
+import {
+  createExecutionsRenderer,
+  selectEntry,
+  selectGroupBy,
+  selectHeading,
+} from './create-execution-renderer.js';
 import { renderLintAndAnalyzeExecution } from './lint-analyze-executions.js';
 import {
   groupTestCaseExecutions,
   renderTestCaseExecution,
 } from './test-executions.js';
-import { pluralize } from './utils.js';
+import { pluralize, sortRecordByKey, sortRecordBySeverity } from './utils.js';
 
 export function collectSeverityCounts(
   report: Report,
@@ -46,8 +52,9 @@ export function collectSeverityCounts(
 
 export function renderReport(
   report: Report,
-  options: { format?: ThymianFormat } = {},
+  options: { format?: ThymianFormat; sortReportsBy?: SortReportsBy } = {},
 ): string {
+  const sortReportsBy: SortReportsBy = options.sortReportsBy ?? 'endpoint';
   if (report.runs.length === 0) {
     return 'No tool runs were reported.';
   }
@@ -80,12 +87,26 @@ export function renderReport(
       continue;
     }
 
+    // `endpoint` (default) keeps each surface's historical grouping; `rule` and
+    // `severity` regroup uniformly across run types. `severity` orders its groups
+    // by `SEVERITY_GROUP_ORDER`; the others fall back to alphabetical.
+    const sortGroups =
+      sortReportsBy === 'severity' ? sortRecordBySeverity : sortRecordByKey;
+
     if (run.runType === 'lint' || run.runType === 'analyze') {
       const render = createExecutionsRenderer<LintExecution | AnalyzeExecution>(
-        (execution) =>
+        selectGroupBy(sortReportsBy, ruleIndex, (execution) =>
           resolveLocation(execution.location, run.thymianFormatVersion),
-        renderLintAndAnalyzeExecution,
+        ),
+        selectHeading(sortReportsBy),
+        selectEntry(
+          sortReportsBy,
+          renderLintAndAnalyzeExecution,
+          (execution, locationResolver, toolRun) =>
+            locationResolver(execution.location, toolRun.thymianFormatVersion),
+        ),
         1,
+        sortGroups,
       );
 
       // `ToolRun` is a discriminated union on `runType`, so a lint/analyze run's
@@ -95,9 +116,15 @@ export function renderReport(
       lines.push(...render(executions, ruleIndex, resolveLocation, run));
     } else {
       const render = createExecutionsRenderer<TestCaseExecution>(
-        groupTestCaseExecutions,
-        renderTestCaseExecution,
+        selectGroupBy(sortReportsBy, ruleIndex, groupTestCaseExecutions),
+        selectHeading(sortReportsBy),
+        selectEntry(
+          sortReportsBy,
+          renderTestCaseExecution,
+          (execution) => execution.name,
+        ),
         1,
+        sortGroups,
       );
 
       const executions: TestCaseExecution[] = run.executions;

--- a/packages/common-cli/src/render/create-execution-renderer.ts
+++ b/packages/common-cli/src/render/create-execution-renderer.ts
@@ -5,41 +5,64 @@ import {
   type LocationResolver,
   resolveExecutionSeverity,
   type RuleDescriptor,
+  type Severity,
+  SEVERITY_COLORS,
+  SEVERITY_SYMBOLS,
+  type SortReportsBy,
   type TestCaseExecution,
   type ToolRun,
 } from '@thymian/core';
 
 import { renderStatus } from './status.js';
-import { indent, sortRecordByKey } from './utils.js';
+import { indent, pluralizeSeverity, sortRecordByKey } from './utils.js';
 
-export type GroupExecutionsFn<
-  T extends LintExecution | TestCaseExecution | AnalyzeExecution,
-> = (execution: T) => string;
+type Groupable = LintExecution | TestCaseExecution | AnalyzeExecution;
 
-export type RenderExecutionDetailsFn<
-  T extends LintExecution | TestCaseExecution | AnalyzeExecution,
-> = (
+export type GroupExecutionsFn<T extends Groupable> = (execution: T) => string;
+
+export type RenderExecutionDetailsFn<T extends Groupable> = (
   execution: T,
   indentationLevel: number,
   locationResolver: LocationResolver,
   toolRun: ToolRun,
 ) => string[];
 
-export type RenderExecutionForRun<
-  T extends LintExecution | TestCaseExecution | AnalyzeExecution,
-> = (
+/** Context every per-execution entry renderer receives. */
+export type ExecutionEntryContext = {
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>;
+  locationResolver: LocationResolver;
+  toolRun: ToolRun;
+};
+
+/** Renders a group's heading text — already colorized, without indentation. */
+export type RenderGroupHeadingFn<T extends Groupable> = (
+  key: string,
+  group: T[],
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
+) => string;
+
+/** Renders one non-passed execution's full block, from `indentationLevel`. */
+export type RenderExecutionEntryFn<T extends Groupable> = (
+  execution: T,
+  indentationLevel: number,
+  context: ExecutionEntryContext,
+) => string[];
+
+export type RenderExecutionForRun<T extends Groupable> = (
   executions: T[],
   ruleIndex: ReadonlyMap<string, RuleDescriptor>,
   locationResolver: LocationResolver,
   toolRun: ToolRun,
 ) => string[];
 
-export function createExecutionsRenderer<
-  T extends LintExecution | TestCaseExecution | AnalyzeExecution,
->(
+export function createExecutionsRenderer<T extends Groupable>(
   groupBy: GroupExecutionsFn<T>,
-  renderExecution: RenderExecutionDetailsFn<T>,
+  renderHeading: RenderGroupHeadingFn<T>,
+  renderEntry: RenderExecutionEntryFn<T>,
   indentationLevel: number,
+  sortGroups: (
+    record: Record<string, T[]>,
+  ) => Record<string, T[]> = sortRecordByKey,
 ): RenderExecutionForRun<T> {
   return function (executions, ruleIndex, locationResolver, toolRun) {
     const groups = executions.reduce(
@@ -55,12 +78,14 @@ export function createExecutionsRenderer<
     );
 
     const lines: string[] = [];
-    for (const [name, group] of Object.entries(sortRecordByKey(groups))) {
+    for (const [key, group] of Object.entries(sortGroups(groups))) {
       if (!group.some((execution) => execution.status.kind !== 'passed')) {
         continue;
       }
 
-      lines.push(indent(indentationLevel) + ux.colorize('underline', name));
+      lines.push(
+        indent(indentationLevel) + renderHeading(key, group, ruleIndex),
+      );
       lines.push('');
 
       for (const execution of group) {
@@ -68,42 +93,245 @@ export function createExecutionsRenderer<
           continue;
         }
 
-        const rule = execution.ruleId
-          ? ruleIndex.get(execution.ruleId)
-          : undefined;
-        const severity =
-          resolveExecutionSeverity(execution, ruleIndex) ?? 'error';
-        const statusLine = renderStatus(
-          execution.status,
-          severity,
-          rule?.summary?.text ?? rule?.description?.text ?? rule?.name,
-        );
-
-        lines.push(indent(indentationLevel + 1) + statusLine);
-
-        // The rule id is only rendered when we have the resolved descriptor,
-        // because `rule` is itself looked up from `execution.ruleId` via the
-        // rule index. If the descriptor is missing, `rule.id` and
-        // `execution.ruleId` would be identical, so guarding on `rule` does not
-        // hide any additional identifying information.
-        if (rule) {
-          lines.push(
-            indent(indentationLevel + 6) + ux.colorize('dim', '› ' + rule.id),
-          );
-        }
-
         lines.push(
-          ...renderExecution(
-            execution,
-            indentationLevel + 7,
+          ...renderEntry(execution, indentationLevel + 1, {
+            ruleIndex,
             locationResolver,
             toolRun,
-          ),
+          }),
         );
 
         lines.push('');
       }
     }
+
+    return lines;
+  };
+}
+
+/**
+ * Picks the grouping-key function for a `--sort-reports-by` mode. `rule` and
+ * `severity` are run-type agnostic; `endpoint` falls back to the surface's
+ * historical key (location for lint/analyze, test-case name for test) supplied
+ * by the caller.
+ */
+export function selectGroupBy<T extends Groupable>(
+  sortReportsBy: SortReportsBy,
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
+  endpointKey: GroupExecutionsFn<T>,
+): GroupExecutionsFn<T> {
+  switch (sortReportsBy) {
+    case 'rule':
+      return (execution) => execution.ruleId ?? 'unnamed check';
+    case 'severity':
+      return (execution) =>
+        resolveExecutionSeverity(execution, ruleIndex) ??
+        // Skipped executions have no severity; give them their own group
+        // rather than mislabelling them as errors.
+        (execution.status.kind === 'skipped' ? 'skipped' : 'error');
+    case 'endpoint':
+      return endpointKey;
+  }
+}
+
+/** Picks the group-heading renderer for a `--sort-reports-by` mode. */
+export function selectHeading<T extends Groupable>(
+  sortReportsBy: SortReportsBy,
+): RenderGroupHeadingFn<T> {
+  switch (sortReportsBy) {
+    case 'rule':
+      return ruleHeading;
+    case 'severity':
+      return severityHeading;
+    case 'endpoint':
+      return endpointHeading;
+  }
+}
+
+/**
+ * Picks the per-execution entry renderer for a `--sort-reports-by` mode.
+ * `endpoint` keeps the historical status-line layout; `rule`/`severity` lead
+ * each violation with its location (the identity the group heading no longer
+ * carries) plus the reason, showing the rule id only when grouping by severity.
+ */
+export function selectEntry<T extends Groupable>(
+  sortReportsBy: SortReportsBy,
+  renderDetails: RenderExecutionDetailsFn<T>,
+  labelOf: (
+    execution: T,
+    locationResolver: LocationResolver,
+    toolRun: ToolRun,
+  ) => string,
+): RenderExecutionEntryFn<T> {
+  if (sortReportsBy === 'endpoint') {
+    return endpointEntryRenderer(renderDetails);
+  }
+
+  return groupedEntryRenderer(renderDetails, {
+    labelOf,
+    showRule: sortReportsBy === 'severity',
+  });
+}
+
+// --- Heading renderers -----------------------------------------------------
+
+/** `endpoint`: the raw group key (location / test-case name), underlined. */
+const endpointHeading: RenderGroupHeadingFn<Groupable> = (key) =>
+  ux.colorize('underline', key);
+
+/** `rule`: the rule's severity symbol, then the rule id underlined. */
+const ruleHeading: RenderGroupHeadingFn<Groupable> = (
+  key,
+  group,
+  ruleIndex,
+) => {
+  const severity =
+    ruleIndex.get(key)?.severity ?? groupSeverity(group, ruleIndex);
+  return `${colorizedSeveritySymbol(severity)} ${ux.colorize(SEVERITY_COLORS[severity], severity)}: ${ux.colorize('underline', key)} (${group.filter((execution) => execution.status.kind !== 'passed').length})`;
+};
+
+/** `severity`: the severity symbol, then the pluralized severity word. */
+const severityHeading: RenderGroupHeadingFn<Groupable> = (key, group) => {
+  const count = group.filter(
+    (execution) => execution.status.kind !== 'passed',
+  ).length;
+  const label = ux.colorize('underline', pluralizeSeverity(key).toUpperCase());
+  // Keys here are always severity words or the `skipped` bucket; `skipped` has
+  // a symbol but no severity color, so it is rendered uncolored.
+  const heading =
+    key === 'skipped'
+      ? `${SEVERITY_SYMBOLS.skipped} ${label}`
+      : ux.colorize(
+          SEVERITY_COLORS[key as Severity],
+          `${SEVERITY_SYMBOLS[key as Severity]} ${label}`,
+        );
+  return `${heading} (${count})`;
+};
+
+function colorizedSeveritySymbol(severity: Severity): string {
+  return ux.colorize(SEVERITY_COLORS[severity], SEVERITY_SYMBOLS[severity]);
+}
+
+/** Best-effort heading severity when no rule descriptor resolves one. */
+function groupSeverity(
+  group: Groupable[],
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
+): Severity {
+  for (const execution of group) {
+    const severity = resolveExecutionSeverity(execution, ruleIndex);
+    if (severity !== undefined) {
+      return severity;
+    }
+  }
+  return 'error';
+}
+
+// --- Entry renderers -------------------------------------------------------
+
+/**
+ * `endpoint` entry: the historical layout — a status line, the rule id, then
+ * the finding/step details. Kept byte-identical to the pre-flag output.
+ */
+function endpointEntryRenderer<T extends Groupable>(
+  renderDetails: RenderExecutionDetailsFn<T>,
+): RenderExecutionEntryFn<T> {
+  return (
+    execution,
+    indentationLevel,
+    { ruleIndex, locationResolver, toolRun },
+  ) => {
+    const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
+    const severity = resolveExecutionSeverity(execution, ruleIndex) ?? 'error';
+    const statusLine = renderStatus(
+      execution.status,
+      severity,
+      rule?.summary?.text ?? rule?.description?.text ?? rule?.name,
+    );
+
+    const lines = [indent(indentationLevel) + statusLine];
+
+    // The rule id is only rendered when we have the resolved descriptor,
+    // because `rule` is itself looked up from `execution.ruleId` via the rule
+    // index. If the descriptor is missing, `rule.id` and `execution.ruleId`
+    // would be identical, so guarding on `rule` hides no identifying info.
+    if (rule) {
+      lines.push(
+        indent(indentationLevel + 5) + ux.colorize('dim', '› ' + rule.id),
+      );
+    }
+
+    lines.push(
+      ...renderDetails(
+        execution,
+        indentationLevel + 6,
+        locationResolver,
+        toolRun,
+      ),
+    );
+
+    return lines;
+  };
+}
+
+/**
+ * `rule`/`severity` entry: the group heading already carries the rule or
+ * severity, so each violation leads with its location (the identity endpoint
+ * grouping used to supply) and the reason. Under severity grouping it also
+ * names the violated rule. Skipped executions are marked with the skip glyph.
+ */
+function groupedEntryRenderer<T extends Groupable>(
+  renderDetails: RenderExecutionDetailsFn<T>,
+  options: {
+    labelOf: (
+      execution: T,
+      locationResolver: LocationResolver,
+      toolRun: ToolRun,
+    ) => string;
+    showRule: boolean;
+  },
+): RenderExecutionEntryFn<T> {
+  return (
+    execution,
+    indentationLevel,
+    { ruleIndex, locationResolver, toolRun },
+  ) => {
+    const label = options.labelOf(execution, locationResolver, toolRun);
+    const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
+    const severity =
+      resolveExecutionSeverity(execution, ruleIndex) ??
+      (execution.status.kind === 'skipped' ? 'skipped' : 'error');
+    const symbol =
+      severity === 'skipped' ? SEVERITY_SYMBOLS['skipped'] + '  skipped:' : '•';
+
+    const reason =
+      'reason' in execution.status ? execution.status.reason : undefined;
+    const message = reason ?? rule?.summary?.text ?? rule?.description?.text;
+
+    const ruleRef =
+      options.showRule && rule ? ` ${ux.colorize('dim', '› ' + rule.id)}` : '';
+
+    let detailIndentionLevel = indentationLevel + 1;
+
+    const lines = [`${indent(indentationLevel)}${symbol} ${label}`];
+
+    if (message) {
+      lines.push(indent(indentationLevel + 1) + '➜ ' + message);
+      // if we print a message we must increase the indentation of the details
+      detailIndentionLevel++;
+    }
+
+    if (options.showRule && ruleRef) {
+      lines.push(indent(indentationLevel + 1) + ruleRef);
+    }
+
+    lines.push(
+      ...renderDetails(
+        execution,
+        detailIndentionLevel,
+        locationResolver,
+        toolRun,
+      ),
+    );
 
     return lines;
   };

--- a/packages/common-cli/src/render/create-execution-renderer.ts
+++ b/packages/common-cli/src/render/create-execution-renderer.ts
@@ -3,18 +3,22 @@ import {
   type AnalyzeExecution,
   type LintExecution,
   type LocationResolver,
+  pluralizeSeverity,
   resolveExecutionSeverity,
+  resolveGroupSeverity,
   type RuleDescriptor,
   type Severity,
   SEVERITY_COLORS,
   SEVERITY_SYMBOLS,
+  severityGroupKey,
   type SortReportsBy,
   type TestCaseExecution,
   type ToolRun,
+  UNNAMED_CHECK_LABEL,
 } from '@thymian/core';
 
 import { renderStatus } from './status.js';
-import { indent, pluralizeSeverity, sortRecordByKey } from './utils.js';
+import { indent, sortRecordByKey } from './utils.js';
 
 type Groupable = LintExecution | TestCaseExecution | AnalyzeExecution;
 
@@ -122,13 +126,9 @@ export function selectGroupBy<T extends Groupable>(
 ): GroupExecutionsFn<T> {
   switch (sortReportsBy) {
     case 'rule':
-      return (execution) => execution.ruleId ?? 'unnamed check';
+      return (execution) => execution.ruleId ?? UNNAMED_CHECK_LABEL;
     case 'severity':
-      return (execution) =>
-        resolveExecutionSeverity(execution, ruleIndex) ??
-        // Skipped executions have no severity; give them their own group
-        // rather than mislabelling them as errors.
-        (execution.status.kind === 'skipped' ? 'skipped' : 'error');
+      return (execution) => severityGroupKey(execution, ruleIndex);
     case 'endpoint':
       return endpointKey;
   }
@@ -179,51 +179,34 @@ export function selectEntry<T extends Groupable>(
 const endpointHeading: RenderGroupHeadingFn<Groupable> = (key) =>
   ux.colorize('underline', key);
 
-/** `rule`: the rule's severity symbol, then the rule id underlined. */
+/** `rule`: the rule's severity symbol + word, then the rule id underlined. */
 const ruleHeading: RenderGroupHeadingFn<Groupable> = (
   key,
   group,
   ruleIndex,
 ) => {
   const severity =
-    ruleIndex.get(key)?.severity ?? groupSeverity(group, ruleIndex);
-  return `${colorizedSeveritySymbol(severity)} ${ux.colorize(SEVERITY_COLORS[severity], severity)}: ${ux.colorize('underline', key)} (${group.filter((execution) => execution.status.kind !== 'passed').length})`;
+    ruleIndex.get(key)?.severity ??
+    resolveGroupSeverity(group, ruleIndex) ??
+    'error';
+  return `${colorizedSeveritySymbol(severity)} ${ux.colorize(SEVERITY_COLORS[severity], severity)}: ${ux.colorize('underline', key)}`;
 };
 
 /** `severity`: the severity symbol, then the pluralized severity word. */
-const severityHeading: RenderGroupHeadingFn<Groupable> = (key, group) => {
-  const count = group.filter(
-    (execution) => execution.status.kind !== 'passed',
-  ).length;
+const severityHeading: RenderGroupHeadingFn<Groupable> = (key) => {
   const label = ux.colorize('underline', pluralizeSeverity(key).toUpperCase());
   // Keys here are always severity words or the `skipped` bucket; `skipped` has
   // a symbol but no severity color, so it is rendered uncolored.
-  const heading =
-    key === 'skipped'
-      ? `${SEVERITY_SYMBOLS.skipped} ${label}`
-      : ux.colorize(
-          SEVERITY_COLORS[key as Severity],
-          `${SEVERITY_SYMBOLS[key as Severity]} ${label}`,
-        );
-  return `${heading} (${count})`;
+  return key === 'skipped'
+    ? `${SEVERITY_SYMBOLS.skipped} ${label}`
+    : ux.colorize(
+        SEVERITY_COLORS[key as Severity],
+        `${SEVERITY_SYMBOLS[key as Severity]} ${label}`,
+      );
 };
 
 function colorizedSeveritySymbol(severity: Severity): string {
   return ux.colorize(SEVERITY_COLORS[severity], SEVERITY_SYMBOLS[severity]);
-}
-
-/** Best-effort heading severity when no rule descriptor resolves one. */
-function groupSeverity(
-  group: Groupable[],
-  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
-): Severity {
-  for (const execution of group) {
-    const severity = resolveExecutionSeverity(execution, ruleIndex);
-    if (severity !== undefined) {
-      return severity;
-    }
-  }
-  return 'error';
 }
 
 // --- Entry renderers -------------------------------------------------------
@@ -307,27 +290,33 @@ function groupedEntryRenderer<T extends Groupable>(
       'reason' in execution.status ? execution.status.reason : undefined;
     const message = reason ?? rule?.summary?.text ?? rule?.description?.text;
 
+    // Derive the rule ref from `execution.ruleId`, not the resolved descriptor:
+    // under severity grouping the heading is the severity, so a descriptor-less
+    // rule would otherwise lose its identity here (the markdown surface keeps
+    // it). The descriptor is still used for the message fallback above.
     const ruleRef =
-      options.showRule && rule ? ` ${ux.colorize('dim', '› ' + rule.id)}` : '';
+      options.showRule && execution.ruleId
+        ? ux.colorize('dim', '› ' + execution.ruleId)
+        : '';
 
-    let detailIndentionLevel = indentationLevel + 1;
+    let detailIndentationLevel = indentationLevel + 1;
 
     const lines = [`${indent(indentationLevel)}${symbol} ${label}`];
 
     if (message) {
       lines.push(indent(indentationLevel + 1) + '➜ ' + message);
       // if we print a message we must increase the indentation of the details
-      detailIndentionLevel++;
+      detailIndentationLevel++;
     }
 
-    if (options.showRule && ruleRef) {
+    if (ruleRef) {
       lines.push(indent(indentationLevel + 1) + ruleRef);
     }
 
     lines.push(
       ...renderDetails(
         execution,
-        detailIndentionLevel,
+        detailIndentationLevel,
         locationResolver,
         toolRun,
       ),

--- a/packages/common-cli/src/render/utils.ts
+++ b/packages/common-cli/src/render/utils.ts
@@ -1,4 +1,4 @@
-import { type Severity, SEVERITY_GROUP_ORDER } from '@thymian/core';
+import { compareSeverityGroupKeys } from '@thymian/core';
 
 const SINGLE_INDENTATION = '  ';
 
@@ -19,38 +19,15 @@ export function sortRecordByKey<T>(
 }
 
 /**
- * Orders record keys by severity rank (`error` → `warn` → `hint` → `info` per
- * `SEVERITY_GROUP_ORDER`). Keys that are not severities (e.g. the `error`
- * fallback aside, an unexpected value) sort last, alphabetically among
- * themselves. Used for `--sort-reports-by=severity` grouping.
+ * Orders record keys for `--sort-reports-by=severity` grouping via the shared
+ * core comparator (`error` → `warn` → `hint` → `info`, non-severities last).
  */
 export function sortRecordBySeverity<T>(
   record: Record<string, T>,
 ): Record<string, T> {
-  const order: readonly string[] = SEVERITY_GROUP_ORDER;
-  const rank = (key: string): number => {
-    const index = order.indexOf(key);
-    return index === -1 ? order.length : index;
-  };
-
   return Object.fromEntries(
-    Object.entries(record).sort(
-      ([keyA], [keyB]) => rank(keyA) - rank(keyB) || keyA.localeCompare(keyB),
+    Object.entries(record).sort(([keyA], [keyB]) =>
+      compareSeverityGroupKeys(keyA, keyB),
     ),
   );
-}
-
-export function pluralizeSeverity(severity: string): string {
-  switch (severity) {
-    case 'error':
-      return 'errors';
-    case 'warn':
-      return 'warnings';
-    case 'info':
-      return 'infos';
-    case 'hint':
-      return 'hints';
-    default:
-      return severity;
-  }
 }

--- a/packages/common-cli/src/render/utils.ts
+++ b/packages/common-cli/src/render/utils.ts
@@ -1,3 +1,5 @@
+import { type Severity, SEVERITY_GROUP_ORDER } from '@thymian/core';
+
 const SINGLE_INDENTATION = '  ';
 
 export function indent(times: number): string {
@@ -14,4 +16,41 @@ export function sortRecordByKey<T>(
   return Object.fromEntries(
     Object.entries(record).sort(([keyA], [keyB]) => keyA.localeCompare(keyB)),
   );
+}
+
+/**
+ * Orders record keys by severity rank (`error` → `warn` → `hint` → `info` per
+ * `SEVERITY_GROUP_ORDER`). Keys that are not severities (e.g. the `error`
+ * fallback aside, an unexpected value) sort last, alphabetically among
+ * themselves. Used for `--sort-reports-by=severity` grouping.
+ */
+export function sortRecordBySeverity<T>(
+  record: Record<string, T>,
+): Record<string, T> {
+  const order: readonly string[] = SEVERITY_GROUP_ORDER;
+  const rank = (key: string): number => {
+    const index = order.indexOf(key);
+    return index === -1 ? order.length : index;
+  };
+
+  return Object.fromEntries(
+    Object.entries(record).sort(
+      ([keyA], [keyB]) => rank(keyA) - rank(keyB) || keyA.localeCompare(keyB),
+    ),
+  );
+}
+
+export function pluralizeSeverity(severity: string): string {
+  switch (severity) {
+    case 'error':
+      return 'errors';
+    case 'warn':
+      return 'warnings';
+    case 'info':
+      return 'infos';
+    case 'hint':
+      return 'hints';
+    default:
+      return severity;
+  }
 }

--- a/packages/common-cli/src/workflow-outcome.ts
+++ b/packages/common-cli/src/workflow-outcome.ts
@@ -1,6 +1,6 @@
 import type { Command } from '@oclif/core';
 import { ux } from '@oclif/core';
-import type { Execution, Report } from '@thymian/core';
+import type { Execution, Report, SortReportsBy } from '@thymian/core';
 
 import { renderReport } from './render/cli-report.js';
 
@@ -83,8 +83,9 @@ export function handleWorkflowOutcome(
   command: Pick<Command, 'exit'> & { guidance(message: string): void },
   report: Report,
   options: ReportClassificationOptions = {},
+  renderOptions: { sortReportsBy?: SortReportsBy } = {},
 ): void {
-  ux.stdout(renderReport(report));
+  ux.stdout(renderReport(report, renderOptions));
 
   const classification = classifyReport(report, options);
 

--- a/packages/common-cli/test/apply-plugin-options.test.ts
+++ b/packages/common-cli/test/apply-plugin-options.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyReporterSortReportsBy } from '../src/apply-plugin-options.js';
+import type { ThymianConfig } from '../src/thymian-config.js';
+
+const REPORTER = '@thymian/plugin-reporter';
+
+function configWith(
+  plugins: Record<string, { options?: Record<string, unknown> }>,
+): ThymianConfig {
+  return { plugins } as unknown as ThymianConfig;
+}
+
+describe('applyReporterSortReportsBy', () => {
+  it('overrides an existing -o/config sortReportsBy when the flag is set', () => {
+    const config = configWith({
+      [REPORTER]: { options: { sortReportsBy: 'rule', path: 'report.md' } },
+    });
+
+    applyReporterSortReportsBy(config, 'severity');
+
+    // Flag wins; other options are preserved.
+    expect(config.plugins[REPORTER]?.options).toEqual({
+      sortReportsBy: 'severity',
+      path: 'report.md',
+    });
+  });
+
+  it('leaves the -o/config value untouched when the flag is absent', () => {
+    const config = configWith({
+      [REPORTER]: { options: { sortReportsBy: 'rule' } },
+    });
+
+    applyReporterSortReportsBy(config, undefined);
+
+    expect(config.plugins[REPORTER]?.options).toEqual({
+      sortReportsBy: 'rule',
+    });
+  });
+
+  it('never auto-registers the reporter when it is not configured', () => {
+    const config = configWith({});
+
+    applyReporterSortReportsBy(config, 'severity');
+
+    expect(config.plugins[REPORTER]).toBeUndefined();
+  });
+
+  it('creates the options object when the reporter is configured without one', () => {
+    const config = configWith({ [REPORTER]: {} });
+
+    applyReporterSortReportsBy(config, 'rule');
+
+    expect(config.plugins[REPORTER]?.options).toEqual({
+      sortReportsBy: 'rule',
+    });
+  });
+});

--- a/packages/common-cli/test/cli-report-renderer.test.ts
+++ b/packages/common-cli/test/cli-report-renderer.test.ts
@@ -545,9 +545,9 @@ describe('cli report renderer', () => {
 
       // Headings show the rule's severity, the rule id, and a violation count;
       // groups sort alphabetically by rule id.
-      expect(output).toContain('⚠ warn: alpha/rule (1)');
-      expect(output).toContain('✖ error: beta/rule (1)');
-      expect(output).toContain('✖ error: unnamed check (1)'); // ruleless fallback
+      expect(output).toContain('⚠ warn: alpha/rule');
+      expect(output).toContain('✖ error: beta/rule');
+      expect(output).toContain('✖ error: unnamed check'); // ruleless fallback
       expect(output.indexOf('alpha/rule')).toBeLessThan(
         output.indexOf('beta/rule'),
       );
@@ -573,8 +573,8 @@ describe('cli report renderer', () => {
       );
 
       // `error` precedes `warn` despite `error` > `warn` alphabetically.
-      expect(output).toContain('✖ ERRORS (2)');
-      expect(output).toContain('⚠ WARNINGS (1)');
+      expect(output).toContain('✖ ERRORS');
+      expect(output).toContain('⚠ WARNINGS');
       expect(output.indexOf('✖ ERRORS')).toBeLessThan(
         output.indexOf('⚠ WARNINGS'),
       );
@@ -586,6 +586,44 @@ describe('cli report renderer', () => {
       // A ruleless violation still shows location + reason, with no rule ref.
       expect(output).toContain('• GET /c');
       expect(output).toContain('➜ orphan');
+    });
+
+    it('severity mode: shows the rule ref even when the rule has no descriptor', () => {
+      const output = stripAnsi(
+        renderReport(
+          {
+            reportId: 'report-1',
+            createdAt: new Date().toISOString(),
+            runs: [
+              {
+                runId: 'run-1',
+                tool: { name: '@thymian/plugin-http-linter' },
+                runType: 'lint' as const,
+                runAt: new Date().toISOString(),
+                rules: [], // no descriptor for `ghost/rule`
+                executions: [
+                  {
+                    kind: 'lint' as const,
+                    ruleId: 'ghost/rule',
+                    status: {
+                      kind: 'failed' as const,
+                      severity: 'error' as const,
+                      reason: 'boom',
+                    },
+                    location: { type: 'custom' as const, value: 'GET /a' },
+                    findings: [],
+                  },
+                ],
+              },
+            ],
+          },
+          { sortReportsBy: 'severity' },
+        ),
+      );
+
+      // The ref is derived from execution.ruleId (not the descriptor), so rule
+      // identity survives — matching the markdown surface.
+      expect(output).toContain('› ghost/rule');
     });
 
     it('files skipped executions under their own group in severity mode, not error', () => {
@@ -626,8 +664,8 @@ describe('cli report renderer', () => {
 
       // The skip gets its own heading, ordered after the real severities —
       // never mislabelled under `error`.
-      expect(output).toContain('✖ ERRORS (1)');
-      expect(output).toContain('⏭ SKIPPED (1)');
+      expect(output).toContain('✖ ERRORS');
+      expect(output).toContain('⏭ SKIPPED');
       expect(output.indexOf('✖ ERRORS')).toBeLessThan(
         output.indexOf('⏭ SKIPPED'),
       );
@@ -688,7 +726,7 @@ describe('cli report renderer', () => {
       );
 
       // One rule heading (error severity, 2 cases); each case shown by name.
-      expect(output).toContain('✖ error: shared/rule (2)');
+      expect(output).toContain('✖ error: shared/rule');
       expect(output).toContain('• case alpha');
       expect(output).toContain('• case beta');
       expect(output.indexOf('shared/rule')).toBeLessThan(

--- a/packages/common-cli/test/cli-report-renderer.test.ts
+++ b/packages/common-cli/test/cli-report-renderer.test.ts
@@ -482,6 +482,223 @@ describe('cli report renderer', () => {
     expect(output).not.toContain('api.example.com');
   });
 
+  describe('--sort-reports-by grouping', () => {
+    const lintReport = {
+      reportId: 'report-1',
+      createdAt: new Date().toISOString(),
+      runs: [
+        {
+          runId: 'run-1',
+          tool: { name: '@thymian/plugin-http-linter' },
+          runType: 'lint' as const,
+          runAt: new Date().toISOString(),
+          rules: [
+            { id: 'alpha/rule', severity: 'warn' as const },
+            { id: 'beta/rule', severity: 'error' as const },
+          ],
+          executions: [
+            {
+              kind: 'lint' as const,
+              ruleId: 'beta/rule',
+              status: { kind: 'failed' as const, reason: 'e1' },
+              location: { type: 'custom' as const, value: 'GET /a' },
+              findings: [],
+            },
+            {
+              kind: 'lint' as const,
+              ruleId: 'alpha/rule',
+              status: { kind: 'failed' as const, reason: 'w1' },
+              location: { type: 'custom' as const, value: 'POST /b' },
+              findings: [],
+            },
+            {
+              kind: 'lint' as const,
+              status: { kind: 'failed' as const, reason: 'orphan' },
+              location: { type: 'custom' as const, value: 'GET /c' },
+              findings: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const headingLine = (output: string, key: string): number =>
+      output.split('\n').findIndex((line) => line === `  ${key}`);
+
+    it('endpoint (default) groups by resolved location, alphabetically', () => {
+      const output = stripAnsi(renderReport(lintReport));
+
+      // A location-less rule is grouped under its endpoint, sorted A→Z.
+      expect(headingLine(output, 'GET /a')).toBeGreaterThanOrEqual(0);
+      expect(headingLine(output, 'GET /c')).toBeGreaterThan(
+        headingLine(output, 'GET /a'),
+      );
+      expect(headingLine(output, 'POST /b')).toBeGreaterThan(
+        headingLine(output, 'GET /c'),
+      );
+    });
+
+    it('rule mode: severity+rule heading with count, per-violation location and reason', () => {
+      const output = stripAnsi(
+        renderReport(lintReport, { sortReportsBy: 'rule' }),
+      );
+
+      // Headings show the rule's severity, the rule id, and a violation count;
+      // groups sort alphabetically by rule id.
+      expect(output).toContain('⚠ warn: alpha/rule (1)');
+      expect(output).toContain('✖ error: beta/rule (1)');
+      expect(output).toContain('✖ error: unnamed check (1)'); // ruleless fallback
+      expect(output.indexOf('alpha/rule')).toBeLessThan(
+        output.indexOf('beta/rule'),
+      );
+      expect(output.indexOf('beta/rule')).toBeLessThan(
+        output.indexOf('unnamed check'),
+      );
+
+      // Each violation shows its location (bulleted) then its reason — the
+      // location that endpoint grouping used to carry, no longer lost.
+      expect(output).toContain('• POST /b');
+      expect(output).toContain('➜ w1');
+      expect(output).toContain('• GET /a');
+      expect(output).toContain('➜ e1');
+      expect(output).toContain('• GET /c');
+      expect(output).toContain('➜ orphan');
+      // The rule is the heading, so it is not repeated per violation.
+      expect(output).not.toContain('› beta/rule');
+    });
+
+    it('severity mode: pluralized heading (error→warn) with location, rule, reason', () => {
+      const output = stripAnsi(
+        renderReport(lintReport, { sortReportsBy: 'severity' }),
+      );
+
+      // `error` precedes `warn` despite `error` > `warn` alphabetically.
+      expect(output).toContain('✖ ERRORS (2)');
+      expect(output).toContain('⚠ WARNINGS (1)');
+      expect(output.indexOf('✖ ERRORS')).toBeLessThan(
+        output.indexOf('⚠ WARNINGS'),
+      );
+
+      // Each violation shows its location, reason, and the violated rule.
+      expect(output).toContain('• GET /a');
+      expect(output).toContain('➜ e1');
+      expect(output).toContain('› beta/rule');
+      // A ruleless violation still shows location + reason, with no rule ref.
+      expect(output).toContain('• GET /c');
+      expect(output).toContain('➜ orphan');
+    });
+
+    it('files skipped executions under their own group in severity mode, not error', () => {
+      const output = stripAnsi(
+        renderReport(
+          {
+            reportId: 'report-1',
+            createdAt: new Date().toISOString(),
+            runs: [
+              {
+                runId: 'run-1',
+                tool: { name: '@thymian/plugin-http-linter' },
+                runType: 'lint' as const,
+                runAt: new Date().toISOString(),
+                rules: [{ id: 'beta/rule', severity: 'error' as const }],
+                executions: [
+                  {
+                    kind: 'lint' as const,
+                    ruleId: 'beta/rule',
+                    status: { kind: 'failed' as const, reason: 'e1' },
+                    location: { type: 'custom' as const, value: 'GET /a' },
+                    findings: [],
+                  },
+                  {
+                    kind: 'lint' as const,
+                    ruleId: 'gamma/rule',
+                    status: { kind: 'skipped' as const, reason: 'n/a' },
+                    location: { type: 'custom' as const, value: 'GET /b' },
+                    findings: [],
+                  },
+                ],
+              },
+            ],
+          },
+          { sortReportsBy: 'severity' },
+        ),
+      );
+
+      // The skip gets its own heading, ordered after the real severities —
+      // never mislabelled under `error`.
+      expect(output).toContain('✖ ERRORS (1)');
+      expect(output).toContain('⏭ SKIPPED (1)');
+      expect(output.indexOf('✖ ERRORS')).toBeLessThan(
+        output.indexOf('⏭ SKIPPED'),
+      );
+      // The skip keeps its location + reason.
+      expect(output).toContain('skipped: GET /b');
+      expect(output).toContain('➜ n/a');
+    });
+
+    it('keeps each test case name visible when regrouped by rule', () => {
+      const testReport = {
+        reportId: 'report-1',
+        createdAt: new Date().toISOString(),
+        runs: [
+          {
+            runId: 'run-1',
+            tool: { name: '@thymian/plugin-http-tester' },
+            runType: 'test' as const,
+            runAt: new Date().toISOString(),
+            rules: [{ id: 'shared/rule', severity: 'error' as const }],
+            executions: [
+              {
+                kind: 'test' as const,
+                ruleId: 'shared/rule',
+                status: { kind: 'failed' as const },
+                name: 'case alpha',
+                steps: [
+                  {
+                    name: 'Step 1',
+                    location: { type: 'custom' as const, value: 'GET /a' },
+                    findings: [
+                      { id: 'f-1', kind: 'assertion-failure', title: 'boom a' },
+                    ],
+                  },
+                ],
+              },
+              {
+                kind: 'test' as const,
+                ruleId: 'shared/rule',
+                status: { kind: 'failed' as const },
+                name: 'case beta',
+                steps: [
+                  {
+                    name: 'Step 1',
+                    location: { type: 'custom' as const, value: 'GET /b' },
+                    findings: [
+                      { id: 'f-2', kind: 'assertion-failure', title: 'boom b' },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const output = stripAnsi(
+        renderReport(testReport, { sortReportsBy: 'rule' }),
+      );
+
+      // One rule heading (error severity, 2 cases); each case shown by name.
+      expect(output).toContain('✖ error: shared/rule (2)');
+      expect(output).toContain('• case alpha');
+      expect(output).toContain('• case beta');
+      expect(output.indexOf('shared/rule')).toBeLessThan(
+        output.indexOf('case alpha'),
+      );
+      // Findings still render beneath each case.
+      expect(output).toContain('✖ boom a');
+    });
+  });
+
   it('emits only standard SGR color sequences that strip to plain text', () => {
     const rendered = renderReport({
       reportId: 'report-1',

--- a/packages/core/src/report/grouping.ts
+++ b/packages/core/src/report/grouping.ts
@@ -1,0 +1,82 @@
+import type { Logger } from '../logger/logger.js';
+import { resolveExecutionSeverity } from './finding-render.js';
+import type { Execution, RuleDescriptor, Severity } from './report.js';
+import { SEVERITY_GROUP_ORDER } from './report-style.js';
+
+/** The accepted `--sort-reports-by` values — the single source for the flag,
+ * the reporter option schema, and the {@link SortReportsBy} type. */
+export const SORT_REPORTS_BY_VALUES = ['rule', 'endpoint', 'severity'] as const;
+
+/**
+ * Strategy used to group findings in report output, controlled by the
+ * `--sort-reports-by` flag. `endpoint` (the default) reproduces the historical
+ * grouping on every surface.
+ */
+export type SortReportsBy = (typeof SORT_REPORTS_BY_VALUES)[number];
+
+/** Heading label for executions with no rule id under `rule` grouping. */
+export const UNNAMED_CHECK_LABEL = 'unnamed check';
+
+/**
+ * Group key for an execution under `severity` grouping. Skipped executions have
+ * no severity, so they get a dedicated `skipped` bucket rather than being
+ * mislabelled as errors.
+ */
+export function severityGroupKey(
+  execution: Execution,
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
+  logger?: Logger,
+): string {
+  return (
+    resolveExecutionSeverity(execution, ruleIndex, logger) ??
+    (execution.status.kind === 'skipped' ? 'skipped' : 'error')
+  );
+}
+
+/**
+ * First resolvable execution severity in a group — the `rule`-heading severity
+ * fallback when the rule id has no descriptor. Returns `undefined` when no
+ * execution resolves one (callers default to `error`).
+ */
+export function resolveGroupSeverity(
+  executions: readonly Execution[],
+  ruleIndex: ReadonlyMap<string, RuleDescriptor>,
+  logger?: Logger,
+): Severity | undefined {
+  for (const execution of executions) {
+    const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
+    if (severity !== undefined) {
+      return severity;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Orders `severity` group keys by `SEVERITY_GROUP_ORDER` (error→warn→hint→info),
+ * with any non-severity key (e.g. the `skipped` bucket) sorted last.
+ */
+export function compareSeverityGroupKeys(a: string, b: string): number {
+  const order: readonly string[] = SEVERITY_GROUP_ORDER;
+  const rank = (key: string): number => {
+    const index = order.indexOf(key);
+    return index === -1 ? order.length : index;
+  };
+  return rank(a) - rank(b) || a.localeCompare(b);
+}
+
+/** Pluralizes a severity word (`error`→`errors`, …) for severity-group headings. */
+export function pluralizeSeverity(severity: string): string {
+  switch (severity) {
+    case 'error':
+      return 'errors';
+    case 'warn':
+      return 'warnings';
+    case 'info':
+      return 'infos';
+    case 'hint':
+      return 'hints';
+    default:
+      return severity;
+  }
+}

--- a/packages/core/src/report/index.ts
+++ b/packages/core/src/report/index.ts
@@ -4,6 +4,7 @@ export {
   findingDetails,
   resolveExecutionSeverity,
 } from './finding-render.js';
+export * from './grouping.js';
 export type { LocationResolver } from './location-format.js';
 export {
   createLocationResolver,

--- a/packages/core/src/report/report-style.ts
+++ b/packages/core/src/report/report-style.ts
@@ -26,3 +26,23 @@ export const SEVERITY_SYMBOLS: Record<
   info: infoSymbol,
   warn: warnSymbol,
 };
+
+/**
+ * The strategy used to group findings in report output, controlled by the
+ * `--sort-reports-by` CLI flag. `endpoint` (the default) reproduces the
+ * historical grouping on every surface.
+ */
+export type SortReportsBy = 'rule' | 'endpoint' | 'severity';
+
+/**
+ * Order in which severity groups are rendered under `--sort-reports-by=severity`.
+ * Most-to-least severe (`error` → `warn` → `hint` → `info`), matching the CLI
+ * Summary line and `SEVERITY_COLORS`/`SEVERITY_SYMBOLS` key order — deliberately
+ * NOT alphabetical.
+ */
+export const SEVERITY_GROUP_ORDER: readonly Severity[] = [
+  'error',
+  'warn',
+  'hint',
+  'info',
+];

--- a/packages/core/src/report/report-style.ts
+++ b/packages/core/src/report/report-style.ts
@@ -28,13 +28,6 @@ export const SEVERITY_SYMBOLS: Record<
 };
 
 /**
- * The strategy used to group findings in report output, controlled by the
- * `--sort-reports-by` CLI flag. `endpoint` (the default) reproduces the
- * historical grouping on every surface.
- */
-export type SortReportsBy = 'rule' | 'endpoint' | 'severity';
-
-/**
  * Order in which severity groups are rendered under `--sort-reports-by=severity`.
  * Most-to-least severe (`error` → `warn` → `hint` → `info`), matching the CLI
  * Summary line and `SEVERITY_COLORS`/`SEVERITY_SYMBOLS` key order — deliberately

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -13,12 +13,16 @@ import type {
 } from '@thymian/core';
 import {
   buildRuleIndex,
+  compareSeverityGroupKeys,
   findingDetails,
   httpStatusCodeToPhrase,
   isValidHttpStatusCode,
+  pluralizeSeverity,
   resolveExecutionSeverity,
-  SEVERITY_GROUP_ORDER,
+  resolveGroupSeverity,
   SEVERITY_SYMBOLS,
+  severityGroupKey,
+  UNNAMED_CHECK_LABEL,
   walkExecutions,
 } from '@thymian/core';
 import { mkdir, writeFile } from 'fs/promises';
@@ -93,15 +97,10 @@ function executionGroupKey(
   logger: Logger,
 ): string {
   if (sortReportsBy === 'rule') {
-    return execution.ruleId ?? 'unnamed check';
+    return execution.ruleId ?? UNNAMED_CHECK_LABEL;
   }
   if (sortReportsBy === 'severity') {
-    return (
-      resolveExecutionSeverity(execution, ruleIndex, logger) ??
-      // Skipped executions have no severity; give them their own group rather
-      // than mislabelling them as errors.
-      (execution.status.kind === 'skipped' ? 'skipped' : 'error')
-    );
+    return severityGroupKey(execution, ruleIndex, logger);
   }
   return execution.kind === 'test'
     ? execution.name
@@ -110,20 +109,15 @@ function executionGroupKey(
 
 /**
  * Orders group headings for a mode: `endpoint` keeps insertion (walk) order;
- * `rule` sorts alphabetically; `severity` follows `SEVERITY_GROUP_ORDER`
- * (non-severity keys last).
+ * `rule` sorts alphabetically; `severity` follows the shared core comparator
+ * (error→warn→hint→info, non-severity keys last).
  */
 function orderGroupKeys(
   keys: string[],
   sortReportsBy: SortReportsBy,
 ): string[] {
   if (sortReportsBy === 'severity') {
-    const order: readonly string[] = SEVERITY_GROUP_ORDER;
-    const rank = (key: string): number => {
-      const index = order.indexOf(key);
-      return index === -1 ? order.length : index;
-    };
-    return [...keys].sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+    return [...keys].sort(compareSeverityGroupKeys);
   }
   if (sortReportsBy === 'rule') {
     return [...keys].sort((a, b) => a.localeCompare(b));
@@ -131,52 +125,16 @@ function orderGroupKeys(
   return keys;
 }
 
-/** Pluralizes a severity word for `severity`-mode group headings. */
-function pluralizeSeverityWord(severity: string): string {
-  switch (severity) {
-    case 'error':
-      return 'errors';
-    case 'warn':
-      return 'warnings';
-    case 'info':
-      return 'infos';
-    case 'hint':
-      return 'hints';
-    default:
-      return severity;
-  }
-}
-
-/**
- * First resolvable execution severity in a group — mirrors the CLI's
- * `groupSeverity` so the `rule` heading falls back to the same value on both
- * surfaces when the rule has no descriptor.
- */
-function firstResolvedSeverity(
-  executions: Execution[],
-  ruleIndex: ReturnType<typeof buildRuleIndex>,
-  logger: Logger,
-): Severity | undefined {
-  for (const execution of executions) {
-    const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
-    if (severity !== undefined) {
-      return severity;
-    }
-  }
-  return undefined;
-}
-
 /**
  * Group-heading text for a mode, mirroring the CLI report: `rule` shows the
- * rule's severity, id and violation count; `severity` shows the symbol, the
- * pluralized severity and count; `endpoint` keeps the raw key (resolved
- * location / test-case name). `fallbackSeverity` (the group's first resolved
- * severity) matches the CLI when the rule id has no descriptor.
+ * rule's severity + id; `severity` shows the symbol + pluralized severity;
+ * `endpoint` keeps the raw key (resolved location / test-case name).
+ * `fallbackSeverity` (the group's first resolved severity) matches the CLI when
+ * the rule id has no descriptor.
  */
 function groupHeadingText(
   key: string,
   sortReportsBy: SortReportsBy,
-  count: number,
   ruleIndex: ReturnType<typeof buildRuleIndex>,
   fallbackSeverity?: Severity,
 ): string {
@@ -185,14 +143,14 @@ function groupHeadingText(
       ruleIndex.get(key)?.severity ?? fallbackSeverity ?? 'error';
     // The rule id is user-authored; escape it like table cells so a `<…>` /
     // metacharacter id cannot inject raw markup into the heading.
-    return `${SEVERITY_SYMBOLS[severity]} ${severity}: ${escapeHtml(key)} (${count})`;
+    return `${SEVERITY_SYMBOLS[severity]} ${severity}: ${escapeHtml(key)}`;
   }
   if (sortReportsBy === 'severity') {
     const symbol =
       key === 'skipped'
         ? SEVERITY_SYMBOLS.skipped
         : SEVERITY_SYMBOLS[key as Severity];
-    return `${symbol} ${pluralizeSeverityWord(key).toUpperCase()} (${count})`;
+    return `${symbol} ${pluralizeSeverity(key).toUpperCase()}`;
   }
   return key;
 }
@@ -342,7 +300,11 @@ function buildOverviewRow(run: ToolRun): string {
   return `| ${escapeCell(run.tool.name)} | ${run.runType} | ${outcome} | ${duration} |`;
 }
 
-/** Renders lint/analyze run bodies: location-grouped `Severity | Rule | Message` tables. */
+/**
+ * Renders lint/analyze run bodies as grouped tables. The column layout and
+ * group heading vary by `--sort-reports-by`; `endpoint` (default) keeps the
+ * historical location-grouped `Severity | Rule | Message` layout.
+ */
 function buildLintAnalyzeSection(
   run: ToolRun,
   resolveLocation: LocationResolver,
@@ -354,10 +316,7 @@ function buildLintAnalyzeSection(
   lines.push('');
 
   const ruleIndex = buildRuleIndex(run.rules);
-  const groups = new Map<
-    string,
-    { rows: string[]; count: number; executions: Execution[] }
-  >();
+  const groups = new Map<string, { rows: string[]; executions: Execution[] }>();
 
   for (const execution of walkExecutions(run.executions)) {
     if (execution.kind !== 'lint' && execution.kind !== 'analyze') {
@@ -384,7 +343,7 @@ function buildLintAnalyzeSection(
     );
     let group = groups.get(groupKey);
     if (!group) {
-      group = { rows: [], count: 0, executions: [] };
+      group = { rows: [], executions: [] };
       groups.set(groupKey, group);
     }
     group.executions.push(execution);
@@ -400,10 +359,6 @@ function buildLintAnalyzeSection(
     const locationCell = escapeCell(
       resolveLocation(execution.location, run.thymianFormatVersion),
     );
-
-    if (execution.status.kind !== 'passed') {
-      group.count += 1;
-    }
 
     const row = (statusLabel: string, message: string): string =>
       renderLintAnalyzeRow(sortReportsBy, {
@@ -448,9 +403,8 @@ function buildLintAnalyzeSection(
       `### ${groupHeadingText(
         groupKey,
         sortReportsBy,
-        group.count,
         ruleIndex,
-        firstResolvedSeverity(group.executions, ruleIndex, logger),
+        resolveGroupSeverity(group.executions, ruleIndex, logger),
       )}`,
     );
     lines.push('');
@@ -658,15 +612,12 @@ function buildTestSection(
     if (groupCases.length === 0) {
       continue;
     }
-    // `groupCases` are all failed/skipped (passed cases were filtered out), so
-    // their length is the violation count for the heading.
     lines.push(
       `### ${groupHeadingText(
         key,
         sortReportsBy,
-        groupCases.length,
         ruleIndex,
-        firstResolvedSeverity(groupCases, ruleIndex, logger),
+        resolveGroupSeverity(groupCases, ruleIndex, logger),
       )}`,
     );
     lines.push('');

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -7,6 +7,8 @@ import type {
   Report,
   ReportHttpTransaction,
   Severity,
+  SortReportsBy,
+  TestCaseExecution,
   ToolRun,
 } from '@thymian/core';
 import {
@@ -15,6 +17,8 @@ import {
   httpStatusCodeToPhrase,
   isValidHttpStatusCode,
   resolveExecutionSeverity,
+  SEVERITY_GROUP_ORDER,
+  SEVERITY_SYMBOLS,
   walkExecutions,
 } from '@thymian/core';
 import { mkdir, writeFile } from 'fs/promises';
@@ -73,6 +77,140 @@ function renderRuleCell(
 
 function severityWord(severity: Severity): string {
   return severity === 'warn' ? 'warning' : severity;
+}
+
+/**
+ * The heading a failed/skipped execution is grouped under for a given
+ * `--sort-reports-by` mode. `endpoint` keeps the historical key (location for
+ * lint/analyze, test-case name for test); `rule`/`severity` regroup uniformly.
+ */
+function executionGroupKey(
+  execution: Execution,
+  sortReportsBy: SortReportsBy,
+  ruleIndex: ReturnType<typeof buildRuleIndex>,
+  resolveLocation: LocationResolver,
+  run: ToolRun,
+  logger: Logger,
+): string {
+  if (sortReportsBy === 'rule') {
+    return execution.ruleId ?? 'unnamed check';
+  }
+  if (sortReportsBy === 'severity') {
+    return (
+      resolveExecutionSeverity(execution, ruleIndex, logger) ??
+      // Skipped executions have no severity; give them their own group rather
+      // than mislabelling them as errors.
+      (execution.status.kind === 'skipped' ? 'skipped' : 'error')
+    );
+  }
+  return execution.kind === 'test'
+    ? execution.name
+    : resolveLocation(execution.location, run.thymianFormatVersion);
+}
+
+/**
+ * Orders group headings for a mode: `endpoint` keeps insertion (walk) order;
+ * `rule` sorts alphabetically; `severity` follows `SEVERITY_GROUP_ORDER`
+ * (non-severity keys last).
+ */
+function orderGroupKeys(
+  keys: string[],
+  sortReportsBy: SortReportsBy,
+): string[] {
+  if (sortReportsBy === 'severity') {
+    const order: readonly string[] = SEVERITY_GROUP_ORDER;
+    const rank = (key: string): number => {
+      const index = order.indexOf(key);
+      return index === -1 ? order.length : index;
+    };
+    return [...keys].sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+  }
+  if (sortReportsBy === 'rule') {
+    return [...keys].sort((a, b) => a.localeCompare(b));
+  }
+  return keys;
+}
+
+/** Pluralizes a severity word for `severity`-mode group headings. */
+function pluralizeSeverityWord(severity: string): string {
+  switch (severity) {
+    case 'error':
+      return 'errors';
+    case 'warn':
+      return 'warnings';
+    case 'info':
+      return 'infos';
+    case 'hint':
+      return 'hints';
+    default:
+      return severity;
+  }
+}
+
+/**
+ * Group-heading text for a mode, mirroring the CLI report: `rule` shows the
+ * rule's severity, id and violation count; `severity` shows the symbol, the
+ * pluralized severity and count; `endpoint` keeps the raw key (resolved
+ * location / test-case name).
+ */
+function groupHeadingText(
+  key: string,
+  sortReportsBy: SortReportsBy,
+  count: number,
+  ruleIndex: ReturnType<typeof buildRuleIndex>,
+): string {
+  if (sortReportsBy === 'rule') {
+    const severity = ruleIndex.get(key)?.severity ?? 'error';
+    return `${SEVERITY_SYMBOLS[severity]} ${severity}: ${key} (${count})`;
+  }
+  if (sortReportsBy === 'severity') {
+    const symbol =
+      key === 'skipped'
+        ? SEVERITY_SYMBOLS.skipped
+        : SEVERITY_SYMBOLS[key as Severity];
+    return `${symbol} ${pluralizeSeverityWord(key).toUpperCase()} (${count})`;
+  }
+  return key;
+}
+
+/**
+ * Column layout for a lint/analyze table. `rule`/`severity` swap in a Location
+ * column — the identity the group heading no longer carries — and drop the
+ * column now redundant with the heading (Rule / Severity respectively).
+ */
+function lintAnalyzeTableHeader(sortReportsBy: SortReportsBy): string[] {
+  // Drop the column the group heading already carries: `rule` drops Severity
+  // and Rule (both implied by the rule heading); `severity` drops Severity.
+  const columns =
+    sortReportsBy === 'rule'
+      ? ['Location', 'Message']
+      : sortReportsBy === 'severity'
+        ? ['Rule', 'Location', 'Message']
+        : ['Severity', 'Rule', 'Message'];
+  return [
+    `| ${columns.join(' | ')} |`,
+    `| ${columns.map(() => '---').join(' | ')} |`,
+  ];
+}
+
+/** Builds one lint/analyze table row with the column layout for the mode. */
+function renderLintAnalyzeRow(
+  sortReportsBy: SortReportsBy,
+  cells: {
+    statusLabel: string;
+    ruleCell: string;
+    locationCell: string;
+    message: string;
+  },
+): string {
+  const { statusLabel, ruleCell, locationCell, message } = cells;
+  if (sortReportsBy === 'rule') {
+    return `| ${locationCell} | ${message} |`;
+  }
+  if (sortReportsBy === 'severity') {
+    return `| ${ruleCell} | ${locationCell} | ${message} |`;
+  }
+  return `| ${statusLabel} | ${ruleCell} | ${message} |`;
 }
 
 function findingKindWord(kind: string): string {
@@ -185,26 +323,32 @@ function buildLintAnalyzeSection(
   run: ToolRun,
   resolveLocation: LocationResolver,
   logger: Logger,
+  sortReportsBy: SortReportsBy,
 ): string[] {
   const lines: string[] = [];
   lines.push(`## ${run.tool.name} · ${run.runType}`);
   lines.push('');
 
   const ruleIndex = buildRuleIndex(run.rules);
-  const groups = new Map<string, string[]>();
+  const groups = new Map<string, { rows: string[]; count: number }>();
 
   for (const execution of walkExecutions(run.executions)) {
     if (execution.kind !== 'lint' && execution.kind !== 'analyze') {
       continue;
     }
 
-    const location = resolveLocation(
-      execution.location,
-      run.thymianFormatVersion,
+    const groupKey = executionGroupKey(
+      execution,
+      sortReportsBy,
+      ruleIndex,
+      resolveLocation,
+      run,
+      logger,
     );
-    const rows = groups.get(location) ?? [];
-    if (!groups.has(location)) {
-      groups.set(location, rows);
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { rows: [], count: 0 };
+      groups.set(groupKey, group);
     }
 
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
@@ -213,6 +357,23 @@ function buildLintAnalyzeSection(
     const ruleCell = escapeCell(
       renderRuleCell(execution.ruleId, rule?.helpUri),
     );
+    // Location is the group heading under `endpoint`, but a table column under
+    // `rule`/`severity` so it is not lost.
+    const locationCell = escapeCell(
+      resolveLocation(execution.location, run.thymianFormatVersion),
+    );
+
+    if (execution.status.kind !== 'passed') {
+      group.count += 1;
+    }
+
+    const row = (statusLabel: string, message: string): string =>
+      renderLintAnalyzeRow(sortReportsBy, {
+        statusLabel,
+        ruleCell,
+        locationCell,
+        message: escapeCell(message),
+      });
 
     if (execution.status.kind === 'failed') {
       const severity =
@@ -222,38 +383,35 @@ function buildLintAnalyzeSection(
         rule?.summary?.text ??
         rule?.description?.text ??
         '';
-      rows.push(
-        `| ${severityWord(severity)} | ${ruleCell} | ${escapeCell(message)} |`,
-      );
+      group.rows.push(row(severityWord(severity), message));
     } else if (execution.status.kind === 'skipped') {
       const message = execution.status.reason ?? rule?.summary?.text ?? '';
-      rows.push(`| skipped | ${ruleCell} | ${escapeCell(message)} |`);
+      group.rows.push(row('skipped', message));
     }
 
     for (const finding of execution.findings) {
       if (finding.kind === 'informational') {
-        rows.push(
-          `| info | ${ruleCell} | ${escapeCell(finding.message?.text ?? finding.title)} |`,
-        );
+        group.rows.push(row('info', finding.message?.text ?? finding.title));
       } else if (finding.kind === 'assertion-failure') {
         const suffix = assertionFailureSuffix(finding);
         const base = finding.message?.text ?? finding.title;
-        const message = suffix ? `${base} ${suffix}` : base;
-        rows.push(`| failed | ${ruleCell} | ${escapeCell(message)} |`);
+        group.rows.push(row('failed', suffix ? `${base} ${suffix}` : base));
       }
     }
   }
 
-  for (const [location, rows] of groups) {
-    if (rows.length === 0) {
+  for (const groupKey of orderGroupKeys([...groups.keys()], sortReportsBy)) {
+    const group = groups.get(groupKey);
+    if (!group || group.rows.length === 0) {
       continue;
     }
 
-    lines.push(`### ${location}`);
+    lines.push(
+      `### ${groupHeadingText(groupKey, sortReportsBy, group.count, ruleIndex)}`,
+    );
     lines.push('');
-    lines.push('| Severity | Rule | Message |');
-    lines.push('| --- | --- | --- |');
-    lines.push(...rows);
+    lines.push(...lintAnalyzeTableHeader(sortReportsBy));
+    lines.push(...group.rows);
     lines.push('');
   }
 
@@ -299,11 +457,109 @@ function formatHttpTransaction(transaction: ReportHttpTransaction): string {
   return lines.join('\n').trimEnd();
 }
 
+/** Renders one failed/skipped test case under the given heading prefix (`###`/`####`). */
+function renderTestCase(
+  execution: TestCaseExecution,
+  headingPrefix: string,
+  resolveLocation: LocationResolver,
+  run: ToolRun,
+  ruleIndex: ReturnType<typeof buildRuleIndex>,
+  logger: Logger,
+  sortReportsBy: SortReportsBy,
+): string[] {
+  const lines: string[] = [];
+
+  const statusGlyph =
+    execution.status.kind === 'failed' ? errorSymbol : skippedSymbol;
+  lines.push(
+    `${headingPrefix} ${execution.name} · _${statusGlyph} ${execution.status.kind}_`,
+  );
+  lines.push('');
+
+  const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
+  const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
+  const ruleCell = renderRuleCell(execution.ruleId, rule?.helpUri);
+  const message =
+    execution.status.kind === 'failed'
+      ? (execution.status.reason ??
+        rule?.summary?.text ??
+        rule?.description?.text ??
+        '')
+      : execution.status.kind === 'skipped'
+        ? (execution.status.reason ?? rule?.summary?.text ?? '')
+        : '';
+
+  // The summary omits whatever the group heading already carries: the severity
+  // under `severity` grouping, the rule under `rule` grouping.
+  const summaryParts: string[] = [];
+  if (sortReportsBy !== 'severity' && severity) {
+    summaryParts.push(severityWord(severity));
+  }
+  if (sortReportsBy !== 'rule') {
+    summaryParts.push(ruleCell);
+  }
+  summaryParts.push(escapeHtml(message));
+
+  lines.push(`<details><summary>${summaryParts.join(' · ')}</summary>`);
+  lines.push('');
+
+  execution.steps.forEach((step, index) => {
+    const stepLocation = resolveLocation(
+      step.location,
+      run.thymianFormatVersion,
+    );
+    lines.push(`**Step ${index + 1}** · ${stepLocation}`);
+    lines.push('');
+
+    if (step.findings.length > 0) {
+      lines.push('| Kind | Title | Message |');
+      lines.push('| --- | --- | --- |');
+      for (const finding of step.findings) {
+        const kind = findingKindWord(finding.kind);
+        let message = finding.message?.text ?? '';
+
+        if (finding.kind === 'assertion-failure') {
+          const suffix = assertionFailureSuffix(finding);
+          message = suffix
+            ? message
+              ? `${message} ${suffix}`
+              : suffix
+            : message;
+        }
+
+        lines.push(
+          `| ${kind} | ${escapeCell(finding.title)} | ${escapeCell(message)} |`,
+        );
+      }
+      lines.push('');
+    }
+
+    if (step.httpTransactions?.length) {
+      lines.push('<details><summary>HTTP transaction</summary>');
+      lines.push('');
+      for (const transaction of step.httpTransactions) {
+        lines.push('```http');
+        lines.push(formatHttpTransaction(transaction));
+        lines.push('```');
+        lines.push('');
+      }
+      lines.push('</details>');
+      lines.push('');
+    }
+  });
+
+  lines.push('</details>');
+  lines.push('');
+
+  return lines;
+}
+
 /** Renders test run bodies: per-test-case `<details>` narrative with per-finding step rows. */
 function buildTestSection(
   run: ToolRun,
   resolveLocation: LocationResolver,
   logger: Logger,
+  sortReportsBy: SortReportsBy,
 ): string[] {
   const lines: string[] = [];
   lines.push(`## ${run.tool.name} · test`);
@@ -311,82 +567,72 @@ function buildTestSection(
 
   const ruleIndex = buildRuleIndex(run.rules);
 
-  for (const execution of walkExecutions(run.executions)) {
-    if (execution.kind !== 'test' || execution.status.kind === 'passed') {
+  const cases = [...walkExecutions(run.executions)].filter(
+    (execution): execution is TestCaseExecution =>
+      execution.kind === 'test' && execution.status.kind !== 'passed',
+  );
+
+  // `endpoint` keeps the flat, per-case `###` layout unchanged.
+  if (sortReportsBy === 'endpoint') {
+    for (const execution of cases) {
+      lines.push(
+        ...renderTestCase(
+          execution,
+          '###',
+          resolveLocation,
+          run,
+          ruleIndex,
+          logger,
+          sortReportsBy,
+        ),
+      );
+    }
+    return lines;
+  }
+
+  // `rule`/`severity` add a `###` group heading; each case drops to `####` so
+  // its name survives under the (rule id / severity) group.
+  const groups = new Map<string, TestCaseExecution[]>();
+  for (const execution of cases) {
+    const key = executionGroupKey(
+      execution,
+      sortReportsBy,
+      ruleIndex,
+      resolveLocation,
+      run,
+      logger,
+    );
+    const groupCases = groups.get(key) ?? [];
+    if (!groups.has(key)) {
+      groups.set(key, groupCases);
+    }
+    groupCases.push(execution);
+  }
+
+  for (const key of orderGroupKeys([...groups.keys()], sortReportsBy)) {
+    const groupCases = groups.get(key) ?? [];
+    if (groupCases.length === 0) {
       continue;
     }
-
-    const statusGlyph =
-      execution.status.kind === 'failed' ? errorSymbol : skippedSymbol;
+    // `groupCases` are all failed/skipped (passed cases were filtered out), so
+    // their length is the violation count for the heading.
     lines.push(
-      `### ${execution.name} · _${statusGlyph} ${execution.status.kind}_`,
+      `### ${groupHeadingText(key, sortReportsBy, groupCases.length, ruleIndex)}`,
     );
     lines.push('');
-
-    const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
-    const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
-    const severityPrefix = severity ? `${severityWord(severity)} · ` : '';
-    const ruleCell = renderRuleCell(execution.ruleId, rule?.helpUri);
-    const message =
-      execution.status.kind === 'failed'
-        ? (execution.status.reason ??
-          rule?.summary?.text ??
-          rule?.description?.text ??
-          '')
-        : (execution.status.reason ?? rule?.summary?.text ?? '');
-
-    lines.push(
-      `<details><summary>${severityPrefix}${ruleCell} · ${escapeHtml(message)}</summary>`,
-    );
-    lines.push('');
-
-    execution.steps.forEach((step, index) => {
-      const stepLocation = resolveLocation(
-        step.location,
-        run.thymianFormatVersion,
+    for (const execution of groupCases) {
+      lines.push(
+        ...renderTestCase(
+          execution,
+          '####',
+          resolveLocation,
+          run,
+          ruleIndex,
+          logger,
+          sortReportsBy,
+        ),
       );
-      lines.push(`**Step ${index + 1}** · ${stepLocation}`);
-      lines.push('');
-
-      if (step.findings.length > 0) {
-        lines.push('| Kind | Title | Message |');
-        lines.push('| --- | --- | --- |');
-        for (const finding of step.findings) {
-          const kind = findingKindWord(finding.kind);
-          let message = finding.message?.text ?? '';
-
-          if (finding.kind === 'assertion-failure') {
-            const suffix = assertionFailureSuffix(finding);
-            message = suffix
-              ? message
-                ? `${message} ${suffix}`
-                : suffix
-              : message;
-          }
-
-          lines.push(
-            `| ${kind} | ${escapeCell(finding.title)} | ${escapeCell(message)} |`,
-          );
-        }
-        lines.push('');
-      }
-
-      if (step.httpTransactions?.length) {
-        lines.push('<details><summary>HTTP transaction</summary>');
-        lines.push('');
-        for (const transaction of step.httpTransactions) {
-          lines.push('```http');
-          lines.push(formatHttpTransaction(transaction));
-          lines.push('```');
-          lines.push('');
-        }
-        lines.push('</details>');
-        lines.push('');
-      }
-    });
-
-    lines.push('</details>');
-    lines.push('');
+    }
   }
 
   return lines;
@@ -401,10 +647,20 @@ export class MarkdownFormatter implements Formatter<MarkdownFormatterOptions> {
 
   private readonly reports: Report[] = [];
 
+  /**
+   * Grouping strategy injected by the reporter plugin from `--sort-reports-by`.
+   * Kept off {@link MarkdownFormatterOptions} so the user-facing formatter
+   * config schema stays `{ path }`; defaults to `endpoint`.
+   */
+  private sortReportsBy: SortReportsBy = 'endpoint';
+
   constructor(private readonly logger: Logger) {}
 
-  init(options: MarkdownFormatterOptions): void {
+  init(
+    options: MarkdownFormatterOptions & { sortReportsBy?: SortReportsBy },
+  ): void {
     this.options = options;
+    this.sortReportsBy = options.sortReportsBy ?? 'endpoint';
   }
 
   report(report: Report): void {
@@ -442,13 +698,19 @@ export class MarkdownFormatter implements Formatter<MarkdownFormatterOptions> {
     }
     lines.push('');
 
+    const sortReportsBy = this.sortReportsBy;
     for (const report of this.reports) {
       const resolveLocation = createLocationResolver(report);
       for (const run of report.runs) {
         lines.push(
           ...(run.runType === 'test'
-            ? buildTestSection(run, resolveLocation, this.logger)
-            : buildLintAnalyzeSection(run, resolveLocation, this.logger)),
+            ? buildTestSection(run, resolveLocation, this.logger, sortReportsBy)
+            : buildLintAnalyzeSection(
+                run,
+                resolveLocation,
+                this.logger,
+                sortReportsBy,
+              )),
         );
       }
     }

--- a/packages/plugin-reporter/src/formatters/markdown.ts
+++ b/packages/plugin-reporter/src/formatters/markdown.ts
@@ -148,20 +148,44 @@ function pluralizeSeverityWord(severity: string): string {
 }
 
 /**
+ * First resolvable execution severity in a group — mirrors the CLI's
+ * `groupSeverity` so the `rule` heading falls back to the same value on both
+ * surfaces when the rule has no descriptor.
+ */
+function firstResolvedSeverity(
+  executions: Execution[],
+  ruleIndex: ReturnType<typeof buildRuleIndex>,
+  logger: Logger,
+): Severity | undefined {
+  for (const execution of executions) {
+    const severity = resolveExecutionSeverity(execution, ruleIndex, logger);
+    if (severity !== undefined) {
+      return severity;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Group-heading text for a mode, mirroring the CLI report: `rule` shows the
  * rule's severity, id and violation count; `severity` shows the symbol, the
  * pluralized severity and count; `endpoint` keeps the raw key (resolved
- * location / test-case name).
+ * location / test-case name). `fallbackSeverity` (the group's first resolved
+ * severity) matches the CLI when the rule id has no descriptor.
  */
 function groupHeadingText(
   key: string,
   sortReportsBy: SortReportsBy,
   count: number,
   ruleIndex: ReturnType<typeof buildRuleIndex>,
+  fallbackSeverity?: Severity,
 ): string {
   if (sortReportsBy === 'rule') {
-    const severity = ruleIndex.get(key)?.severity ?? 'error';
-    return `${SEVERITY_SYMBOLS[severity]} ${severity}: ${key} (${count})`;
+    const severity =
+      ruleIndex.get(key)?.severity ?? fallbackSeverity ?? 'error';
+    // The rule id is user-authored; escape it like table cells so a `<…>` /
+    // metacharacter id cannot inject raw markup into the heading.
+    return `${SEVERITY_SYMBOLS[severity]} ${severity}: ${escapeHtml(key)} (${count})`;
   }
   if (sortReportsBy === 'severity') {
     const symbol =
@@ -330,10 +354,23 @@ function buildLintAnalyzeSection(
   lines.push('');
 
   const ruleIndex = buildRuleIndex(run.rules);
-  const groups = new Map<string, { rows: string[]; count: number }>();
+  const groups = new Map<
+    string,
+    { rows: string[]; count: number; executions: Execution[] }
+  >();
 
   for (const execution of walkExecutions(run.executions)) {
     if (execution.kind !== 'lint' && execution.kind !== 'analyze') {
+      continue;
+    }
+
+    // Under `rule`/`severity` grouping a passed execution has no meaningful
+    // group key (its severity is undefined → would fall into the `error`
+    // bucket) and is not a violation, so exclude it and its informational
+    // findings — matching the CLI grouped renderer, which skips passed
+    // executions. `endpoint` groups by location and keeps them, so its output
+    // is unchanged.
+    if (sortReportsBy !== 'endpoint' && execution.status.kind === 'passed') {
       continue;
     }
 
@@ -347,9 +384,10 @@ function buildLintAnalyzeSection(
     );
     let group = groups.get(groupKey);
     if (!group) {
-      group = { rows: [], count: 0 };
+      group = { rows: [], count: 0, executions: [] };
       groups.set(groupKey, group);
     }
+    group.executions.push(execution);
 
     const rule = execution.ruleId ? ruleIndex.get(execution.ruleId) : undefined;
     // HTML anchor (via renderRuleCell), then escapeCell so a `|` in the id/uri
@@ -407,7 +445,13 @@ function buildLintAnalyzeSection(
     }
 
     lines.push(
-      `### ${groupHeadingText(groupKey, sortReportsBy, group.count, ruleIndex)}`,
+      `### ${groupHeadingText(
+        groupKey,
+        sortReportsBy,
+        group.count,
+        ruleIndex,
+        firstResolvedSeverity(group.executions, ruleIndex, logger),
+      )}`,
     );
     lines.push('');
     lines.push(...lintAnalyzeTableHeader(sortReportsBy));
@@ -617,7 +661,13 @@ function buildTestSection(
     // `groupCases` are all failed/skipped (passed cases were filtered out), so
     // their length is the violation count for the heading.
     lines.push(
-      `### ${groupHeadingText(key, sortReportsBy, groupCases.length, ruleIndex)}`,
+      `### ${groupHeadingText(
+        key,
+        sortReportsBy,
+        groupCases.length,
+        ruleIndex,
+        firstResolvedSeverity(groupCases, ruleIndex, logger),
+      )}`,
     );
     lines.push('');
     for (const execution of groupCases) {

--- a/packages/plugin-reporter/src/get-formatters.ts
+++ b/packages/plugin-reporter/src/get-formatters.ts
@@ -1,6 +1,10 @@
 import { resolve } from 'node:path';
 
-import { type Logger, ThymianBaseError } from '@thymian/core';
+import {
+  type Logger,
+  type SortReportsBy,
+  ThymianBaseError,
+} from '@thymian/core';
 
 import type { Formatter } from './formatter.js';
 import { CsvFormatter, type CsvFormatterOptions } from './formatters/csv.js';
@@ -83,6 +87,7 @@ export async function getFormatters(
   config: ReporterPluginOptions['formatters'] = {},
   cwd: string,
   logger: Logger,
+  sortReportsBy?: SortReportsBy,
 ): Promise<Formatter[]> {
   return Promise.all(
     Object.entries(config).map(async ([name, options]) => {
@@ -108,8 +113,9 @@ export async function getFormatters(
         logger,
       });
 
-      // we know that the options are valid, so we can safely cast them
-      await formatter.init(preparedOptions as never);
+      // we know that the options are valid, so we can safely cast them.
+      // `sortReportsBy` rides along for every formatter; only markdown reads it.
+      await formatter.init({ ...preparedOptions, sortReportsBy } as never);
 
       return formatter;
     }),

--- a/packages/plugin-reporter/src/index.ts
+++ b/packages/plugin-reporter/src/index.ts
@@ -1,5 +1,6 @@
 import {
   type Report,
+  SORT_REPORTS_BY_VALUES,
   type SortReportsBy,
   type ThymianPlugin,
 } from '@thymian/core';
@@ -75,7 +76,7 @@ export const reporterPlugin: ThymianPlugin<ReporterPluginOptions> = {
           'How report findings are grouped (rule, endpoint, or severity). Normally set from the --sort-reports-by CLI flag; affects the markdown formatter only.',
         nullable: true,
         type: 'string',
-        enum: ['rule', 'endpoint', 'severity'],
+        enum: [...SORT_REPORTS_BY_VALUES],
       },
     },
   },

--- a/packages/plugin-reporter/src/index.ts
+++ b/packages/plugin-reporter/src/index.ts
@@ -1,9 +1,18 @@
-import { type Report, type ThymianPlugin } from '@thymian/core';
+import {
+  type Report,
+  type SortReportsBy,
+  type ThymianPlugin,
+} from '@thymian/core';
 
 import { type Formatters, getFormatters } from './get-formatters.js';
 
 export type ReporterPluginOptions = {
   formatters?: Partial<Formatters>;
+  /**
+   * How report findings are grouped. Normally injected from the
+   * `--sort-reports-by` CLI flag; only the markdown formatter honours it.
+   */
+  sortReportsBy?: SortReportsBy;
 };
 
 export const reporterPlugin: ThymianPlugin<ReporterPluginOptions> = {
@@ -61,6 +70,13 @@ export const reporterPlugin: ThymianPlugin<ReporterPluginOptions> = {
         },
         additionalProperties: false,
       },
+      sortReportsBy: {
+        description:
+          'How report findings are grouped (rule, endpoint, or severity). Normally set from the --sort-reports-by CLI flag; affects the markdown formatter only.',
+        nullable: true,
+        type: 'string',
+        enum: ['rule', 'endpoint', 'severity'],
+      },
     },
   },
   version: '0.x',
@@ -70,7 +86,11 @@ export const reporterPlugin: ThymianPlugin<ReporterPluginOptions> = {
   actions: {
     listensOn: ['core.close'],
   },
-  async plugin(emitter, logger, { formatters: userFormatters, cwd }) {
+  async plugin(
+    emitter,
+    logger,
+    { formatters: userFormatters, cwd, sortReportsBy },
+  ) {
     const formatters = Object.fromEntries(
       Object.entries({
         ...(userFormatters ?? {}),
@@ -78,7 +98,12 @@ export const reporterPlugin: ThymianPlugin<ReporterPluginOptions> = {
     ) as Formatters;
 
     let hasFlushed = false;
-    const reporters = await getFormatters(formatters, cwd, logger);
+    const reporters = await getFormatters(
+      formatters,
+      cwd,
+      logger,
+      sortReportsBy,
+    );
 
     const flushReporters = async (): Promise<void> => {
       if (hasFlushed) {

--- a/packages/plugin-reporter/test/csv.test.ts
+++ b/packages/plugin-reporter/test/csv.test.ts
@@ -19,6 +19,7 @@ import {
   csvSafe,
   reportToCsvLines,
 } from '../src/formatters/csv.js';
+import { getFormatters } from '../src/get-formatters.js';
 
 const CSV_HEADER =
   'run_id,run_type,tool,rule_id,location,row_type,status,severity,finding_kind,finding_id,title,message,detail';
@@ -55,6 +56,27 @@ describe('CSV formatter helpers', () => {
 
   it('escapes CSV cells', () => {
     expect(csvSafe('hello, world')).toBe('"hello, world"');
+  });
+});
+
+describe('CsvFormatter ignores --sort-reports-by (flag-invariant)', () => {
+  it('produces byte-identical CSV for every sort mode', async () => {
+    const outputs = await Promise.all(
+      (['endpoint', 'rule', 'severity'] as const).map(async (mode) => {
+        const [formatter] = await getFormatters(
+          { csv: { path: join(process.cwd(), 'tmp', `csv-${mode}.csv`) } },
+          process.cwd(),
+          new NoopLogger(),
+          mode,
+        );
+        await formatter!.report(report);
+        return (await formatter!.flush()) ?? '';
+      }),
+    );
+
+    // Grouping is a presentation concern; the flat CSV export never changes.
+    expect(outputs[1]).toBe(outputs[0]);
+    expect(outputs[2]).toBe(outputs[0]);
   });
 });
 

--- a/packages/plugin-reporter/test/markdown.test.ts
+++ b/packages/plugin-reporter/test/markdown.test.ts
@@ -29,6 +29,19 @@ function render(report: ReturnType<typeof createReport>): Promise<string> {
   return formatter.flush().then((output) => output ?? '');
 }
 
+function renderSorted(
+  report: ReturnType<typeof createReport>,
+  sortReportsBy: 'rule' | 'endpoint' | 'severity',
+): Promise<string> {
+  const formatter = new MarkdownFormatter(new NoopLogger());
+  formatter.init({
+    path: join(process.cwd(), 'tmp', 'markdown.test.md'),
+    sortReportsBy,
+  });
+  formatter.report(report);
+  return formatter.flush().then((output) => output ?? '');
+}
+
 function failedLint(
   location: string,
   opts: { ruleId?: string; reason?: string } = {},
@@ -439,6 +452,146 @@ describe('MarkdownFormatter test bodies (AC9-AC12)', () => {
     expect(output).toContain('HTTP/1.1 404 Not Found');
     expect((output.match(/<details>/g) ?? []).length).toBe(
       (output.match(/<\/details>/g) ?? []).length,
+    );
+  });
+});
+
+describe('MarkdownFormatter --sort-reports-by grouping', () => {
+  const lintRules: RuleDescriptor[] = [
+    { id: 'alpha/rule', severity: 'warn' },
+    { id: 'beta/rule', severity: 'error' },
+  ];
+
+  const lintReport = createReport([
+    createToolRun({
+      tool: { name: '@thymian/plugin-http-linter' },
+      runType: 'lint',
+      rules: lintRules,
+      executions: [
+        failedLint('GET /a', { ruleId: 'beta/rule', reason: 'e1' }),
+        failedLint('POST /b', { ruleId: 'alpha/rule', reason: 'w1' }),
+        failedLint('GET /c', { reason: 'orphan' }),
+      ],
+    }),
+  ]);
+
+  it('groups lint rows by rule (mirrored heading), adding a Location column', async () => {
+    const output = await renderSorted(lintReport, 'rule');
+
+    // Headings mirror the CLI: severity symbol + severity + rule id + count.
+    expect(output).toContain('### ⚠ warn: alpha/rule (1)');
+    expect(output).toContain('### ✖ error: beta/rule (1)');
+    expect(output).toContain('### ✖ error: unnamed check (1)'); // ruleless fallback
+    expect(output.indexOf('alpha/rule')).toBeLessThan(
+      output.indexOf('beta/rule'),
+    );
+    expect(output.indexOf('beta/rule')).toBeLessThan(
+      output.indexOf('unnamed check'),
+    );
+
+    // Location is now a column (no longer lost); Severity and Rule are dropped
+    // because the heading already carries both.
+    expect(output).toContain('| Location | Message |');
+    expect(output).toContain('| POST /b | w1 |');
+    expect(output).toContain('| GET /a | e1 |');
+    expect(output).not.toContain('| Severity | Location | Message |');
+  });
+
+  it('groups lint rows by severity (error→warn), adding a Location column', async () => {
+    const output = await renderSorted(lintReport, 'severity');
+
+    expect(output).toContain('### ✖ ERRORS (2)');
+    expect(output).toContain('### ⚠ WARNINGS (1)');
+    expect(output.indexOf('### ✖ ERRORS')).toBeLessThan(
+      output.indexOf('### ⚠ WARNINGS'),
+    );
+
+    // Rule + Location columns; the Severity column (now the heading) is dropped.
+    expect(output).toContain('| Rule | Location | Message |');
+    expect(output).toContain('| <code>beta/rule</code> | GET /a | e1 |');
+    expect(output).toContain('| <code>alpha/rule</code> | POST /b | w1 |');
+  });
+
+  it('files skipped executions under a dedicated group in severity mode', async () => {
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [{ id: 'beta/rule', severity: 'error' }],
+        executions: [
+          failedLint('GET /a', { ruleId: 'beta/rule', reason: 'e1' }),
+          createLintExecution({
+            location: { type: 'custom', value: 'GET /b' },
+            ruleId: 'gamma/rule',
+            status: { kind: 'skipped', reason: 'n/a' },
+          }),
+        ],
+      }),
+    ]);
+
+    const output = await renderSorted(report, 'severity');
+
+    expect(output).toContain('### ✖ ERRORS (1)');
+    expect(output).toContain('### ⏭ SKIPPED (1)');
+    // Skipped sorts after the real severities, never merged into `error`.
+    expect(output.indexOf('### ✖ ERRORS')).toBeLessThan(
+      output.indexOf('### ⏭ SKIPPED'),
+    );
+    // The skip keeps its location in the added column.
+    expect(output).toContain('| <code>gamma/rule</code> | GET /b | n/a |');
+  });
+
+  it('regroups test cases under a rule heading with #### sub-headings', async () => {
+    const testReport = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-tester' },
+        runType: 'test',
+        rules: [{ id: 'shared/rule', severity: 'error' }],
+        executions: [
+          createTestCaseExecution({
+            name: 'case a',
+            ruleId: 'shared/rule',
+            status: { kind: 'failed', reason: 'boom a' },
+            steps: [],
+          }),
+          createTestCaseExecution({
+            name: 'case b',
+            ruleId: 'shared/rule',
+            status: { kind: 'failed', reason: 'boom b' },
+            steps: [],
+          }),
+        ],
+      }),
+    ]);
+
+    const ruleOutput = await renderSorted(testReport, 'rule');
+    const grouped = ruleOutput.split('\n');
+    expect(grouped).toContain('### ✖ error: shared/rule (2)');
+    expect(grouped).toContain('#### case a · _✖ failed_');
+    expect(grouped).toContain('#### case b · _✖ failed_');
+    // The case name is a `####` sub-heading, not a top-level `###` heading.
+    expect(grouped.some((line) => line.startsWith('### case a'))).toBe(false);
+    // The summary keeps the severity but drops the rule (it is the heading).
+    expect(ruleOutput).toContain('<details><summary>error · boom a</summary>');
+    expect(ruleOutput).not.toContain('shared/rule</code> · boom a');
+
+    // Grouped by severity: the summary drops the `error · ` prefix (the
+    // heading carries the severity) but keeps the rule.
+    const severityOutput = await renderSorted(testReport, 'severity');
+    expect(severityOutput).toContain('### ✖ ERRORS (2)');
+    expect(severityOutput).toContain(
+      '<details><summary><code>shared/rule</code> · boom a</summary>',
+    );
+    expect(severityOutput).not.toContain('error · <code>shared/rule</code>');
+
+    // Default keeps the historical flat, per-case `###` layout, with both the
+    // severity and the rule in the summary.
+    const flatOutput = await render(testReport);
+    const flat = flatOutput.split('\n');
+    expect(flat).toContain('### case a · _✖ failed_');
+    expect(flat.some((line) => line.startsWith('#### '))).toBe(false);
+    expect(flatOutput).toContain(
+      '<details><summary>error · <code>shared/rule</code> · boom a</summary>',
     );
   });
 });

--- a/packages/plugin-reporter/test/markdown.test.ts
+++ b/packages/plugin-reporter/test/markdown.test.ts
@@ -479,9 +479,9 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     const output = await renderSorted(lintReport, 'rule');
 
     // Headings mirror the CLI: severity symbol + severity + rule id + count.
-    expect(output).toContain('### ⚠ warn: alpha/rule (1)');
-    expect(output).toContain('### ✖ error: beta/rule (1)');
-    expect(output).toContain('### ✖ error: unnamed check (1)'); // ruleless fallback
+    expect(output).toContain('### ⚠ warn: alpha/rule');
+    expect(output).toContain('### ✖ error: beta/rule');
+    expect(output).toContain('### ✖ error: unnamed check'); // ruleless fallback
     expect(output.indexOf('alpha/rule')).toBeLessThan(
       output.indexOf('beta/rule'),
     );
@@ -500,8 +500,8 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
   it('groups lint rows by severity (error→warn), adding a Location column', async () => {
     const output = await renderSorted(lintReport, 'severity');
 
-    expect(output).toContain('### ✖ ERRORS (2)');
-    expect(output).toContain('### ⚠ WARNINGS (1)');
+    expect(output).toContain('### ✖ ERRORS');
+    expect(output).toContain('### ⚠ WARNINGS');
     expect(output.indexOf('### ✖ ERRORS')).toBeLessThan(
       output.indexOf('### ⚠ WARNINGS'),
     );
@@ -531,8 +531,8 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
 
     const output = await renderSorted(report, 'severity');
 
-    expect(output).toContain('### ✖ ERRORS (1)');
-    expect(output).toContain('### ⏭ SKIPPED (1)');
+    expect(output).toContain('### ✖ ERRORS');
+    expect(output).toContain('### ⏭ SKIPPED');
     // Skipped sorts after the real severities, never merged into `error`.
     expect(output.indexOf('### ✖ ERRORS')).toBeLessThan(
       output.indexOf('### ⏭ SKIPPED'),
@@ -601,7 +601,7 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     const output = await renderSorted(report, 'rule');
     // Severity resolved from the execution (status.severity), matching the CLI
     // `ruleHeading`/`groupSeverity` fallback — not the hardcoded `error`.
-    expect(output).toContain('### ⚠ warn: ghost/rule (1)');
+    expect(output).toContain('### ⚠ warn: ghost/rule');
     expect(output).not.toContain('error: ghost/rule');
   });
 
@@ -618,7 +618,7 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     ]);
 
     const output = await renderSorted(report, 'rule');
-    expect(output).toContain('### ✖ error: x/&lt;b&gt;oops&lt;/b&gt; (1)');
+    expect(output).toContain('### ✖ error: x/&lt;b&gt;oops&lt;/b&gt;');
     expect(output).not.toContain('### ✖ error: x/<b>oops</b>');
   });
 
@@ -647,7 +647,7 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
 
     const ruleOutput = await renderSorted(testReport, 'rule');
     const grouped = ruleOutput.split('\n');
-    expect(grouped).toContain('### ✖ error: shared/rule (2)');
+    expect(grouped).toContain('### ✖ error: shared/rule');
     expect(grouped).toContain('#### case a · _✖ failed_');
     expect(grouped).toContain('#### case b · _✖ failed_');
     // The case name is a `####` sub-heading, not a top-level `###` heading.
@@ -659,7 +659,7 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     // Grouped by severity: the summary drops the `error · ` prefix (the
     // heading carries the severity) but keeps the rule.
     const severityOutput = await renderSorted(testReport, 'severity');
-    expect(severityOutput).toContain('### ✖ ERRORS (2)');
+    expect(severityOutput).toContain('### ✖ ERRORS');
     expect(severityOutput).toContain(
       '<details><summary><code>shared/rule</code> · boom a</summary>',
     );
@@ -674,6 +674,41 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     expect(flatOutput).toContain(
       '<details><summary>error · <code>shared/rule</code> · boom a</summary>',
     );
+  });
+
+  it('files a skipped test case under the skipped severity group', async () => {
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-tester' },
+        runType: 'test',
+        rules: [{ id: 'lifecycle', severity: 'error' }],
+        executions: [
+          createTestCaseExecution({
+            name: 'failing case',
+            ruleId: 'lifecycle',
+            status: { kind: 'failed', reason: 'boom' },
+            steps: [],
+          }),
+          createTestCaseExecution({
+            name: 'skipped case',
+            ruleId: 'lifecycle',
+            status: { kind: 'skipped', reason: 'n/a' },
+            steps: [],
+          }),
+        ],
+      }),
+    ]);
+
+    const output = await renderSorted(report, 'severity');
+
+    expect(output).toContain('### ✖ ERRORS');
+    expect(output).toContain('### ⏭ SKIPPED');
+    expect(output.indexOf('### ✖ ERRORS')).toBeLessThan(
+      output.indexOf('### ⏭ SKIPPED'),
+    );
+    // The skipped case lands under SKIPPED, the failing one under ERRORS.
+    expect(output).toContain('#### skipped case · _⏭ skipped_');
+    expect(output).toContain('#### failing case · _✖ failed_');
   });
 });
 

--- a/packages/plugin-reporter/test/markdown.test.ts
+++ b/packages/plugin-reporter/test/markdown.test.ts
@@ -541,6 +541,87 @@ describe('MarkdownFormatter --sort-reports-by grouping', () => {
     expect(output).toContain('| <code>gamma/rule</code> | GET /b | n/a |');
   });
 
+  it('excludes passed executions (and their info findings) from rule/severity groups', async () => {
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [{ id: 'hinty', severity: 'hint' }],
+        executions: [
+          createLintExecution({
+            location: { type: 'custom', value: 'GET /passed' },
+            ruleId: 'hinty',
+            status: { kind: 'passed' },
+            findings: [
+              {
+                id: 'i-1',
+                kind: 'informational',
+                title: 'fyi',
+                message: { text: 'fyi detail' },
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+
+    // severity mode: only a passed execution exists, so there is nothing to
+    // group — no bogus `### ✖ ERRORS (0)` heading and no mis-filed info row.
+    const severity = await renderSorted(report, 'severity');
+    expect(severity).not.toContain('ERRORS');
+    expect(severity).not.toContain('fyi detail');
+
+    // rule mode: the passed execution contributes no group at all.
+    const rule = await renderSorted(report, 'rule');
+    expect(rule).not.toContain('hinty');
+    expect(rule).not.toContain('fyi detail');
+
+    // endpoint mode still surfaces the informational finding under its location.
+    const endpoint = await render(report);
+    expect(endpoint).toContain('### GET /passed');
+    expect(endpoint).toContain('fyi detail');
+  });
+
+  it('rule heading falls back to the execution severity when the rule has no descriptor', async () => {
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [], // no descriptor for `ghost/rule`
+        executions: [
+          createLintExecution({
+            location: { type: 'custom', value: 'GET /a' },
+            ruleId: 'ghost/rule',
+            status: { kind: 'failed', severity: 'warn', reason: 'w' },
+          }),
+        ],
+      }),
+    ]);
+
+    const output = await renderSorted(report, 'rule');
+    // Severity resolved from the execution (status.severity), matching the CLI
+    // `ruleHeading`/`groupSeverity` fallback — not the hardcoded `error`.
+    expect(output).toContain('### ⚠ warn: ghost/rule (1)');
+    expect(output).not.toContain('error: ghost/rule');
+  });
+
+  it('escapes HTML metacharacters in a rule id used as a heading', async () => {
+    const report = createReport([
+      createToolRun({
+        tool: { name: '@thymian/plugin-http-linter' },
+        runType: 'lint',
+        rules: [{ id: 'x/<b>oops</b>', severity: 'error' }],
+        executions: [
+          failedLint('GET /a', { ruleId: 'x/<b>oops</b>', reason: 'boom' }),
+        ],
+      }),
+    ]);
+
+    const output = await renderSorted(report, 'rule');
+    expect(output).toContain('### ✖ error: x/&lt;b&gt;oops&lt;/b&gt; (1)');
+    expect(output).not.toContain('### ✖ error: x/<b>oops</b>');
+  });
+
   it('regroups test cases under a rule heading with #### sub-headings', async () => {
     const testReport = createReport([
       createToolRun({

--- a/packages/thymian/src/commands/analyze.ts
+++ b/packages/thymian/src/commands/analyze.ts
@@ -6,7 +6,6 @@ import {
   resolveRuleSeverity,
 } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
-import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-har';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
@@ -65,10 +64,7 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
       this,
       outcome,
       {},
-      {
-        sortReportsBy: this.flags['sort-reports-by'] as
-          SortReportsBy | undefined,
-      },
+      { sortReportsBy: this.flags['sort-reports-by'] },
     );
   }
 }

--- a/packages/thymian/src/commands/analyze.ts
+++ b/packages/thymian/src/commands/analyze.ts
@@ -6,6 +6,7 @@ import {
   resolveRuleSeverity,
 } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
+import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-har';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
@@ -60,6 +61,14 @@ export default class Analyze extends BaseCliRunCommand<typeof Analyze> {
       });
     });
 
-    handleWorkflowOutcome(this, outcome);
+    handleWorkflowOutcome(
+      this,
+      outcome,
+      {},
+      {
+        sortReportsBy: this.flags['sort-reports-by'] as
+          SortReportsBy | undefined,
+      },
+    );
   }
 }

--- a/packages/thymian/src/commands/lint.ts
+++ b/packages/thymian/src/commands/lint.ts
@@ -5,6 +5,7 @@ import {
   mergeRuleSets,
   resolveRuleSeverity,
 } from '@thymian/common-cli';
+import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
 import type {} from '@thymian/plugin-sampler';
@@ -43,6 +44,14 @@ export default class Lint extends BaseCliRunCommand<typeof Lint> {
       });
     });
 
-    handleWorkflowOutcome(this, outcome);
+    handleWorkflowOutcome(
+      this,
+      outcome,
+      {},
+      {
+        sortReportsBy: this.flags['sort-reports-by'] as
+          SortReportsBy | undefined,
+      },
+    );
   }
 }

--- a/packages/thymian/src/commands/lint.ts
+++ b/packages/thymian/src/commands/lint.ts
@@ -5,7 +5,6 @@ import {
   mergeRuleSets,
   resolveRuleSeverity,
 } from '@thymian/common-cli';
-import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
 import type {} from '@thymian/plugin-sampler';
@@ -48,10 +47,7 @@ export default class Lint extends BaseCliRunCommand<typeof Lint> {
       this,
       outcome,
       {},
-      {
-        sortReportsBy: this.flags['sort-reports-by'] as
-          SortReportsBy | undefined,
-      },
+      { sortReportsBy: this.flags['sort-reports-by'] },
     );
   }
 }

--- a/packages/thymian/src/commands/test.ts
+++ b/packages/thymian/src/commands/test.ts
@@ -6,6 +6,7 @@ import {
   resolveRuleSeverity,
 } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
+import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
 import type {} from '@thymian/plugin-sampler';
@@ -55,6 +56,14 @@ export default class Test extends BaseCliRunCommand<typeof Test> {
       });
     });
 
-    handleWorkflowOutcome(this, outcome);
+    handleWorkflowOutcome(
+      this,
+      outcome,
+      {},
+      {
+        sortReportsBy: this.flags['sort-reports-by'] as
+          SortReportsBy | undefined,
+      },
+    );
   }
 }

--- a/packages/thymian/src/commands/test.ts
+++ b/packages/thymian/src/commands/test.ts
@@ -6,7 +6,6 @@ import {
   resolveRuleSeverity,
 } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
-import type { SortReportsBy } from '@thymian/core';
 import type {} from '@thymian/plugin-openapi';
 import type {} from '@thymian/plugin-reporter';
 import type {} from '@thymian/plugin-sampler';
@@ -60,10 +59,7 @@ export default class Test extends BaseCliRunCommand<typeof Test> {
       this,
       outcome,
       {},
-      {
-        sortReportsBy: this.flags['sort-reports-by'] as
-          SortReportsBy | undefined,
-      },
+      { sortReportsBy: this.flags['sort-reports-by'] },
     );
   }
 }


### PR DESCRIPTION
# Reintroduce `--sort-reports-by` grouping flag

## Summary

Reintroduces the `--sort-reports-by=<rule|endpoint|severity>` `BASE` flag on `lint`, `test`, and `analyze`. It controls how validation findings are **grouped** in report output. The flag was during the report-model migration; this brings it back as a **render-time grouping strategy** rather than reviving the deleted core `report-sorter.ts`/`sortReports()` reshaping.

`endpoint` is the default and reproduces today's output **byte-for-byte** on every surface. `rule` and `severity` are new grouping modes.

## Behavior

| Mode | Groups findings by |
|------|--------------------|
| `endpoint` (default) | Resolved location (lint/analyze) / test-case name (test) — unchanged from today |
| `rule` | Rule id (`unnamed check` for rule-less executions) |
| `severity` | Resolved severity, ordered **error → warn → hint → info**, with a dedicated `skipped` group last |

Applies to the **CLI terminal report** and the **markdown** file formatter. **CSV is intentionally a no-op** — it's a flat data export whose `rule_id`/`location`/`severity` columns already let consumers sort themselves; grouping is a presentation concern.

**CLI terminal** grouped modes lead each group with a severity-symbol heading + violation count and list each violation by location + reason (+ rule under severity grouping). For example, `lint --sort-reports-by=severity`:

```
  ✖ ERRORS (2)

    • GET /a
      ➜ Date header missing
       › rfc9110/date-header

    • POST /b
      ➜ charset should be specified

  ⚠ WARNINGS (1)

    • PUT /c
      ➜ deprecated media type
       › rfc9110/media-type
```

**Markdown** grouped-mode tables gain a `Location` column (so the location isn't lost when it's no longer the heading) and drop the column the heading already carries; test cases regroup under a `###` group heading with `####` per-case sub-headings. Headings mirror the CLI (`### ✖ error: rfc9110/date-header (2)`, `### ✖ ERRORS (2)`).

## What changed

- **`@thymian/core`** — added the `SortReportsBy` type + `SEVERITY_GROUP_ORDER` constant (shared, single source of truth).
- **`@thymian/common-cli`**
  - New `--sort-reports-by` `BASE` flag on the run commands (oclif rejects invalid values, listing the options).
  - `create-execution-renderer` refactored to pluggable heading/entry renderers; `renderReport` selects grouping + ordering per mode; `sortRecordBySeverity` orders severity groups.
  - `applyOptionsToPlugins` injects the flag into the reporter plugin's options **only when the reporter is already configured** (never auto-registers it). Precedence: an explicit `--sort-reports-by` wins over `-o …sortReportsBy=` / config.
- **`thymian` (`lint`/`test`/`analyze`)** — pass the flag through `handleWorkflowOutcome`.
- **`@thymian/plugin-reporter`** — `sortReportsBy` plugin option (JSON-schema-typed); markdown formatter grows mode-aware columns + mirrored headings; CSV unchanged. No new dependency on `common-cli` (shared only via `@thymian/core`).

## Invariants preserved

- `endpoint` (default) output is byte-identical on CLI, markdown, and CSV.
- No revival of core report reshaping (ADR-0014); report model v4 untouched.
- Reporter is never auto-registered by the flag.
- Module boundaries intact (no `plugin-reporter → common-cli` edge).

## Edge cases handled (surfaced by adversarial code review)

- **Skipped executions** get their own `skipped` group under `severity`, never mislabeled as errors.
- **Passed executions** (and their informational findings) are excluded from `rule`/`severity` grouping, matching the CLI — so no `ERRORS (0)` heading with a mis-filed row.
- **Descriptor-less rules**: the markdown `rule` heading resolves severity from the group's executions (CLI parity) rather than hardcoding `error`.
- Rule ids are HTML-escaped in markdown headings, like table cells.

## Testing

- Unit tests for all three modes across `lint`/`analyze`/`test` in the CLI renderer and the markdown formatter, plus CSV flag-invariance and the edge cases above.
- e2e (`cli-lint`): flag acceptance + invalid-value rejection.
- `endpoint` regressions all pass unchanged. `build` + `test` green across `core`, `common-cli`, `plugin-reporter`, `thymian`; lint clean; Prettier clean.

## Docs

The flag's `description` documents it for `--help`; CI regenerates the oclif README / astro-docs references from it (no hand-edited generated docs).