### PR TITLE
feat(rules-rfc-9110): educational explanations for methods (§9) and range requests (§14)

### DIFF
--- a/packages/rules-rfc-9110/src/rules/methods/general-purpose-severs-must-support-get-and-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/general-purpose-severs-must-support-get-and-head.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
   .description(
     'All general-purpose servers MUST support the methods GET and HEAD.',
   )
+  .explanation(
+    'Any server meant for general use must handle GET and HEAD requests rather than rejecting them as not implemented; every other method is optional. This matters because GET and HEAD are the baseline of the Web: clients, caches, crawlers, and link checkers assume they can always retrieve a resource or its metadata. A server that fails to support them cannot interoperate with the wider ecosystem, since callers have no reliable way to read what the server exposes.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/origin-sever-may-accept-connect-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/origin-sever-may-accept-connect-request.rule.ts
@@ -8,6 +8,9 @@ export default httpRule('rfc9110/origin-sever-may-accept-connect-request')
   .description(
     'An origin server MAY accept a CONNECT request, but most origin servers do not implement CONNECT',
   )
+  .explanation(
+    'CONNECT is intended for proxies to open a tunnel to a destination, so it is optional for an origin server: an origin server may accept it, but most do not implement it and will report it as not implemented. This is informational rather than a hard requirement, and it sets expectations for clients: since CONNECT targets proxies, sending it directly to an origin server usually will not establish a tunnel, so clients should not assume plain origin servers support it.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(method('CONNECT'), statusCode(501)),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/server-must-not-send-transfer-encoding-or-content-length-headers-in-2xx-response-to-connect-request.rule.ts
@@ -26,6 +26,9 @@ export default httpRule(
   .description(
     'A server MUST NOT send any Transfer-Encoding or Content-Length header fields in a 2xx (Successful) response to CONNECT.',
   )
+  .explanation(
+    'When a server answers a CONNECT request with a 2xx success, it must not include Transfer-Encoding or Content-Length headers. A successful CONNECT means the connection immediately switches to a raw tunnel after the response headers, and everything that follows is tunneled data from the destination, not an HTTP message body. Sending those framing headers would falsely imply a normal response body, confusing the client about where the tunnel begins and corrupting the tunneled stream.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/delete/client-should-not-generate-content-for-delete-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/delete/client-should-not-generate-content-for-delete-request.rule.ts
@@ -9,6 +9,9 @@ export default httpRule(
   .description(
     'A client SHOULD NOT generate content in a DELETE request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.',
   )
+  .explanation(
+    'Your client should not put a body on a DELETE request unless it is talking directly to an origin server that has confirmed the body is meaningful and supported. Content in a DELETE has no standard meaning and cannot change what gets deleted. It matters for interoperability and safety: intermediaries may not forward the body, and some implementations reject or drop the connection because an unexpected body looks like a request smuggling attack.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(method('DELETE'), hasRequestBody()),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/delete/origin-server-should-send-correct-successful-status-code-to-delete-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/delete/origin-server-should-send-correct-successful-status-code-to-delete-request.rule.ts
@@ -17,6 +17,9 @@ export default httpRule(
   .description(
     'If a DELETE method is successfully applied, the origin server SHOULD send 202 (Accepted), 204 (No Content) or 200 (OK).',
   )
+  .explanation(
+    'When a DELETE succeeds, the origin server should answer with one of three specific codes: 202 if the deletion is accepted but not yet carried out, 204 if it is done and there is nothing more to say, or 200 if it is done and the response includes a body describing the outcome. Using these expected codes lets clients reliably tell that the deletion worked and how much detail to expect, rather than guessing from an unusual or ambiguous success status.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/get/client-should-not-generate-content-in-get-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/get/client-should-not-generate-content-in-get-request.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
     'A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. ',
   )
   .summary('A client SHOULD NOT generate content in a GET request.')
+  .explanation(
+    'Your client should not attach a body to a GET request unless it is talking directly to an origin server that has confirmed such a body is meaningful and supported. Content in a GET has no standard meaning and cannot change what the request retrieves. It matters for interoperability and safety: intermediaries may not forward the body, and some implementations reject the request or close the connection because an unexpected body looks like a request smuggling attack.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(and(method('GET'), hasRequestBody())),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/client-should-not-generate-content-in-head-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/client-should-not-generate-content-in-head-request.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
     'A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. ',
   )
   .summary('A client SHOULD NOT generate content in a HEAD request.')
+  .explanation(
+    'Your client should not attach a body to a HEAD request unless it is talking directly to an origin server that has confirmed such a body is meaningful and supported. Content in a HEAD has no standard meaning and cannot change what the request asks for. It matters for interoperability and safety: intermediaries may not forward the body, and some implementations reject the request or close the connection because an unexpected body looks like a request smuggling attack.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(and(method('HEAD'), hasRequestBody())),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/server-must-not-send-content-in-response-to-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/server-must-not-send-content-in-response-to-head.rule.ts
@@ -9,6 +9,9 @@ export default httpRule(
   .description(
     'The HEAD method is identical to GET except that the server MUST NOT send content in the response.',
   )
+  .explanation(
+    'A HEAD request behaves like a GET but asks only for the headers, so the server must return no response body at all. HEAD exists precisely to obtain header metadata for a resource, such as its size or modification time, without transferring the representation itself. A client issuing HEAD does not expect and will not read a body, so sending one wastes bandwidth and defeats the purpose of using HEAD instead of GET.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(and(method('HEAD'), hasResponseBody())),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/server-should-send-same-header-fields-in-response-to-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/head/server-should-send-same-header-fields-in-response-to-head.rule.ts
@@ -13,6 +13,9 @@ export default httpRule(
   .description(
     'The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET.',
   )
+  .explanation(
+    "A response to HEAD should carry the same header fields the server would have returned for the equivalent GET, just without the body. Since the whole point of HEAD is to inspect a resource's metadata cheaply, clients rely on those headers to learn its type, size, and freshness before deciding whether to fetch it. Dropping headers that GET would include defeats that purpose and can mislead callers about the resource. A few fields determined only while generating content may legitimately be omitted.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateGroupedCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/client-may-send-max-forwards-header-in-option-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/client-may-send-max-forwards-header-in-option-request.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
   .description(
     'A client MAY send a Max-Forwards header field in an OPTIONS request to target a specific recipient in the request chain.',
   )
+  .explanation(
+    'On an OPTIONS request a client may optionally include a Max-Forwards header, which limits how many proxies the request may pass through so a specific intermediary in the chain answers it instead of the origin. Its absence is never wrong, but when present the value must be a plain non-negative integer, since each proxy decrements it and must respond as the final recipient once it reaches zero. A malformed value breaks that hop-counting and leaves the intended recipient ambiguous.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/client-must-send-content-type-header-for-content-in-options-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/client-must-send-content-type-header-for-content-in-options-request.rule.ts
@@ -16,6 +16,9 @@ export default httpRule(
   .description(
     'A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.',
   )
+  .explanation(
+    "If your client attaches a body to an OPTIONS request, it must also include a Content-Type header that correctly describes that body's media type. This matters because a body with no declared type leaves the server guessing how to parse it; declaring the type keeps the message unambiguous and lets any recipient in the chain handle the content correctly, even though HTTP defines no standard use for content in an OPTIONS request.",
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/proxy-must-not-generate-new-max-forwards-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/proxy-must-not-generate-new-max-forwards-header.rule.ts
@@ -15,6 +15,9 @@ export default httpRule(
   .description(
     'A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.',
   )
+  .explanation(
+    "A proxy may only pass along a Max-Forwards header if the request it received already carried one; it must never invent a Max-Forwards value the client did not send. This matters because Max-Forwards lets a client cap how many hops its OPTIONS or TRACE request travels through. If a proxy fabricates one, it silently changes the client's intended targeting and could cause the request to stop short of where the client meant it to reach.",
+  )
   .appliesTo('proxy')
   .overrideAnalyticsRule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/options/server-should-send-headers-indicating-optional-features-in-2xx-response-to-options-request.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
   .description(
     'A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.',
   )
+  .explanation(
+    "When your server answers an OPTIONS request successfully, it should advertise what the target resource supports by sending headers such as Allow that name the applicable optional features. This matters because the whole point of OPTIONS is to let a client discover a resource's capabilities without acting on it; a bare 2xx response with no such headers tells the client nothing, defeating that purpose and forcing it to guess which methods and features are available.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/post/origin-server-may-redirect-for-existing-resource-for-201-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/post/origin-server-may-redirect-for-existing-resource-for-201-response.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
   .description(
     "If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field.",
   )
+  .explanation(
+    "When a POST would produce something equivalent to a resource that already exists, your origin server is allowed to answer with a 303 (See Other) pointing at that existing resource's URL via the Location field, instead of creating a duplicate. This matters because it hands the client a stable identifier and lets the representation be fetched with a cache-friendly GET, avoiding redundant copies at the cost of one extra round trip. It is optional, so this surfaces as advisory rather than a violation.",
+  )
   .appliesTo('origin server')
   .rule((context) =>
     context.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/post/origin-server-should-send-location-header-for-201-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/post/origin-server-should-send-location-header-for-201-response.rule.ts
@@ -13,6 +13,9 @@ export default httpRule(
   .description(
     'If one or more resources has been created on the origin server as a result of successfully processing a POST request, the origin server SHOULD send a 201 (Created) response containing a Location header field that provides an identifier for the primary resource created and a representation that describes the status of the request while referring to the new resource(s).',
   )
+  .explanation(
+    'When a POST creates one or more new resources, your server should respond 201 (Created) and include a Location header giving the URL of the primary resource it just made. This matters because POST does not name the resource in advance, so without a Location header the client has no way to learn where the new resource lives; supplying it lets the client link to, fetch, or update what was created instead of having to guess the address.',
+  )
   .appliesTo('origin server')
   .rule((context) =>
     context.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/put/origin-server-must-not-sent-validator-field-in-response-to-put-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/put/origin-server-must-not-sent-validator-field-in-response-to-put-request.rule.ts
@@ -16,6 +16,9 @@ export default httpRule(
   .description(
     "An origin server MUST NOT send a validator field, such as an ETag or Last-Modified field, in a successful response to PUT unless the request's representation data was saved without any transformation applied to the content (i.e., the resource's new representation data is identical to the content received in the PUT request) and the validator field value reflects the new representation.",
   )
+  .explanation(
+    "On a successful PUT, your server may only return a validator like ETag or Last-Modified if it stored exactly what the client sent, unchanged, and the validator describes that stored representation. This matters because a client uses the returned validator to conclude the copy it still holds in memory matches the server's, skipping a re-fetch and using it for future conditional requests. If the server transformed the content but returns a validator anyway, the client trusts a stale copy and later conditional requests can silently overwrite or misfire.",
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/put/origin-server-must-respond-with-correct-response-code-for-put-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/put/origin-server-must-respond-with-correct-response-code-for-put-request.rule.ts
@@ -20,6 +20,9 @@ export default httpRule(
   .description(
     'If the target resource does not have a current representation and the PUT successfully creates one, then the origin server MUST inform the user agent by sending a 201 (Created) response. If the target resource does have a current representation and that representation is successfully modified in accordance with the state of the enclosed representation, then the origin server MUST send either a 200 (OK) or a 204 (No Content) response to indicate successful completion of the request.',
   )
+  .explanation(
+    'A successful PUT must be answered with the status code that reflects what happened: 201 (Created) when it brought a brand-new resource into existence, and 200 (OK) or 204 (No Content) when it replaced the state of one that already existed. This matters because the client relies on the code to tell created apart from updated; using the wrong one, or some other 2xx, misleads the client about whether a resource was newly made and undermines any logic that branches on that distinction.',
+  )
   .appliesTo('origin server')
   .rule((context) =>
     context.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/client-must-not-generate-fields-containing-sensitive-data-in-trace-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/client-must-not-generate-fields-containing-sensitive-data-in-trace-request.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
   .description(
     'A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.',
   )
+  .explanation(
+    'When your client issues a TRACE request, it must leave out any header fields that carry sensitive data, such as stored credentials or cookies. This matters because TRACE is a loop-back: the recipient reflects the request message straight back into the response body, so anything sensitive the client sends is echoed where it can be read, logged, or intercepted. Withholding those fields keeps secrets from being needlessly disclosed by the diagnostic response.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/client-must-not-send-content-in-trace-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/client-must-not-send-content-in-trace-request.rule.ts
@@ -5,6 +5,9 @@ export default httpRule('rfc9110/client-must-not-send-content-in-trace-request')
   .type('static', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-trace')
   .description('A client MUST NOT send content in a TRACE request.')
+  .explanation(
+    'Your client must not attach a body to a TRACE request. This matters because TRACE exists purely to reflect the request message back for diagnostics; a request body has no defined meaning here and would only invite ambiguity in how intermediaries handle the message. Keeping TRACE requests bodyless ensures every recipient interprets the loop-back consistently.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(method('TRACE'), hasRequestBody()),

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/trace/final-recipient-should-exclude-sensitive-request-data-from-response-to-trace.rule.ts
@@ -33,6 +33,9 @@ export default httpRule(
   .description(
     'The final recipient of the request SHOULD exclude any request fields that are likely to contain sensitive data when that recipient generates the response content.',
   )
+  .explanation(
+    'When your server is the final recipient of a TRACE and builds the reflected response body, it should strip out request fields likely to hold sensitive data rather than echoing them back verbatim. This matters because TRACE mirrors the request into the response, so faithfully reflecting fields like credentials or cookies would expose them; filtering them out protects secrets even when a client mistakenly included them, acting as a safety net on the receiving end.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/accept-ranges/accept-ranges-may-be-sent-in-trailer.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/accept-ranges/accept-ranges-may-be-sent-in-trailer.rule.ts
@@ -16,6 +16,9 @@ export default httpRule('rfc9110/accept-ranges-may-be-sent-in-trailer')
   .summary(
     'Accept-Ranges may be sent in a trailer, but the header field is preferred for failed-transfer recovery.',
   )
+  .explanation(
+    'A server is permitted to place Accept-Ranges in the trailer section, but sending it as a normal header is preferred. This matters because Accept-Ranges tells a client whether it can resume a large transfer with a range request, and the trailer arrives only after the whole body has been sent, too late to help recover a transfer that failed mid-content. Putting it in the header lets the client know up front, so this surfaces as advice rather than a violation.',
+  )
   .appliesTo('server')
   // Sending Accept-Ranges in a trailer is a conformant MAY, but the header form
   // is preferred (a trailer arrives too late to help a client restart a failed

--- a/packages/rules-rfc-9110/src/rules/range-requests/accept-ranges/server-may-send-accept-ranges-none.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/accept-ranges/server-may-send-accept-ranges-none.rule.ts
@@ -15,6 +15,9 @@ export default httpRule('rfc9110/server-may-send-accept-ranges-none')
   .summary(
     'Server may send "Accept-Ranges: none" to advise against range requests.',
   )
+  .explanation(
+    'A server that supports no range requests at all for a resource may send "Accept-Ranges: none" to tell the client not to bother trying a range request on that path. This matters because it saves the client from attempting partial requests that would just be rejected, and the "none" unit is reserved solely for this opt-out. It is optional, so this surfaces informationally when a response advertises some unit other than "none" rather than flagging a violation.',
+  )
   .appliesTo('server')
   // "Accept-Ranges: none" is a conformant MAY, so this surfaces (as analytics)
   // responses that carry an Accept-Ranges header advertising a unit other than

--- a/packages/rules-rfc-9110/src/rules/range-requests/content-range/recipient-must-not-recombine-invalid-content-range.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/content-range/recipient-must-not-recombine-invalid-content-range.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
   .summary(
     'Recipient must not recombine content with invalid Content-Range values.',
   )
+  .explanation(
+    'A Content-Range is nonsensical if its range runs backwards (last byte before first byte) or claims a total length that is not bigger than the last byte it reports. When you receive one like that, do not stitch the partial content back into any copy you already hold. Trusting an impossible range would corrupt the reassembled representation, so the safe move is to reject it rather than merge garbage into stored data.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       responseHeader('content-range'),

--- a/packages/rules-rfc-9110/src/rules/range-requests/content-range/sender-should-indicate-complete-length-for-byte-ranges.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/content-range/sender-should-indicate-complete-length-for-byte-ranges.rule.ts
@@ -27,6 +27,9 @@ export default httpRule(
   .summary(
     'Sender should indicate complete length in Content-Range unless unknown.',
   )
+  .explanation(
+    'When you send a byte range, spell out the total size of the whole resource after the slash in Content-Range (for example "bytes 0-1023/8192"), and only use "*" there if you genuinely cannot determine that size. Knowing the full length lets the client show accurate download progress, decide whether it already has everything, and reassemble multiple ranges correctly, so hiding it behind "*" when you actually know it makes clients guess needlessly.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/content-range/server-should-send-content-range-in-416-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/content-range/server-should-send-content-range-in-416-response.rule.ts
@@ -69,6 +69,9 @@ export default httpRule(
   .summary(
     'Server should send Content-Range with unsatisfied-range in 416 responses.',
   )
+  .explanation(
+    'When you reject a byte-range request as unsatisfiable with 416, include a Content-Range of the form "bytes */complete-length" that reports the resource\'s current total size. That size tells the client why its range did not fit and lets it retry with a valid range instead of giving up or looping, which keeps range-based downloads recoverable rather than leaving the client blind to how big the resource actually is.',
+  )
   .appliesTo('server')
   .overrideTest((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/partial-put/origin-server-should-send-400-for-unsupported-partial-put.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/partial-put/origin-server-should-send-400-for-unsupported-partial-put.rule.ts
@@ -20,7 +20,7 @@ export default httpRule(
     'Origin server should respond with 400 to a Content-Range PUT on a resource that does not support partial PUT.',
   )
   .explanation(
-    'A Content-Range on a PUT asks the server to overwrite only part of the resource at a given offset. If this resource does not support that partial-PUT behaviour, reject the request with 400 (Bad Request) rather than accepting it. Otherwise the server might treat the partial content as a full replacement and silently destroy the rest of the resource, so refusing up front protects the client from data loss it never intended.',
+    'A Content-Range on a PUT asks the server to overwrite only part of the resource at a given offset. If this resource does not support that partial-PUT behavior, reject the request with 400 (Bad Request) rather than accepting it. Otherwise the server might treat the partial content as a full replacement and silently destroy the rest of the resource, so refusing up front protects the client from data loss it never intended.',
   )
   .appliesTo('origin server')
   // Static: a PUT operation that declares no 206 response does not support

--- a/packages/rules-rfc-9110/src/rules/range-requests/partial-put/origin-server-should-send-400-for-unsupported-partial-put.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/partial-put/origin-server-should-send-400-for-unsupported-partial-put.rule.ts
@@ -19,6 +19,9 @@ export default httpRule(
   .summary(
     'Origin server should respond with 400 to a Content-Range PUT on a resource that does not support partial PUT.',
   )
+  .explanation(
+    'A Content-Range on a PUT asks the server to overwrite only part of the resource at a given offset. If this resource does not support that partial-PUT behaviour, reject the request with 400 (Bad Request) rather than accepting it. Otherwise the server might treat the partial content as a full replacement and silently destroy the rest of the resource, so refusing up front protects the client from data loss it never intended.',
+  )
   .appliesTo('origin server')
   // Static: a PUT operation that declares no 206 response does not support
   // partial PUT, so it SHOULD also declare a 400 for the Content-Range-on-PUT

--- a/packages/rules-rfc-9110/src/rules/range-requests/range-units/recipient-must-anticipate-large-decimal-numerals-for-byte-range.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range-units/recipient-must-anticipate-large-decimal-numerals-for-byte-range.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .summary(
     'Recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows.',
   )
+  .explanation(
+    'Byte-range positions can be arbitrarily large numbers because there is no fixed cap on how big content may be, so parse them in a way that handles values beyond a normal integer without overflowing or wrapping around. If your code assumes a small integer type, a huge but perfectly legal range value could crash the parser or produce a wrong position, breaking range handling exactly when it is needed for very large resources.',
+  )
   .rule((ctx, _, logger) =>
     ctx.validateHttpTransactions(
       requestHeader('range'),

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-list-multiple-ranges-in-ascending-order.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-list-multiple-ranges-in-ascending-order.rule.ts
@@ -41,7 +41,7 @@ export default httpRule(
     'Client should list multiple ranges in ascending order unless there is a specific need to request a later part earlier.',
   )
   .explanation(
-    'When you ask for several byte ranges at once, list them in increasing order, the same order they appear in the full resource, unless you have a real reason to fetch a later part first. Ordered ranges let the server read and stream the representation in one forward pass; jumbled ranges force extra seeking and can look like a broken client or an attack, so servers may treat scrambled requests less favourably.',
+    'When you ask for several byte ranges at once, list them in increasing order, the same order they appear in the full resource, unless you have a real reason to fetch a later part first. Ordered ranges let the server read and stream the representation in one forward pass; jumbled ranges force extra seeking and can look like a broken client or an attack, so servers may treat scrambled requests less favorably.',
   )
   .appliesTo('client')
   .rule((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-list-multiple-ranges-in-ascending-order.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-list-multiple-ranges-in-ascending-order.rule.ts
@@ -40,6 +40,9 @@ export default httpRule(
   .summary(
     'Client should list multiple ranges in ascending order unless there is a specific need to request a later part earlier.',
   )
+  .explanation(
+    'When you ask for several byte ranges at once, list them in increasing order, the same order they appear in the full resource, unless you have a real reason to fetch a later part first. Ordered ranges let the server read and stream the representation in one forward pass; jumbled ranges force extra seeking and can look like a broken client or an attack, so servers may treat scrambled requests less favourably.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-not-request-inefficient-multiple-ranges.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/client-should-not-request-inefficient-multiple-ranges.rule.ts
@@ -72,6 +72,9 @@ export default httpRule(
   .summary(
     'A client should not request multiple ranges that are less efficient than a single encompassing range.',
   )
+  .explanation(
+    'Do not split a request into many byte ranges when a single range covering the same span would be cheaper to fetch, such as overlapping ranges or tiny ranges separated by only a few bytes. Multipart range responses carry per-part overhead and make the server do more work, so a request that fragments what is essentially one contiguous chunk wastes bandwidth and processing and can even look like a denial-of-service pattern.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/proxy-may-discard-range-header-with-unknown-range-unit.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/proxy-may-discard-range-header-with-unknown-range-unit.rule.ts
@@ -14,7 +14,7 @@ export default httpRule(
     'A proxy may discard a Range header field that contains a range unit it does not understand.',
   )
   .explanation(
-    'If a proxy sees a Range header whose range unit it does not recognise (anything other than a unit it knows, such as bytes), it is allowed to strip that header before forwarding the request rather than pass it along. This is permissive, not required, but it lets an intermediary avoid relaying a range instruction it cannot reason about, so the origin server simply returns the full resource instead of acting on an unit the proxy could not validate.',
+    'If a proxy sees a Range header whose range unit it does not recognize (anything other than a unit it knows, such as bytes), it is allowed to strip that header before forwarding the request rather than pass it along. This is permissive, not required, but it lets an intermediary avoid relaying a range instruction it cannot reason about, so the origin server simply returns the full resource instead of acting on a unit the proxy could not validate.',
   )
   .appliesTo('proxy')
   .rule((ctx) => ctx.validateHttpTransactions(requestHeader('range')))

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/proxy-may-discard-range-header-with-unknown-range-unit.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/proxy-may-discard-range-header-with-unknown-range-unit.rule.ts
@@ -13,6 +13,9 @@ export default httpRule(
   .summary(
     'A proxy may discard a Range header field that contains a range unit it does not understand.',
   )
+  .explanation(
+    'If a proxy sees a Range header whose range unit it does not recognise (anything other than a unit it knows, such as bytes), it is allowed to strip that header before forwarding the request rather than pass it along. This is permissive, not required, but it lets an intermediary avoid relaying a range instruction it cannot reason about, so the origin server simply returns the full resource instead of acting on an unit the proxy could not validate.',
+  )
   .appliesTo('proxy')
   .rule((ctx) => ctx.validateHttpTransactions(requestHeader('range')))
   .done();

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/server-must-ignore-range-header-for-unrecognized-method.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/server-must-ignore-range-header-for-unrecognized-method.rule.ts
@@ -31,6 +31,9 @@ export default httpRule(
   .summary(
     'A server must ignore a Range header field received with a method (other than GET) for which range handling is not defined.',
   )
+  .explanation(
+    'Range requests are only defined for GET, so if a Range header arrives on any other method (or a method the server does not recognise), the server must act as if the header were not there and respond normally, never with 206 or a Content-Range. Honouring a range on, say, a POST or PUT would give meaning to something the spec leaves undefined, producing surprising, non-interoperable behaviour that clients cannot rely on.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/server-must-ignore-range-header-for-unrecognized-method.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/server-must-ignore-range-header-for-unrecognized-method.rule.ts
@@ -32,7 +32,7 @@ export default httpRule(
     'A server must ignore a Range header field received with a method (other than GET) for which range handling is not defined.',
   )
   .explanation(
-    'Range requests are only defined for GET, so if a Range header arrives on any other method (or a method the server does not recognise), the server must act as if the header were not there and respond normally, never with 206 or a Content-Range. Honouring a range on, say, a POST or PUT would give meaning to something the spec leaves undefined, producing surprising, non-interoperable behaviour that clients cannot rely on.',
+    'Range requests are only defined for GET, so if a Range header arrives on any other method (or a method the server does not recognize), the server must act as if the header were not there and respond normally, never with 206 or a Content-Range. Honoring a range on, say, a POST or PUT would give meaning to something the spec leaves undefined, producing surprising, non-interoperable behavior that clients cannot rely on.',
   )
   .appliesTo('server')
   .rule((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/range-requests/range/server-should-send-206-response-for-satisfiable-range.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/range-requests/range/server-should-send-206-response-for-satisfiable-range.rule.ts
@@ -24,6 +24,9 @@ export default httpRule(
   .summary(
     'Server should send 206 response when Range header conditions are met and range is satisfiable.',
   )
+  .explanation(
+    'When the server supports ranges for a resource and receives a valid, satisfiable Range request, it should return 206 (Partial Content) with just the requested byte range instead of sending the whole resource with 200. Delivering only the asked-for slice is the whole point of range requests: it saves bandwidth and lets clients resume interrupted downloads or fetch just the part they need, which fails if the server keeps sending the full representation.',
+  )
   .appliesTo('origin server')
   .rule(async (ctx) => {
     const results: RuleFnResult[] = [];


### PR DESCRIPTION
## What

Adds a user-facing `.explanation(...)` — a plain-language description of the rule plus why it matters — to **32 rules across the Methods and Range Requests chapters** of `@thymian/rules-rfc-9110`. Part of the work for thymianofficial/thymian-internal#289.

## Which part of the specification

**RFC 9110 §9 — Methods** and **§14 — Range Requests.**

- **Methods (§9):** general GET/HEAD support (§9.1 overview) and the method definitions (§9.3) — GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, and TRACE (including method-specific content, header, and status-code requirements).
- **Range Requests (§14):** `Range` (§14.2), `Accept-Ranges` (§14.3), `Content-Range` (§14.4), partial `PUT` (§14.5), and byte-range / range-unit handling.

Each explanation is grounded in the exact RFC 9110 section the rule links via `.url(...)`.

## Scope & guarantees

- **Purely additive** — only `.explanation(...)` calls were added; no rule logic, metadata, `.description`, `.summary`, `.url`, or tests were changed (0 deletions).
- **Only user-facing rules** — rules whose `.type(...)` is purely `informational` (never surfaced to users) were intentionally left untouched.
- One `.explanation(...)` per rule.

## Verification

The full 171-rule change was verified green before splitting: `tsc --noEmit` clean, `eslint` 0 errors, `prettier` clean, and 105/105 package tests pass. This PR is a strict, additive subset of that verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
