### PR TITLE
fix(plugin-openapi): declare @scalar/json-magic runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34813,6 +34813,7 @@
       "version": "0.0.0-PLACEHOLDER",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@scalar/json-magic": "^0.9.0",
         "@scalar/openapi-parser": "^0.23.2",
         "@scalar/openapi-upgrader": "^0.1.4",
         "@thymian/common-cli": "0.0.0-PLACEHOLDER",

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -36,6 +36,7 @@
     "openapi-types": "^12.1.3"
   },
   "dependencies": {
+    "@scalar/json-magic": "^0.9.0",
     "@scalar/openapi-parser": "^0.23.2",
     "@scalar/openapi-upgrader": "^0.1.4",
     "@thymian/common-cli": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
## Problem

`@thymian/plugin-openapi` imports `@scalar/json-magic` at runtime (`src/load-openapi.ts`: `@scalar/json-magic/bundle` and `@scalar/json-magic/bundle/plugins/node`) but did not declare it in `dependencies`. Under npm/yarn hoisting the import resolved incidentally via the transitive dep from `@scalar/openapi-parser`. Under pnpm's strict per-package isolation it fails and **every** Thymian CLI command dies at plugin load:

```
Cannot find package '@scalar/json-magic'
Failed to load plugin module "@thymian/plugin-openapi"
PluginLoadError  (exit code 2)
```

`pnpm dlx thymian lint ...` is a complete repro; `--config.shamefully-hoist=true` does not help. Confirmed in `0.1.12` and `0.1.13-canary.20260727-02bb901`.

## Fix

Declare `@scalar/json-magic` `^0.9.0` in `packages/plugin-openapi/package.json` — compatible with the `0.9.0` that `@scalar/openapi-parser@^0.23.2` resolves (root already hoists `0.9.6`, which satisfies the range). Adds the matching direct-dependency edge to `package-lock.json`; no package versions change.

## Notes

- Purely additive dependency declaration for an already-installed, already-used package. No code or resolved-version changes under npm/yarn; the fix restores resolution under strict installers (pnpm).

Tracked in thymianofficial/thymian-internal#454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)