### PR TITLE
feat(rules-rfc-9110): educational explanations for representation metadata, message context & identifiers (§8, §10, §4)

### DIFF
--- a/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/recipient-must-reject-http-uri-without-host.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/recipient-must-reject-http-uri-without-host')
   .description(
     `A recipient that processes a 'http' URI reference with empty host MUST reject it as invalid.`,
   )
+  .explanation(
+    'An http URI must name a host (like example.com) in its authority component; that host identifies the origin server that owns the resource. If a server receives an http URI whose host is empty, it must treat the URI as invalid and reject it rather than trying to process it. An http URI with no host does not identify any server, so accepting it would leave the request pointing nowhere and could open the door to ambiguity or misrouting.',
+  )
   .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/http/sender-must-not-generate-http-uri-with-empty-host.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'http' URI with an empty host identifier.`,
   )
+  .explanation(
+    'Whenever a client produces an http URI, that URI must include a non-empty host (such as example.com), because the host is what identifies the origin server responsible for the resource. Emitting an http URI with an empty host is forbidden. A hostless URI points to no server at all, so any recipient would be unable to route or resolve it and is required to reject it as invalid, breaking the request.',
+  )
   .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/recipient-must-reject-https-uri-without-host.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/recipient-must-reject-https-uri-without-host')
   .description(
     `A recipient that processes a 'https' URI reference with empty host MUST reject it as invalid.`,
   )
+  .explanation(
+    'An https URI must name a host (like example.com) in its authority component, because that host identifies the origin server that owns the resource. If a server processes an https URI whose host is empty, it must treat the URI as invalid and reject it rather than acting on it. A hostless https URI identifies no server, so accepting it would leave the request pointing nowhere and could enable ambiguity or misrouting.',
+  )
   .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/https/sender-must-not-generate-https-uri-with-empty-host.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
   .description(
     `A sender MUST NOT generate an 'https' URI with an empty host identifier.`,
   )
+  .explanation(
+    'Whenever a client produces an https URI, that URI must include a non-empty host (such as example.com), because the host identifies the origin server responsible for the resource. Emitting an https URI with an empty host is forbidden. A hostless URI points to no server, so any recipient would be unable to route or resolve it and is required to reject it as invalid, breaking the request.',
+  )
   .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/sender-recipient-should-support-8000-octet-uris.rule.ts
@@ -9,6 +9,9 @@ export default httpRule(
   .description(
     'It is RECOMMENDED that all senders and recipients support, at a minimum, URIs with lengths of 8000 octets in protocol elements.',
   )
+  .explanation(
+    'Both clients and servers should be able to handle URIs at least 8000 octets long wherever URIs appear, such as request targets, without truncating or rejecting them for size alone. If an implementation caps URIs below this floor, long but legitimate URLs (deep paths, large query strings) fail unpredictably from one endpoint to another. A common minimum lets senders and recipients interoperate reliably instead of guessing how much URL each side will tolerate.',
+  )
   .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(statusCode(414), (req, _res, location) => {

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/recipient-should-treat-userinfo-in-uri-from-untrusted-source-as-error.rule.ts
@@ -16,6 +16,9 @@ export default httpRule(
   .description(
     `A recipient SHOULD parse for userinfo and treat its presence as an error; it is likely being used to obscure the authority for the sake of phishing attacks.`,
   )
+  .explanation(
+    'Before acting on an http or https URI that came from an untrusted source, a recipient should check for a userinfo part (the user:password@ segment before the host) and treat its presence as an error. The userinfo component is deprecated in HTTP URIs, and when present it is commonly used to hide the real host so a link looks like it points somewhere trustworthy. Rejecting such URIs helps defend users against phishing that disguises the true authority.',
+  )
   .appliesTo('server')
   .rule((ctx, opts, logger) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/identifiers/userinfo/sender-must-not-generate-userinfo-in-uri.rule.ts
@@ -10,6 +10,9 @@ export default httpRule('rfc9110/sender-must-not-generate-userinfo-in-uri')
   .description(
     "A sender MUST NOT generate the userinfo subcomponent (and its '@' delimiter) when an 'http' or 'https' URI reference is generated within a message as a target URI or field value.",
   )
+  .explanation(
+    'When a sender puts an http or https URI into a message, whether as the request target or inside a header value, it must not include the userinfo part (the user:password@ segment, along with its @ delimiter) before the host. Userinfo in HTTP URIs is deprecated because embedding credentials this way can leak passwords and is a common trick for disguising the real host in phishing. Leaving it out keeps URIs safe to display and reason about and avoids exposing authentication details.',
+  )
   .appliesTo('client')
   .rule((ctx, opts, logger) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/client-must-not-generate-100-continue-without-content.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/client-must-not-generate-100-continue-without-content.rule.ts
@@ -17,6 +17,9 @@ export default httpRule(
   .description(
     'A client MUST NOT generate a 100-continue expectation in a request that does not include content.',
   )
+  .explanation(
+    'Only send an Expect: 100-continue in a request that actually carries a body. The whole point of that expectation is to ask the server for a go-ahead before the client streams (presumably large) content, so it makes no sense on a request with no content to send. Attaching it to a bodyless request just confuses the server about whether more data is coming, potentially causing it to wait needlessly or handle the exchange incorrectly.',
+  )
   .appliesTo('client')
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/server-may-respond-with-417-response-for-other-expect-than-100-continue.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/server-may-respond-with-417-response-for-other-expect-than-100-continue.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
   .description(
     'A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.',
   )
+  .explanation(
+    "The only expectation this specification defines is 100-continue. If a request's Expect header asks for anything else, the server is allowed to reject it by replying 417 (Expectation Failed) rather than proceeding. Signalling that the requested expectation cannot be met, instead of silently ignoring it, lets the client learn its expectation was unsupported and adjust or retry without it, which keeps the exchange predictable.",
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/server-may-respond-with-417-response-for-other-expect-than-100-continue.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/expect/server-may-respond-with-417-response-for-other-expect-than-100-continue.rule.ts
@@ -11,7 +11,7 @@ export default httpRule(
     'A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.',
   )
   .explanation(
-    "The only expectation this specification defines is 100-continue. If a request's Expect header asks for anything else, the server is allowed to reject it by replying 417 (Expectation Failed) rather than proceeding. Signalling that the requested expectation cannot be met, instead of silently ignoring it, lets the client learn its expectation was unsupported and adjust or retry without it, which keeps the exchange predictable.",
+    "The only expectation this specification defines is 100-continue. If a request's Expect header asks for anything else, the server is allowed to reject it by replying 417 (Expectation Failed) rather than proceeding. Signaling that the requested expectation cannot be met, instead of silently ignoring it, lets the client learn its expectation was unsupported and adjust or retry without it, which keeps the exchange predictable.",
   )
   .appliesTo('server')
   .rule((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/from/robotic-user-agent-should-send-valid-from-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/from/robotic-user-agent-should-send-valid-from-header.rule.ts
@@ -18,6 +18,9 @@ export default httpRule(
   .summary(
     'A From header field sent by a (robotic) user agent SHOULD contain a valid mailbox.',
   )
+  .explanation(
+    'If an automated agent (a robot, crawler, or bot) sends a From header, its value should be a real, working email address for the person responsible for the agent. The header exists precisely so a server operator can reach that person when the robot causes problems, such as sending excessive, unwanted, or invalid requests. A malformed or unreachable address defeats that purpose and leaves operators with no way to contact whoever runs the automated client.',
+  )
   .appliesTo('user-agent')
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/from/user-agent-should-not-send-from-without-configuration.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/from/user-agent-should-not-send-from-without-configuration.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
   .description(
     "A user agent SHOULD NOT send a From header field without explicit configuration by the user, since that might conflict with the user's privacy interests or their site's security policy.",
   )
+  .explanation(
+    "Do not attach a From header (a human user's email address) to requests unless the user has explicitly configured you to do so. The From value is expected to be visible to anyone observing the request and is routinely written to logs and error reports without any expectation of privacy, so sending it automatically leaks a personal identifier and can violate the user's privacy interests or their site's security policy.",
+  )
   .appliesTo('user-agent')
   .rule((ctx) => ctx.validateCommonHttpTransactions(requestHeader('from')))
   .done();

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-must-not-include-fragment-or-userinfo-in-referer.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-must-not-include-fragment-or-userinfo-in-referer.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .description(
     'A user agent MUST NOT include the fragment and userinfo components of the URI reference, if any, when generating the Referer field value.',
   )
+  .explanation(
+    'When building a Referer value from the URL of the referring page, strip off the fragment (the part after #) and any userinfo (a username or password before the @ in the URL). These parts are not needed to identify the referring resource and are often sensitive. Because the Referer is sent to the destination server and commonly logged, leaking embedded credentials or in-page fragment state would expose private information to third parties.',
+  )
   .appliesTo('user-agent')
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-must-not-send-referer-in-unsecured-request-from-secure-resource.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-must-not-send-referer-in-unsecured-request-from-secure-resource.rule.ts
@@ -19,6 +19,9 @@ export default httpRule(
   .summary(
     'A user agent MUST NOT send a Referer referring to an https resource in an unsecured http request.',
   )
+  .explanation(
+    "If the page you came from was loaded over a secure protocol (https), you must not reveal its address in the Referer of a request sent over plain, unsecured http. The secure page's URL may contain confidential context, and putting it in an http request would send it in the clear where any network observer could read it. Dropping the Referer in this secure-to-insecure case prevents that leak.",
+  )
   .appliesTo('user-agent')
   .overrideAnalyticsRule((ctx) =>
     // Pre-filter to unsecured (http) requests carrying a Referer; then confirm

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-should-not-send-referer-for-secure-to-insecure.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/referer/user-agent-should-not-send-referer-for-secure-to-insecure.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .description(
     'A user agent SHOULD NOT send a Referer header field if the referring resource was accessed with a secure protocol and the request target has an origin differing from that of the referring resource, unless the referring resource explicitly allows Referer to be sent.',
   )
+  .explanation(
+    "When the referring page was loaded over a secure protocol and you are now requesting a resource on a different origin, you should leave the Referer off unless that referring page has explicitly opted to allow it. The Referer can expose the secure page's address, which may reveal browsing history or confidential context; withholding it across origin boundaries protects the user's privacy while still permitting same-origin analytics and back-links.",
+  )
   .appliesTo('user-agent')
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/te/sender-must-send-te-connection-option-with-te-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/te/sender-must-send-te-connection-option-with-te-header.rule.ts
@@ -17,6 +17,9 @@ export default httpRule(
   .description(
     'A sender of TE MUST also send a "TE" connection option within the Connection header field to inform intermediaries not to forward this field.',
   )
+  .explanation(
+    'Whenever you send a TE header, also list "te" as a connection option in the Connection header. TE describes a capability of the immediate connection (which transfer codings and trailers the client accepts), not something meant for the far end. Naming it in Connection marks it as hop-by-hop so that a proxy consumes it rather than blindly forwarding it. Without this, an intermediary could pass on a TE that no longer reflects the next hop\'s actual capabilities, breaking transfer-coding negotiation.',
+  )
   // Static context sees only header NAMES, so it can only assert structurally
   // that a request carrying TE also carries a Connection header. The RFC
   // requirement is on the Connection VALUE (it must list the "te" option),

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/sender-must-not-generate-advertising-in-product-identifier.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/sender-must-not-generate-advertising-in-product-identifier.rule.ts
@@ -15,6 +15,9 @@ export default httpRule(
   .description(
     'A sender MUST NOT generate advertising or other nonessential information within the product identifier.',
   )
+  .explanation(
+    'Keep the product identifiers in your User-Agent limited to what actually names the software and its significant components. Do not stuff in marketing slogans, promotional URLs, or other nonessential text. Servers rely on the User-Agent to identify clients, tailor responses, and drive analytics, so padding it with advertising pollutes those signals, bloats every request, and increases both latency and the risk of fingerprinting the user.',
+  )
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(
       and(requestHeader('user-agent')),

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/sender-should-not-generate-non-version-info-in-product-version.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/sender-should-not-generate-non-version-info-in-product-version.rule.ts
@@ -15,6 +15,9 @@ export default httpRule(
   .description(
     'A sender SHOULD NOT generate information in product-version that is not a version identifier (i.e., successive versions of the same product name ought to differ only in the product-version portion of the product identifier).',
   )
+  .explanation(
+    'In a User-Agent product token of the form name/version, put only an actual version identifier after the slash, not descriptive words or other free text. The convention is that successive releases of the same product differ solely in that version portion, so servers and analytics can reliably tell versions apart and correlate behavior. Cramming non-version text there makes the field harder to parse and defeats that consistent version comparison.',
+  )
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(
       and(requestHeader('user-agent')),

--- a/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/user-agent-should-send-user-agent-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/request-context/user-agent/user-agent-should-send-user-agent-header.rule.ts
@@ -8,6 +8,9 @@ export default httpRule('rfc9110/user-agent-should-send-user-agent-header')
   .description(
     'A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.',
   )
+  .explanation(
+    'Your client should identify itself by including a User-Agent header on every request, naming the software (and usually its version) making the call, unless it has been deliberately configured to stay anonymous. This matters because servers rely on that identifier to scope interoperability problems to specific clients, to work around known client limitations, and to gather analytics on browser and platform usage; without it, operators lose an important signal for diagnosing and tailoring responses.',
+  )
   .appliesTo('user-agent')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(not(requestHeader('user-agent'))),

--- a/packages/rules-rfc-9110/src/rules/message-context/response-context/server/origin-server-may-generate-server-header-field.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-context/response-context/server/origin-server-may-generate-server-header-field.rule.ts
@@ -10,6 +10,9 @@ export default httpRule(
   .description(
     'An origin server MAY generate a Server header field in its responses.',
   )
+  .explanation(
+    'An origin server is allowed, but not required, to include a Server header that names the software handling the request, typically with its version. This is optional and purely informational: clients use it to scope reported interoperability problems, to tailor requests around known server quirks, and for analytics about server software. Keep in mind that overly detailed values can leak internal implementation details, so many operators either omit it or keep it minimal.',
+  )
   .appliesTo('origin server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(not(responseHeader('server'))),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/content-encoding-should-not-include-identity.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/content-encoding-should-not-include-identity.rule.ts
@@ -28,6 +28,9 @@ export default httpRule('rfc9110/content-encoding-should-not-include-identity')
     `The coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included in Content-Encoding.`,
   )
   .summary('Content-Encoding header SHOULD NOT include "identity" coding.')
+  .explanation(
+    'Do not list "identity" as a content coding in a Content-Encoding header. The token "identity" means "no encoding applied" and exists only for use in Accept-Encoding to say a client will accept an unencoded response; putting it in Content-Encoding is meaningless and can confuse recipients that try to decode it. If nothing was applied, simply omit the header rather than declaring the identity coding.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       responseHeader('content-encoding'),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/recipient-should-treat-x-gzip-as-gzip.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/recipient-should-treat-x-gzip-as-gzip.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/recipient-should-treat-x-gzip-as-gzip')
     `The "gzip" coding is an LZ77 coding with a 32-bit Cyclic Redundancy Check (CRC) that is commonly produced by the gzip file compression program [RFC1952]. A recipient SHOULD consider "x-gzip" to be equivalent to "gzip".`,
   )
   .summary('A recipient SHOULD consider "x-gzip" to be equivalent to "gzip".')
+  .explanation(
+    'When you receive content labelled with the "x-gzip" coding, decode it exactly as if it said "gzip": they are the same compression format, and "x-gzip" is just an older, deprecated alias. Treating them interchangeably means older senders that still emit "x-gzip" keep working, instead of leaving the recipient unable to decompress a body it actually knows how to handle.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(responseHeader('content-encoding', 'x-gzip')),
   )

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/recipient-should-treat-x-gzip-as-gzip.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-encoding/recipient-should-treat-x-gzip-as-gzip.rule.ts
@@ -10,7 +10,7 @@ export default httpRule('rfc9110/recipient-should-treat-x-gzip-as-gzip')
   )
   .summary('A recipient SHOULD consider "x-gzip" to be equivalent to "gzip".')
   .explanation(
-    'When you receive content labelled with the "x-gzip" coding, decode it exactly as if it said "gzip": they are the same compression format, and "x-gzip" is just an older, deprecated alias. Treating them interchangeably means older senders that still emit "x-gzip" keep working, instead of leaving the recipient unable to decompress a body it actually knows how to handle.',
+    'When you receive content labeled with the "x-gzip" coding, decode it exactly as if it said "gzip": they are the same compression format, and "x-gzip" is just an older, deprecated alias. Treating them interchangeably means older senders that still emit "x-gzip" keep working, instead of leaving the recipient unable to decompress a body it actually knows how to handle.',
   )
   .rule((ctx) =>
     ctx.validateHttpTransactions(responseHeader('content-encoding', 'x-gzip')),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/content-language-may-be-applied-to-any-media-type.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/content-language-may-be-applied-to-any-media-type.rule.ts
@@ -27,6 +27,9 @@ export default httpRule(
     'Content-Language MAY be applied to any media type -- it is not limited to textual documents.',
   )
   .summary('Content-Language MAY be applied to any media type.')
+  .explanation(
+    'Content-Language describes the natural language of the intended audience, and you are free to attach it to anything -- an image, an audio file, a PDF -- not just plain text. It matters because the header is about who the content is for, not what format it is in, so restricting it to text/* documents would needlessly hide useful language information from clients that negotiate or filter by language.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       responseHeader('content-language'),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/multiple-languages-may-be-listed-for-multiple-audiences.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/multiple-languages-may-be-listed-for-multiple-audiences.rule.ts
@@ -12,7 +12,7 @@ export default httpRule(
   )
   .summary('Multiple languages MAY be listed in Content-Language.')
   .explanation(
-    'When content is genuinely meant for several language audiences at once -- for example a document presented side by side in Maori and English -- you may list all of those languages in Content-Language. It matters because listing every audience language lets clients that select or filter by language recognise the content as relevant, whereas naming just one would wrongly exclude the others; note this is only for multi-audience content, not text that merely happens to contain foreign words.',
+    'When content is genuinely meant for several language audiences at once -- for example a document presented side by side in Maori and English -- you may list all of those languages in Content-Language. It matters because listing every audience language lets clients that select or filter by language recognize the content as relevant, whereas naming just one would wrongly exclude the others; note this is only for multi-audience content, not text that merely happens to contain foreign words.',
   )
   .rule((ctx) =>
     ctx.validateHttpTransactions(responseHeader('content-language')),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/multiple-languages-may-be-listed-for-multiple-audiences.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-language/multiple-languages-may-be-listed-for-multiple-audiences.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'Multiple languages MAY be listed for content that is intended for multiple audiences.',
   )
   .summary('Multiple languages MAY be listed in Content-Language.')
+  .explanation(
+    'When content is genuinely meant for several language audiences at once -- for example a document presented side by side in Maori and English -- you may list all of those languages in Content-Language. It matters because listing every audience language lets clients that select or filter by language recognise the content as relevant, whereas naming just one would wrongly exclude the others; note this is only for multi-audience content, not text that merely happens to contain foreign words.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(responseHeader('content-language')),
   )

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/origin-server-should-send-content-length-when-size-known.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/origin-server-should-send-content-length-when-size-known.rule.ts
@@ -22,6 +22,9 @@ export default httpRule(
   .summary(
     'Origin servers SHOULD send Content-Length when content size is known.',
   )
+  .explanation(
+    'When a response carries content, is not using Transfer-Encoding, and the server already knows how many bytes it will send before finishing the headers, it should include a Content-Length header stating that byte count. It matters because Content-Length lets downstream recipients show transfer progress, tell when the message is complete, and safely reuse the connection for further requests; without it clients have to guess when the body ends.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/recipient-must-handle-large-content-length.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/recipient-must-handle-large-content-length.rule.ts
@@ -26,6 +26,9 @@ export default httpRule('rfc9110/recipient-must-handle-large-content-length')
   .summary(
     'Content-Length values should be checked for integer overflow risks.',
   )
+  .explanation(
+    'There is no upper bound on how large a Content-Length value can be, so anything reading it must cope with very large decimal numbers without overflowing or losing precision when converting them to an integer. It matters because a naive parser can wrap around or truncate a huge value and then mis-frame where the message body ends, and because Content-Length delimits messages in HTTP/1.1 that framing error can be exploited for request smuggling or response splitting.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       responseHeader('content-length'),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-may-send-content-length-for-304.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-may-send-content-length-for-304.rule.ts
@@ -24,6 +24,9 @@ export default httpRule('rfc9110/server-may-send-content-length-for-304')
   .summary(
     'Servers MAY send Content-Length in 304 responses if it matches what 200 would return.',
   )
+  .explanation(
+    'A 304 Not Modified response has no body, but a server may still include a Content-Length -- and if it does, that value must equal the byte count a 200 OK to the same request would have carried. It matters because caches use Content-Length to describe the stored representation; a value that disagrees with what the full 200 response would return misleads the cache about the resource size and can corrupt cache validation.',
+  )
   .rule(async (ctx) => {
     const results: RuleFnResult[] = [];
     await ctx.httpTest(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-may-send-content-length-for-head-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-may-send-content-length-for-head-response.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
   .summary(
     'Servers MAY send Content-Length in HEAD responses (must match what GET would return).',
   )
+  .explanation(
+    "A HEAD response has no body, but a server may still send a Content-Length -- and when it does, that value must equal the number of bytes a GET on the same resource would have returned. It matters because clients use HEAD precisely to learn a resource's size before downloading it; if the advertised length differs from what GET would deliver, callers make wrong decisions about buffering, progress, or whether to fetch at all.",
+  )
   .rule(async (ctx) => {
     const results: RuleFnResult[] = [];
     await ctx.httpTest(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-must-not-send-content-length-for-1xx-or-204.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-must-not-send-content-length-for-1xx-or-204.rule.ts
@@ -20,6 +20,9 @@ export default httpRule(
   .summary(
     'Servers MUST NOT send Content-Length header in 1xx or 204 responses.',
   )
+  .explanation(
+    'Responses with a 1xx informational status or a 204 No Content status never carry a body, so a server must not put a Content-Length header on them. It matters because these statuses are defined to have no content; adding a Content-Length implies a body that will never arrive, which confuses recipients about message framing and, over HTTP/1.1, can desynchronise the connection or open the door to request smuggling.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-must-not-send-content-length-for-2xx-connect-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/server-must-not-send-content-length-for-2xx-connect-response.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .summary(
     'Servers MUST NOT send Content-Length header in 2xx responses to CONNECT requests.',
   )
+  .explanation(
+    'A 2xx response to a CONNECT request switches the connection into a tunnel rather than returning a normal message body, so the server must not include a Content-Length header on it. It matters because after a successful CONNECT everything on the connection is opaque tunnelled data with no HTTP framing; a Content-Length would falsely mark a body boundary and confuse how the tunnelled bytes are interpreted.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/user-agent-should-not-send-content-length-without-content.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/user-agent-should-not-send-content-length-without-content.rule.ts
@@ -30,6 +30,9 @@ export default httpRule(
   .summary(
     'User agents SHOULD NOT send Content-Length when request has no content.',
   )
+  .explanation(
+    'When a client sends a request that has no body and whose method does not expect one -- such as GET, HEAD, DELETE, CONNECT, OPTIONS, or TRACE -- it should not attach a non-zero Content-Length header. It matters because a Content-Length on a bodyless request signals data that never arrives, which can confuse servers and intermediaries about message framing and, in the worst case, be leveraged for request smuggling.',
+  )
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/user-agent-should-send-content-length-for-request-with-defined-content.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-length/user-agent-should-send-content-length-for-request-with-defined-content.rule.ts
@@ -12,6 +12,9 @@ export default httpRule(
     `A user agent SHOULD send Content-Length in a request when the method defines a meaning for enclosed content and it is not sending Transfer-Encoding.`,
   )
   .summary('User agents SHOULD send Content-Length in requests with content.')
+  .explanation(
+    'When a client uses a method that carries a body -- like POST, PUT, or PATCH -- and it is not using Transfer-Encoding, it should include a Content-Length header giving the body size (even 0 for an empty body). It matters because the server needs to know how many bytes to read to delimit the request body; without either Content-Length or Transfer-Encoding the server cannot tell where the body ends, which stalls or breaks the request.',
+  )
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/recipient-may-assume-media-type-or-determine-its-type.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/recipient-may-assume-media-type-or-determine-its-type.rule.ts
@@ -22,6 +22,9 @@ export default httpRule(
   .summary(
     'When Content-Type is absent, a recipient MAY assume application/octet-stream or sniff the body.',
   )
+  .explanation(
+    'If a message has a body but no Content-Type header, the recipient is allowed to either treat it as generic binary data (application/octet-stream) or inspect the bytes to guess the type. It matters because the sender should really declare the type; relying on the recipient to sniff it is a fallback that can guess wrong and, as the RFC warns, mis-sniffing can create security risks such as privilege escalation, so this flags the missing header rather than the recipient behaviour.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(hasRequestBody(), hasResponseBody()),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/recipient-may-assume-media-type-or-determine-its-type.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/recipient-may-assume-media-type-or-determine-its-type.rule.ts
@@ -23,7 +23,7 @@ export default httpRule(
     'When Content-Type is absent, a recipient MAY assume application/octet-stream or sniff the body.',
   )
   .explanation(
-    'If a message has a body but no Content-Type header, the recipient is allowed to either treat it as generic binary data (application/octet-stream) or inspect the bytes to guess the type. It matters because the sender should really declare the type; relying on the recipient to sniff it is a fallback that can guess wrong and, as the RFC warns, mis-sniffing can create security risks such as privilege escalation, so this flags the missing header rather than the recipient behaviour.',
+    'If a message has a body but no Content-Type header, the recipient is allowed to either treat it as generic binary data (application/octet-stream) or inspect the bytes to guess the type. It matters because the sender should really declare the type; relying on the recipient to sniff it is a fallback that can guess wrong and, as the RFC warns, mis-sniffing can create security risks such as privilege escalation, so this flags the missing header rather than the recipient behavior.',
   )
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/sender-should-generate-content-type-for-message-with-content.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/sender-should-generate-content-type-for-message-with-content.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .summary(
     'Servers SHOULD send Content-Type header in responses containing content.',
   )
+  .explanation(
+    "Whenever a sender produces a message with a body, it should include a Content-Type header naming the body's media type -- the only excuse to omit it is genuinely not knowing what the type is. It matters because Content-Type tells the recipient both the data format and how to process it; leaving it out forces the recipient to assume octet-stream or sniff the bytes, which can guess wrong and introduce interoperability and security problems.",
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(hasResponseBody(), not(responseHeader('content-type'))),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/sender-should-generate-content-type-for-message-with-content.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/content-type/sender-should-generate-content-type-for-message-with-content.rule.ts
@@ -15,7 +15,7 @@ export default httpRule(
     'Servers SHOULD send Content-Type header in responses containing content.',
   )
   .explanation(
-    "Whenever a sender produces a message with a body, it should include a Content-Type header naming the body's media type -- the only excuse to omit it is genuinely not knowing what the type is. It matters because Content-Type tells the recipient both the data format and how to process it; leaving it out forces the recipient to assume octet-stream or sniff the bytes, which can guess wrong and introduce interoperability and security problems.",
+    "Whenever a sender produces a message with a body, it should include a Content-Type header naming the body's media type -- the only excuse to omit it is genuinely not knowing what the type is. It matters because Content-Type tells the recipient both the data format and how to process it; leaving it out forces the recipient to assume application/octet-stream or sniff the bytes, which can guess wrong and introduce interoperability and security problems.",
   )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/etag-must-differ-for-different-content-encodings.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/etag-must-differ-for-different-content-encodings.rule.ts
@@ -39,6 +39,9 @@ export default httpRule(
   .summary(
     'Strong ETags MUST differ between encoded and unencoded representations.',
   )
+  .explanation(
+    'If your server sends the same resource in different content encodings (say a gzipped version and a plain version), each encoded form has to carry its own distinct strong ETag rather than reusing one tag for all of them. Strong ETags promise byte-for-byte identical content, so a cache or a range request that trusts a shared tag could stitch together bytes from the wrong encoding, corrupting the response. Giving each encoding its own tag keeps caching and partial fetches correct.',
+  )
   .overrideAnalyticsRule((ctx) => {
     // Correlate across the recorded corpus: for each resource identity
     // (origin + path) map each strong opaque ETag to the set of distinct

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/origin-server-should-avoid-backslash-in-entity-tags.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/origin-server-should-avoid-backslash-in-entity-tags.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
     Servers therefore ought to avoid backslash characters in entity tags.`,
   )
   .summary('Servers SHOULD avoid backslash characters in entity tags.')
+  .explanation(
+    'Do not put backslash characters inside the value of an ETag. Older specifications treated entity tags as quoted strings, so some recipients still try to unescape backslashes; a backslash in your tag can therefore be silently altered by such a recipient. That changes the tag the client stores and later sends back, breaking conditional requests and cache validation. Keeping tags free of backslashes avoids these mismatches across differing implementations.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       responseHeader('etag'),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/origin-server-should-send-etag.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/origin-server-should-send-etag.rule.ts
@@ -14,6 +14,9 @@ export default httpRule('rfc9110/origin-server-should-send-etag')
   .summary(
     'Origin servers SHOULD send ETag header when change detection can be determined.',
   )
+  .explanation(
+    'Whenever your server can reasonably tell when a resource has changed, it should attach an ETag validator to the response. Clients and caches use that tag in conditional requests to ask "has this changed since the version I hold?", letting the server answer with a small 304 Not Modified instead of resending the whole body. Providing ETags cuts redundant transfers and improves availability, scalability, and reliability under load.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/sender-may-send-etag-in-trailer.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/etag/sender-may-send-etag-in-trailer.rule.ts
@@ -12,6 +12,9 @@ export default httpRule('rfc9110/sender-may-send-etag-in-trailer')
   .summary(
     'Servers MAY send ETag in trailer section (but header field is preferable).',
   )
+  .explanation(
+    'You are allowed to place the ETag in the trailer (the fields sent after the body) instead of the normal header section, which is handy when the tag is computed while streaming the content. Be aware, though, that many recipients ignore trailers entirely, so a tag delivered there may never be seen or used for caching and conditional requests. Prefer sending ETag as a regular header whenever the value is known before the body is sent.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       statusCodeRange(200, 299),

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/last-modified/origin-server-should-send-last-modified.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/last-modified/origin-server-should-send-last-modified.rule.ts
@@ -14,6 +14,9 @@ export default httpRule('rfc9110/origin-server-should-send-last-modified')
   .summary(
     'Origin servers SHOULD send Last-Modified header when modification date can be determined.',
   )
+  .explanation(
+    'When your server can reasonably determine when a resource was last changed, it should include a Last-Modified date on the response. Clients and caches use that timestamp in conditional requests to check whether their stored copy is still current, so the server can reply 304 Not Modified rather than resending unchanged data. Supplying Last-Modified reduces wasteful transfers and helps the service scale and stay available.',
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/last-modified/origin-server-with-clock-must-not-generate-future-last-modified.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/representation-data-and-metadata/validator-fields/last-modified/origin-server-with-clock-must-not-generate-future-last-modified.rule.ts
@@ -18,6 +18,9 @@ export default httpRule(
   .summary(
     'Origin servers MUST NOT generate Last-Modified dates later than the Date header.',
   )
+  .explanation(
+    'A server that has a clock must never claim a resource was last modified at a time later than the moment it generated the response, that is, later than its own Date header. If internal metadata yields a future modification time, the server must clamp it down to the response Date. A future Last-Modified confuses caches and conditional-request logic, which compare that timestamp against the current time and can end up serving stale content or making the wrong freshness decisions.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       and(responseHeader('last-modified'), responseHeader('date')),


### PR DESCRIPTION
## What

Adds a user-facing `.explanation(...)` — a plain-language description of the rule plus why it matters — to **39 rules across the Representation Metadata, Message Context, and Identifiers chapters** of `@thymian/rules-rfc-9110`. Part of the work for thymianofficial/thymian-internal#289.

## Which part of the specification

**RFC 9110 §8 — Representation Data and Metadata**, **§10 — Message Context**, and **§4 — Identifiers.**

- **Representation Data & Metadata (§8):** `Content-Type` (§8.3), `Content-Encoding` (§8.4), `Content-Language`, `Content-Length` (§8.6), and validator fields — `ETag` (§8.8.3) and `Last-Modified` (§8.8.2).
- **Message Context (§10):** request-context fields `Expect`, `From`, `Referer`, `TE`, `User-Agent` (§10.1) and response-context field `Server` (§10.2).
- **Identifiers (§4):** the `http` and `https` URI schemes (§4.2), deprecation of `userinfo` in `http(s)` URIs (§4.2.4), and URI references.

Each explanation is grounded in the exact RFC 9110 section the rule links via `.url(...)`.

## Scope & guarantees

- **Purely additive** — only `.explanation(...)` calls were added; no rule logic, metadata, `.description`, `.summary`, `.url`, or tests were changed (0 deletions).
- **Only user-facing rules** — rules whose `.type(...)` is purely `informational` (never surfaced to users) were intentionally left untouched.
- One `.explanation(...)` per rule.

## Verification

The full 171-rule change was verified green before splitting: `tsc --noEmit` clean, `eslint` 0 errors, `prettier` clean, and 105/105 package tests pass. This PR is a strict, additive subset of that verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
