### PR TITLE
feat(rules-rfc-9110): educational explanations for conditional requests, content negotiation & authentication (§13, §12, §11)

### DIFF
--- a/packages/rules-rfc-9110/src/rules/authentication/origin-server/authentication-info/proxy-must-not-modify-authentication-info.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/origin-server/authentication-info/proxy-must-not-modify-authentication-info.rule.ts
@@ -17,6 +17,9 @@ export default httpRule('rfc9110/proxy-must-not-modify-authentication-info')
   .description(
     'A proxy forwarding a response is not allowed to modify the Authentication-Info field value in any way.',
   )
+  .explanation(
+    "When a proxy passes a response along, it must forward the Authentication-Info header exactly as it received it, without changing, reordering, adding, or dropping anything in the value. This field carries scheme-specific information the origin server sends after accepting the client's credentials (for example a finalization message that authenticates the server). If a proxy alters it, that end-to-end signal can be corrupted and the authentication handshake between client and origin server can break.",
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/authentication/origin-server/authorization/proxy-must-not-modify-authorization.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/origin-server/authorization/proxy-must-not-modify-authorization.rule.ts
@@ -16,6 +16,9 @@ export default httpRule('rfc9110/proxy-must-not-modify-authorization')
   .description(
     'A proxy forwarding a request MUST NOT modify any Authorization header fields in that request.',
   )
+  .explanation(
+    "When a proxy relays a request onward, it must leave the Authorization header untouched and pass the client's credentials through byte-for-byte. The Authorization field is how a user agent proves its identity to the origin server, and many authentication schemes bind those credentials to their exact bytes. If a proxy rewrites the header, the origin server sees different credentials than the client sent, so authentication fails and the client is wrongly rejected.",
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/authentication/origin-server/www-authenticate/proxy-must-not-modify-www-authenticate.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/origin-server/www-authenticate/proxy-must-not-modify-www-authenticate.rule.ts
@@ -16,6 +16,9 @@ export default httpRule('rfc9110/proxy-must-not-modify-www-authenticate')
   .description(
     'A proxy forwarding a response MUST NOT modify any WWW-Authenticate header fields in that response.',
   )
+  .explanation(
+    "When a proxy passes a response back toward the client, it must forward every WWW-Authenticate header exactly as it received it, without editing, adding, or removing any challenge. This field is the origin server's authentication challenge, telling the client which schemes, realms, and parameters to use. If a proxy alters it, the client may build the wrong credentials or pick the wrong scheme, breaking the authentication exchange with the origin server.",
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/authentication/origin-server/www-authenticate/server-may-send-www-authenticate-in-other-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/origin-server/www-authenticate/server-may-send-www-authenticate-in-other-responses.rule.ts
@@ -12,6 +12,9 @@ export default httpRule(
   .description(
     'A server MAY generate a WWW-Authenticate header field in other response messages to indicate that supplying credentials (or different credentials) might affect the response.',
   )
+  .explanation(
+    'A server is allowed to include a WWW-Authenticate header on responses other than a 401, as an optional hint that sending credentials, or different credentials, might change the outcome. It is not required to do so. This lets a server nudge a client toward authenticating even when it did not outright reject the request, which can help clients discover that a better-authorized response is available.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(not(responseHeader('www-authenticate'))),

--- a/packages/rules-rfc-9110/src/rules/authentication/parameters/authentication-parameter-name-must-occur-once-per-challenge.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/parameters/authentication-parameter-name-must-occur-once-per-challenge.rule.ts
@@ -71,6 +71,9 @@ export default httpRule(
   .summary(
     'Each authentication parameter name MUST only occur once per challenge (matched case-insensitively).',
   )
+  .explanation(
+    'Within a single authentication challenge or credential, each parameter name may appear only once, and names are compared ignoring case, so realm and Realm count as the same name. Repeating a name is not allowed. This keeps each name/value pair unambiguous: recipients can rely on a generic parser to read one value per parameter instead of having to guess which of several duplicates applies, which is essential for reliable interoperability across authentication schemes.',
+  )
   // In `test` only the RESPONSE side is observable: the request is
   // Thymian-generated and always well-formed, so a request-side scan is inert.
   .overrideTest((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/authentication/realm/realm-parameter-must-use-quoted-string-syntax.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/authentication/realm/realm-parameter-must-use-quoted-string-syntax.rule.ts
@@ -68,6 +68,9 @@ export default httpRule('rfc9110/realm-parameter-must-use-quoted-string-syntax')
   .summary(
     'A sender MUST only generate the quoted-string syntax for realm parameter values.',
   )
+  .explanation(
+    'When you emit a realm authentication parameter, its value must be written as a quoted string (realm="value"), never as a bare token (realm=value), even though the auth-param grammar technically permits both forms. This is a historical compatibility requirement: many long-deployed clients only accept the quoted form, so generating the token form risks those clients failing to parse the realm and mishandling the authentication challenge.',
+  )
   // In `test` only the RESPONSE side is observable: the request is
   // Thymian-generated and always well-formed, so a request-side scan is inert.
   .overrideTest((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-conditionals-for-connect-options-trace.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-conditionals-for-connect-options-trace.rule.ts
@@ -46,6 +46,9 @@ export default httpRule(
   .summary(
     'Server MUST ignore conditional headers for CONNECT, OPTIONS, or TRACE methods.',
   )
+  .explanation(
+    'For methods like CONNECT, OPTIONS, and TRACE that neither select nor modify a representation, the server must disregard any conditional headers (If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since, If-Range) and respond as if they were absent. Since there is no representation to compare against, a precondition has nothing meaningful to test. Evaluating one anyway would produce a spurious 304 or 412, so ignoring them keeps these methods behaving predictably.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/evaluation/server-must-ignore-preconditions-for-non-2xx-412-responses.rule.ts
@@ -20,6 +20,9 @@ export default httpRule(
     'A server MUST ignore all received preconditions if its response to the same request without those conditions, prior to processing the request content, would have been a status code other than a 2xx (Successful) or 412 (Precondition Failed). In other words, redirects and failures that can be detected before significant processing occurs take precedence over the evaluation of preconditions.',
   )
   .summary('Server MUST ignore preconditions if response would be non-2xx/412.')
+  .explanation(
+    "A server should only evaluate a request's preconditions when the request would otherwise succeed (2xx) or would specifically fail the precondition (412). If the same request without any conditions would already have produced some other outcome, such as a redirect or an early error, the server must ignore the preconditions and return that outcome. In short, redirects and failures detectable up front take priority, so a client is not misled by a 412 when the real problem lay elsewhere.",
+  )
   .appliesTo('origin server')
   .rule(async (ctx) => {
     const results: RuleFnResult[] = [];

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/cache-or-intermediary-may-ignore-if-match.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/cache-or-intermediary-may-ignore-if-match.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/cache-or-intermediary-may-ignore-if-match')
     'A cache or intermediary MAY ignore If-Match because its interoperability features are only necessary for an origin server.',
   )
   .summary('Cache or intermediary MAY ignore If-Match header field.')
+  .explanation(
+    'A cache or intermediary is permitted, but not required, to skip evaluating an If-Match header and simply pass the request along instead. If-Match exists to protect against lost updates and to abort a request when the target representation has changed, and those guarantees only truly matter at the origin server that holds the authoritative representation. So a middlebox can leave the condition for the origin to enforce without violating the specification.',
+  )
   .appliesTo('cache', 'intermediary')
   .rule((ctx) => ctx.validateHttpTransactions(requestHeader('if-match')))
   .done();

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/client-may-send-if-match-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/client-may-send-if-match-header.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/client-may-send-if-match-header')
     'A client MAY send an If-Match header field in a GET request to indicate that it would prefer a 412 (Precondition Failed) response if the selected representation does not match.',
   )
   .summary('A client MAY send an If-Match header field in a GET request.')
+  .explanation(
+    'A client is allowed to attach an If-Match header to a GET, signaling that it would rather receive a 412 (Precondition Failed) than a fresh body if the selected representation no longer matches the given entity tag. It is optional. This is mainly useful for range requests completing a partial download, where the client only wants more of the same representation it already has and does not want a different, newer one silently substituted.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-2xx-response-even-condition-failed.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-2xx-response-even-condition-failed.rule.ts
@@ -13,6 +13,9 @@ export default httpRule(
   .summary(
     'If the request is a state-changing operation that appears to have already been applied to the selected representation, the origin server MAY respond with a 2xx (Successful) status code.',
   )
+  .explanation(
+    "When an If-Match condition fails, the origin server must not perform the method, but it does have a choice of response. Normally it returns 412, yet if the request is a state-changing operation that appears to have already been applied, it may instead return a 2xx success. This handles the case where the client's change actually went through but it never saw the confirmation (a lost response or an equivalent change by another agent), letting the server acknowledge success rather than confusing the client with a failure.",
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-412-response-to-conditional-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-may-respond-with-412-response-to-conditional-request.rule.ts
@@ -19,6 +19,9 @@ export default httpRule(
   .summary(
     'An origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code.',
   )
+  .explanation(
+    'When an origin server evaluates an If-Match condition that turns out false, it must not carry out the requested method, and one permitted way to report this is to return a 412 (Precondition Failed) status. This gives the client a clear, standard signal that the target representation has changed since the entity tag it supplied, so its request was deliberately aborted rather than silently succeeding, which is what prevents accidental overwrites in the lost-update scenario.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-match/origin-server-must-not-perform-method-when-if-match-fails.rule.ts
@@ -20,6 +20,9 @@ export default httpRule(
   .summary(
     'Origin server MUST NOT perform method when If-Match evaluates to false',
   )
+  .explanation(
+    "When a request carries If-Match, the client is saying 'only do this if the resource still matches the entity tag I have'. If none of the given tags match the resource's current ETag, the server must refuse to carry out the request rather than act on stale assumptions, typically answering 412 Precondition Failed. This is what prevents the 'lost update' problem: two clients editing the same resource in parallel can't unknowingly overwrite each other's changes, because a request built against an out-of-date version is rejected instead of applied.",
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.httpTest(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/origin-server-should-respond-304-when-if-modified-since-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/origin-server-should-respond-304-when-if-modified-since-false.rule.ts
@@ -31,6 +31,9 @@ export default httpRule(
   .summary(
     'Origin server SHOULD respond with 304 when If-Modified-Since condition is false.',
   )
+  .explanation(
+    'When a GET or HEAD carries If-Modified-Since and the resource has not changed since the date the client supplied, the server should skip sending the body again and instead reply 304 Not Modified with just the metadata needed to refresh a cached copy. This is the core of efficient caching: the client already holds an up-to-date copy, so re-transferring the whole representation wastes bandwidth and time. Answering 304 lets the client reuse what it has while confirming it is still current.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-for-non-get-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-for-non-get-head.rule.ts
@@ -30,6 +30,9 @@ export default httpRule(
   .summary(
     'Recipient MUST ignore If-Modified-Since for methods other than GET or HEAD.',
   )
+  .explanation(
+    "If-Modified-Since only makes sense on GET or HEAD, where the point is to avoid re-sending an unchanged body. When it arrives on any other method, the recipient must pretend the header isn't there and process the request normally. Honoring it elsewhere and returning 304 would be a conformance bug: a 304 on, say, a POST or PUT would mislead the client into thinking its action was skipped as unchanged, breaking the well-defined meaning of conditional retrieval.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-when-if-none-match-present.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-modified-since/recipient-must-ignore-if-modified-since-when-if-none-match-present.rule.ts
@@ -22,6 +22,9 @@ export default httpRule(
   .summary(
     'Recipient MUST ignore If-Modified-Since when If-None-Match is present.',
   )
+  .explanation(
+    "When a request carries both If-None-Match and If-Modified-Since, the recipient must decide the outcome solely from If-None-Match and disregard the date entirely. Entity-tag comparison is a more precise test of whether a representation changed than a modification timestamp, so it takes precedence; the two are only ever sent together so that older intermediaries that don't understand If-None-Match still have something to evaluate. Letting the date override the tag would produce inconsistent, less accurate cache-validation results.",
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(requestHeader('if-none-match'), requestHeader('if-modified-since')),

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/origin-server-must-respond-304-or-412-when-if-none-match-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-none-match/origin-server-must-respond-304-or-412-when-if-none-match-fails.rule.ts
@@ -31,6 +31,9 @@ export default httpRule(
   .summary(
     'Origin server MUST respond with 304 for GET/HEAD or 412 for other methods when If-None-Match fails.',
   )
+  .explanation(
+    "If-None-Match tells the server 'only act if the resource does NOT match one of these tags'. When one of the tags does match (the condition is false), the server must not perform the method; instead it answers 304 Not Modified for GET or HEAD, and 412 Precondition Failed for any other method. The 304 lets a client reuse its cached copy without a re-download, while the 412 stops an unsafe operation such as a PUT from clobbering a resource the client wrongly assumed was still absent or unchanged.",
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-header-containing-http-date.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-header-containing-http-date.rule.ts
@@ -17,6 +17,9 @@ export default httpRule(
   .summary(
     'A client MUST NOT generate an If-Range header field containing an HTTP-date.',
   )
+  .explanation(
+    "If-Range lets a client resume a partial download only if the representation hasn't changed. A client should put an entity tag there whenever it has one; it may only fall back to a date when it holds no entity tag for the representation AND that date qualifies as a strong validator. Dates are a coarse way to detect change, so using one carelessly risks the server treating a modified resource as unchanged and stitching together bytes from two different versions, producing a corrupted result.",
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-with-weak-etag.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-with-weak-etag.rule.ts
@@ -25,6 +25,9 @@ export default httpRule(
     'A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.',
   )
   .summary('Client MUST NOT generate If-Range with weak entity tag.')
+  .explanation(
+    "A client must never put a weak entity tag (one marked with the W/ prefix) into If-Range. If-Range is evaluated with strong comparison, meaning it must guarantee byte-for-byte identity before the server resumes a partial transfer. A weak tag only promises the representation is semantically equivalent, not identical, so trusting it here could let the server splice a range from a subtly different version of the resource onto the client's partial copy, corrupting the reassembled content.",
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-without-range.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/client-must-not-generate-if-range-without-range.rule.ts
@@ -27,6 +27,9 @@ export default httpRule(
     'A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.',
   )
   .summary('Client MUST NOT generate If-Range without Range header field.')
+  .explanation(
+    'A client must only send If-Range together with a Range header. If-Range exists solely to decide whether the server should honor a requested byte range or send the whole thing instead, so it is meaningless on a request that asks for no range at all. Sending it alone signals a broken or confused client; well-behaved servers will simply ignore the orphaned header, but omitting it keeps requests clean and avoids relying on that lenient behavior.',
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/recipient-must-ignore-range-when-if-range-false.rule.ts
@@ -21,6 +21,9 @@ export default httpRule(
   .summary(
     'Recipient MUST ignore Range when If-Range condition is false; SHOULD respond with 200.',
   )
+  .explanation(
+    "If-Range means 'give me the requested byte range only if my copy is still current; otherwise give me the whole thing'. When the If-Range validator no longer matches the resource (the condition is false), the recipient must disregard the Range header and return the complete, up-to-date representation rather than a 206 Partial Content. This is what makes If-Range safe: it guarantees a client resuming a download never glues fresh bytes onto a stale partial copy, so it always ends up with a consistent whole representation.",
+  )
   .rule((ctx) =>
     ctx.httpTest(
       singleTestCase()

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/server-must-ignore-if-range-without-range.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-range/server-must-ignore-if-range-without-range.rule.ts
@@ -29,6 +29,9 @@ export default httpRule('rfc9110/server-must-ignore-if-range-without-range')
     'A server MUST ignore an If-Range header field received in a request that does not contain a Range header field. An origin server MUST ignore an If-Range header field received in a request for a target resource that does not support Range requests.',
   )
   .summary('Server MUST ignore If-Range without Range header field.')
+  .explanation(
+    "If a request carries If-Range but no Range header (or targets a resource that doesn't support ranges), the server must treat the If-Range as if it weren't there and answer with a normal full response, never a 206 Partial Content. If-Range only has meaning as a gate on range processing, so acting on it without a Range to process is a bug. Returning 206 in that case would hand the client a partial body it never asked for, which it cannot correctly reassemble.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/cache-or-intermediary-may-ignore-if-unmodified-since.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/cache-or-intermediary-may-ignore-if-unmodified-since.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'A cache or intermediary MAY ignore If-Unmodified-Since because its interoperability features are only necessary for an origin server.',
   )
   .summary('Cache or intermediary MAY ignore If-Unmodified-Since header field.')
+  .explanation(
+    "A cache or intermediary is allowed, but not required, to skip evaluating If-Unmodified-Since. This precondition is meant to protect the resource's state from unsafe concurrent changes, which is a concern that ultimately belongs to the origin server that owns the representation. An in-between cache typically can't authoritatively judge whether the resource was modified, so leaving the header to be enforced at the origin keeps the responsibility where the correct answer lives and avoids intermediaries making unsound decisions.",
+  )
   .appliesTo('cache', 'intermediary')
   .rule((ctx) =>
     ctx.validateHttpTransactions(requestHeader('if-unmodified-since')),

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/client-may-send-if-unmodified-since-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/client-may-send-if-unmodified-since-header.rule.ts
@@ -11,6 +11,9 @@ export default httpRule('rfc9110/client-may-send-if-unmodified-since-header')
   .summary(
     'A client MAY send an If-Unmodified-Since header field in a GET request.',
   )
+  .explanation(
+    "A client is permitted to add If-Unmodified-Since to a GET to say 'only give me this if it hasn't changed since this date; otherwise fail with 412'. In practice this is only genuinely useful for range requests, where the client wants to complete a partial copy and does not want a fresh, different representation. For that resume-a-download case If-Range is usually the better fit, since it fetches the whole current copy instead of failing outright when the resource has moved on.",
+  )
   .appliesTo('client')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/origin-server-must-not-perform-method-when-if-unmodified-since-fails.rule.ts
@@ -30,6 +30,9 @@ export default httpRule(
   .summary(
     'Origin server MUST NOT perform method when If-Unmodified-Since fails; MUST respond with 412 or 2xx.',
   )
+  .explanation(
+    "When a client sends If-Unmodified-Since, it is saying 'only do this if the resource has not changed since this time'. If the resource was in fact modified after that time, the server must not carry out the request; it should refuse with 412 (Precondition Failed), or answer 2xx if the change it asked for turns out to already be applied. This lets clients avoid overwriting or acting on data that changed underneath them, preventing lost updates in concurrent edits.",
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.httpTest(

--- a/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/recipient-must-ignore-if-unmodified-since-when-if-match-present.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/conditional-requests/preconditions/if-unmodified-since/recipient-must-ignore-if-unmodified-since-when-if-match-present.rule.ts
@@ -21,6 +21,9 @@ export default httpRule(
   .summary(
     'Recipient MUST ignore If-Unmodified-Since when If-Match is present.',
   )
+  .explanation(
+    'If a request carries both If-Match and If-Unmodified-Since, the server must evaluate only If-Match and ignore the date entirely. If-Match compares entity-tags, which is a more precise test than comparing timestamps, so the two are only sent together to help older intermediaries that do not understand If-Match. This keeps conditional requests behaving consistently: the stronger validator wins, and a stale date does not cause a spurious 412 when the entity-tag condition actually holds.',
+  )
   .rule(async (ctx) => {
     const results: RuleFnResult[] = [];
     await ctx.httpTest(

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-charset/user-agent-may-associate-quality-value-with-charset.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-charset/user-agent-may-associate-quality-value-with-charset.rule.ts
@@ -55,6 +55,9 @@ export default httpRule(
   .summary(
     'A user agent MAY associate a quality value with each charset in Accept-Charset. Note that this header is deprecated by RFC 9110; prefer relying on UTF-8.',
   )
+  .explanation(
+    'A client is allowed, but never required, to attach a quality value (a q= weight) to each charset in Accept-Charset to express how strongly it prefers one over another. This is purely optional. More importantly, RFC 9110 deprecates Accept-Charset altogether: modern clients should simply omit it and let servers default to UTF-8. Sending it adds little value and clutters requests, so the practical guidance is to drop the header rather than fine-tune its weights.',
+  )
   .appliesTo('user-agent')
   // Static context can only observe that the request carries Accept-Charset, so
   // it always surfaces the full hint (the MAY plus the deprecation note).

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/codings-value-may-be-given-quality-value.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/codings-value-may-be-given-quality-value.rule.ts
@@ -38,6 +38,9 @@ export default httpRule('rfc9110/codings-value-may-be-given-quality-value')
   .description(
     'Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.',
   )
+  .explanation(
+    'In Accept-Encoding, a client may optionally attach a quality value (a q= weight from 0 to 1) to each content coding it lists, to say how much it prefers one encoding over another. This is entirely optional; without weights every listed coding is treated as equally acceptable. Using weights lets a client steer the server toward a preferred compression, or rule out a coding with q=0, making content negotiation more expressive when the client actually cares about the choice.',
+  )
   // Static context can only observe that the request carries Accept-Encoding,
   // so it always surfaces the hint about the available quality-value mechanism.
   .rule((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/origin-server-should-send-response-without-content-coding.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/origin-server-should-send-response-without-content-coding.rule.ts
@@ -92,6 +92,9 @@ export default httpRule(
   .summary(
     'The origin server SHOULD send a response without any content coding unless the identity coding is indicated as unacceptable.',
   )
+  .explanation(
+    'When a client sends Accept-Encoding but the server has no representation whose encoding the client marked as acceptable, the server should fall back to sending the response unencoded (identity) rather than applying an encoding the client did not ask for. The only exception is when the client explicitly ruled out identity too. This ensures the client can still read the body: sending an unrequested content coding risks the client being unable to decode it.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/server-must-not-include-accept-encoding-for-non-content-coding-415-errors.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept-encoding/server-must-not-include-accept-encoding-for-non-content-coding-415-errors.rule.ts
@@ -19,6 +19,9 @@ export default httpRule(
   .summary(
     'Servers that fail a request with a 415 status for reasons unrelated to content codings MUST NOT include the Accept-Encoding header field.',
   )
+  .explanation(
+    "A 415 (Unsupported Media Type) can be raised either because the request's content coding was unacceptable or for unrelated media-type reasons. When the rejection has nothing to do with content codings, the server must not attach an Accept-Encoding header to the response. Including it would falsely signal that the failure was about encodings, misleading the client into retrying with a different content coding when the real problem lies elsewhere.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept/sender-should-send-q-parameter-last.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/accept/sender-should-send-q-parameter-last.rule.ts
@@ -22,6 +22,9 @@ export default httpRule('rfc9110/sender-should-send-q-parameter-last')
   .summary(
     'Senders using weights SHOULD send "q" last (after all media-range parameters).',
   )
+  .explanation(
+    "When an Accept value uses a q weight to express preference, the sender should put q last, after all of the media range's own parameters such as charset. Everything before q describes the media type; q itself marks the relative weight. Recipients treat any parameter named q as the weight no matter where it appears, so placing it last keeps the real media-range parameters and the weight clearly separated and unambiguous. For the same reason, a media type is not allowed to define its own parameter named q, since it would collide with the weight.",
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       requestHeader('accept'),

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/origin-server-should-generate-vary-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/origin-server-should-generate-vary-header.rule.ts
@@ -141,6 +141,9 @@ export default httpRule('rfc9110/origin-server-should-generate-vary-header')
   .summary(
     'An origin server SHOULD generate a Vary header field on a cacheable response when it wishes that response to be selectively reused for subsequent requests.',
   )
+  .explanation(
+    'When a server tailors a cacheable response to request headers such as Accept-Language or Accept-Encoding, it should add a Vary header naming those headers. Vary tells caches which request headers made this response specific, so a stored copy is only reused for later requests that match on them. Without it, a shared cache may hand a response built for one client (say, French content) to another client that asked for something different, causing cache poisoning and wrong content being served.',
+  )
   .appliesTo('origin server')
   // Static context sees only header names (no values), so it can only check
   // that a `Vary` header is present when a negotiation request header is.

--- a/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/proxy-must-not-generate-vary-wildcard.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/content-negotiation/content-negotiation-fields/vary/proxy-must-not-generate-vary-wildcard.rule.ts
@@ -13,6 +13,9 @@ export default httpRule('rfc9110/proxy-must-not-generate-vary-wildcard')
     'A list containing the member "*" signals that other aspects of the request might have played a role in selecting the response representation, possibly including aspects outside the message syntax (e.g., the client\'s network address). A recipient will not be able to determine whether this response is appropriate for a later request without forwarding the request to the origin server. A proxy MUST NOT generate "*" in a Vary field value.',
   )
   .summary('A proxy MUST NOT generate "*" in a Vary field value.')
+  .explanation(
+    'A Vary value of * means the response depends on factors beyond the request headers, possibly things not even visible in the message, so no cache can decide on its own whether a stored copy fits a later request without asking the origin server. A proxy must never introduce this * into a Vary header. Doing so would effectively make the response uncacheable for downstream caches and could misrepresent how the origin actually selected the response, degrading cache behavior.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateHttpTransactions(


### PR DESCRIPTION
## What

Adds a user-facing `.explanation(...)` — a plain-language description of the rule plus why it matters — to **33 rules across the Conditional Requests, Content Negotiation, and Authentication chapters** of `@thymian/rules-rfc-9110`. Part of the work for thymianofficial/thymian-internal#289.

## Which part of the specification

**RFC 9110 §13 — Conditional Requests**, **§12 — Content Negotiation**, and **§11 — HTTP Authentication.**

- **Conditional Requests (§13):** `If-Match` (§13.1.1), `If-None-Match` (§13.1.2), `If-Modified-Since` (§13.1.3), `If-Unmodified-Since` (§13.1.4), `If-Range` (§13.1.5), and precondition evaluation / ordering (§13.2).
- **Content Negotiation (§12):** `Accept`, `Accept-Charset`, `Accept-Encoding`, and `Vary` (§12.5).
- **HTTP Authentication (§11):** authentication challenges & credentials, protection space / realm, `WWW-Authenticate` / `Authorization`, and authentication-parameter syntax.

Each explanation is grounded in the exact RFC 9110 section the rule links via `.url(...)`.

## Scope & guarantees

- **Purely additive** — only `.explanation(...)` calls were added; no rule logic, metadata, `.description`, `.summary`, `.url`, or tests were changed (0 deletions).
- **Only user-facing rules** — rules whose `.type(...)` is purely `informational` (never surfaced to users) were intentionally left untouched.
- One `.explanation(...)` per rule.

## Verification

The full 171-rule change was verified green before splitting: `tsc --noEmit` clean, `eslint` 0 errors, `prettier` clean, and 105/105 package tests pass. This PR is a strict, additive subset of that verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
