### PR TITLE
feat(rules-rfc-9110): educational explanations for routing, message abstraction & fields (§7, §6, §5)

### DIFF
--- a/packages/rules-rfc-9110/src/rules/fields/defining-field-values/date-time-formats/sender-must-generate-timestamps-in-imf-fixdate-format.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/defining-field-values/date-time-formats/sender-must-generate-timestamps-in-imf-fixdate-format.rule.ts
@@ -79,6 +79,9 @@ export default httpRule(
   .summary(
     'Sender MUST generate HTTP-date timestamps in the IMF-fixdate format.',
   )
+  .explanation(
+    "Whenever a sender writes a date in a header defined as HTTP-date (such as Date, Expires, or Last-Modified), it must use exactly one format: IMF-fixdate, for example 'Sun, 06 Nov 1994 08:49:37 GMT'. Two older date formats exist but must never be generated. Pinning senders to this single fixed layout, always in GMT, means every recipient can parse timestamps reliably, which is essential for caching, expiration, and conditional requests to work correctly across implementations.",
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(...httpDateResponseHeaders.map((name) => responseHeader(name))),

--- a/packages/rules-rfc-9110/src/rules/fields/defining-field-values/date-time-formats/sender-must-not-generate-additional-whitespace-in-http-date.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/defining-field-values/date-time-formats/sender-must-not-generate-additional-whitespace-in-http-date.rule.ts
@@ -61,6 +61,9 @@ export default httpRule(
   .summary(
     'Sender MUST NOT generate additional whitespace in HTTP-date beyond the grammar.',
   )
+  .explanation(
+    'An HTTP-date must contain only the exact single spaces the grammar prescribes; a sender must not add extra whitespace, such as tabs, doubled spaces, or leading or trailing padding. The date format is deliberately rigid so recipients can parse it with a simple fixed pattern. Even harmless-looking extra spaces can cause a strict parser to reject the timestamp, which then breaks caching and expiration logic that depends on reading these dates.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(...httpDateResponseHeaders.map((name) => responseHeader(name))),

--- a/packages/rules-rfc-9110/src/rules/fields/defining-field-values/lists/sender-must-not-generate-empty-list-elements.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/defining-field-values/lists/sender-must-not-generate-empty-list-elements.rule.ts
@@ -52,6 +52,9 @@ export default httpRule('rfc9110/sender-must-not-generate-empty-list-elements')
     'In any production that uses the list construct, a sender MUST NOT generate empty list elements.',
   )
   .summary('Sender MUST NOT generate empty list elements.')
+  .explanation(
+    'For any header defined as a comma-separated list (such as Vary or Allow), a sender must not emit empty entries, meaning no leading comma, no trailing comma, and no two commas with nothing but whitespace between them. Although recipients are told to tolerate such gaps, producing them is sloppy and risks confusing stricter parsers. Keeping list values clean, with a real value between every comma, avoids ambiguity and interoperability problems across differing implementations.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(...listTypedResponseHeaders.map((name) => responseHeader(name))),

--- a/packages/rules-rfc-9110/src/rules/fields/field-names/proxy-must-forward-unrecognized-header-fields.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/field-names/proxy-must-forward-unrecognized-header-fields.rule.ts
@@ -29,6 +29,9 @@ export default httpRule('rfc9110/proxy-must-forward-unrecognized-header-fields')
     'A proxy MUST forward unrecognized header fields unless the field name is listed in the Connection header field (Section 7.6.1) or the proxy is specifically configured to block, or otherwise transform, such fields.',
   )
   .summary('Proxy MUST forward unrecognized header fields unless excepted.')
+  .explanation(
+    'When a proxy relays a request, it should pass along header fields it does not itself recognize rather than stripping them, unless the field is named in the Connection header (a hop-by-hop control) or the proxy is explicitly configured to remove or transform it. This lets new HTTP features and extensions travel end-to-end and work correctly even though the intermediaries in between were deployed before those features existed, so the protocol can evolve without upgrading every proxy on the path.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/fields/field-names/proxy-must-forward-unrecognized-header-fields.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/field-names/proxy-must-forward-unrecognized-header-fields.rule.ts
@@ -30,7 +30,7 @@ export default httpRule('rfc9110/proxy-must-forward-unrecognized-header-fields')
   )
   .summary('Proxy MUST forward unrecognized header fields unless excepted.')
   .explanation(
-    'When a proxy relays a request, it should pass along header fields it does not itself recognize rather than stripping them, unless the field is named in the Connection header (a hop-by-hop control) or the proxy is explicitly configured to remove or transform it. This lets new HTTP features and extensions travel end-to-end and work correctly even though the intermediaries in between were deployed before those features existed, so the protocol can evolve without upgrading every proxy on the path.',
+    'When a proxy relays a request, it must pass along header fields it does not itself recognize rather than stripping them, unless the field is named in the Connection header (a hop-by-hop control) or the proxy is explicitly configured to remove or transform it. This lets new HTTP features and extensions travel end-to-end and work correctly even though the intermediaries in between were deployed before those features existed, so the protocol can evolve without upgrading every proxy on the path.',
   )
   .appliesTo('proxy')
   .rule((ctx) =>

--- a/packages/rules-rfc-9110/src/rules/fields/field-order/proxy-must-not-change-field-line-order.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/fields/field-order/proxy-must-not-change-field-line-order.rule.ts
@@ -28,6 +28,9 @@ export default httpRule('rfc9110/proxy-must-not-change-field-line-order')
   .summary(
     'Proxy MUST NOT change the order of field line values when forwarding.',
   )
+  .explanation(
+    'When the same header field name appears on several lines, their order carries meaning: the combined value is those line values joined in the order they arrived. A proxy relaying the message must keep that order exactly as received and must not shuffle the lines. If it reorders them, the recipient reconstructs a different combined value than the sender intended, silently corrupting the field and breaking correct interpretation of headers whose meaning depends on sequence.',
+  )
   .appliesTo('proxy')
   // Observable only from proxy-recorded traffic. Reordering of same-name field
   // lines is invisible in a single message; it is detectable only by

--- a/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/origin-server-may-generate-date-for-1xx-5xx.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/origin-server-may-generate-date-for-1xx-5xx.rule.ts
@@ -10,6 +10,9 @@ export default httpRule('rfc9110/origin-server-may-generate-date-for-1xx-5xx')
     'An origin server with a clock (as defined in Section 5.6.7) MAY generate a Date header field in 1xx (Informational) and 5xx (Server Error) responses.',
   )
   .summary('Origin servers MAY generate Date header in 1xx and 5xx responses.')
+  .explanation(
+    'An origin server that knows the current time is permitted, but not required, to include a Date header stating when it produced a 1xx (Informational) or 5xx (Server Error) response. This is optional because these response classes are less useful for caching than 2xx/3xx/4xx, where Date is mandatory. Supplying it anyway gives recipients a timestamp for age and clock-skew calculations, so this rule only hints that the header is absent rather than flagging an error.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/origin-server-with-clock-must-generate-date-for-2xx-3xx-4xx.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/origin-server-with-clock-must-generate-date-for-2xx-3xx-4xx.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
   .summary(
     'Origin servers with a clock MUST generate Date header in 2xx, 3xx, and 4xx responses.',
   )
+  .explanation(
+    "An origin server that has a working clock must stamp every 2xx (Successful), 3xx (Redirection), and 4xx (Client Error) response with a Date header giving the time the response was generated. Caches and clients rely on this timestamp to compute a response's age, detect clock skew, and decide how long a cached response stays fresh. Without Date on these responses, caching and freshness calculations become unreliable, so omitting it on a clock-bearing server is a conformance error.",
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       and(

--- a/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/user-agent-may-send-date-header-in-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/date/user-agent-may-send-date-header-in-request.rule.ts
@@ -10,5 +10,8 @@ export default httpRule('rfc9110/user-agent-may-send-date-header-in-request')
     'A user agent MAY send a Date header field in a request, though generally will not do so unless it is believed to convey useful information to the server.',
   )
   .summary('A user agent MAY send a Date header field in a request.')
+  .explanation(
+    "A user agent is allowed, but not expected, to include a Date header in its requests indicating when the request was created. Most clients omit it because servers rarely need it, but a request Date can be useful for custom applications where the server adjusts its handling based on the difference between the client's clock and its own. Since this is entirely optional, a missing request Date is never a problem; the rule only surfaces it as an informational hint.",
+  )
   .rule((ctx) => ctx.validateHttpTransactions(not(requestHeader('date'))))
   .done();

--- a/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/trailer/sender-should-generate-trailer-header-when-sending-trailers.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-abstraction/message-metadata/trailer/sender-should-generate-trailer-header-when-sending-trailers.rule.ts
@@ -21,6 +21,9 @@ export default httpRule(
   .summary(
     'Senders SHOULD generate Trailer header when sending trailer fields.',
   )
+  .explanation(
+    'If you plan to send any trailer fields after the message content, list their names up front in a Trailer header field in the header section. This gives the recipient advance notice of what metadata to expect after the body, so it can prepare to process those fields on the fly (for example, verifying a checksum or signature computed while the content streams in). It also leaves a hint of what was lost if an intermediary drops the trailer section in transit.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       not(responseHeader('trailer')),

--- a/packages/rules-rfc-9110/src/rules/message-abstraction/trailer-fields/sender-must-not-generate-trailer-unless-permitted.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/message-abstraction/trailer-fields/sender-must-not-generate-trailer-unless-permitted.rule.ts
@@ -37,6 +37,9 @@ export default httpRule(
   .summary(
     'Senders MUST NOT generate trailer fields unless explicitly permitted by field definition.',
   )
+  .explanation(
+    "Only put a field in the trailer section (after the content) if that field's definition actually allows it there. Many fields must be read before the content arrives because they govern framing, routing, authentication, request modifiers, response controls, or content format, so placing them in trailers is too late to be useful. This matters because recipients and intermediaries often discard trailers or cannot safely act on a field that arrives after the body, so a field sent as a trailer that belongs in the header section will simply be ignored or mishandled.",
+  )
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(
       or(...[...FORBIDDEN_TRAILER_FIELDS].map((name) => responseTrailer(name))),

--- a/packages/rules-rfc-9110/src/rules/routing/client-must-not-use-special-request-target-forms-with-other-methods.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/client-must-not-use-special-request-target-forms-with-other-methods.rule.ts
@@ -15,6 +15,9 @@ export default httpRule(
   .summary(
     'Special request target forms MUST NOT be used with methods other than CONNECT or OPTIONS.',
   )
+  .explanation(
+    'Two request targets have special meaning tied to specific methods: a bare host:port (the authority form) is only for CONNECT to name a tunnel destination, and a lone asterisk ("*") is only for OPTIONS to mean "the server as a whole". You must not use either form with any other method. These shapes are not normal paths, so pairing them with, say, a GET leaves the server unable to reliably determine which resource you meant, causing misrouting or rejection.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(constant(true), (req, _res, location) => {
       const method = req.method.toUpperCase();

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/intermediary-must-parse-and-remove-connection-fields.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/intermediary-must-parse-and-remove-connection-fields.rule.ts
@@ -17,6 +17,9 @@ export default httpRule(
   .summary(
     'Intermediary MUST parse and remove Connection fields before forwarding.',
   )
+  .explanation(
+    'Before a proxy passes a message on, it must read the incoming Connection header, and for every field name listed there it must strip out that matching header or trailer, then drop the Connection header itself (or replace it with its own options for the next hop). Those listed fields are meant only for the current connection ("hop-by-hop"); if they leak downstream they can misconfigure or confuse the next recipient. Removing them keeps connection-specific control information from being blindly forwarded.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/intermediary-should-remove-known-hop-by-hop-fields.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/intermediary-should-remove-known-hop-by-hop-fields.rule.ts
@@ -20,6 +20,9 @@ export default httpRule(
     "Intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics. This includes but is not limited to: Proxy-Connection, Keep-Alive, TE, Transfer-Encoding, and Upgrade.",
   )
   .summary('Intermediary SHOULD remove known hop-by-hop fields.')
+  .explanation(
+    'A proxy should strip or replace certain well-known connection-management fields, Proxy-Connection, Keep-Alive, TE, Transfer-Encoding, and Upgrade, before forwarding, even when they are not explicitly named in the Connection header. These fields describe the single hop between two endpoints, not the whole chain, and their semantics should be applied and then dropped. Forwarding them unchanged can cause the next hop to mishandle framing, keep-alive, or upgrades, leading to connection errors or request smuggling risks.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-list-connection-specific-field-in-connection-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-list-connection-specific-field-in-connection-header.rule.ts
@@ -29,6 +29,9 @@ export default httpRule(
     'When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field. This enables proper hop-by-hop vs end-to-end field distinction.',
   )
   .summary('Sender MUST list connection-specific fields in Connection header.')
+  .explanation(
+    'Whenever you send a field that carries control information about the current connection (such as Keep-Alive or Proxy-Connection), you must also name that field in the Connection header. That listing is what tells recipients the field is meant only for this hop, so intermediaries strip it before forwarding. Without it, the field looks like ordinary end-to-end data and gets passed down the chain, where it can misconfigure later connections or be misinterpreted as improperly forwarded.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
@@ -34,6 +34,9 @@ export default httpRule(
     'A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content. For example, Cache-Control is never appropriate as a connection option. This ensures end-to-end fields are not incorrectly marked as hop-by-hop.',
   )
   .summary('Sender MUST NOT use end-to-end fields as connection options.')
+  .explanation(
+    'The Connection header should only name fields meant for the immediate hop, never fields intended for everyone along the chain. So you must not list something like Cache-Control (or other end-to-end representation fields) as a connection option. Doing so marks an end-to-end field as hop-by-hop, causing intermediaries to strip it before it reaches its intended recipients, which breaks caching directives and other behaviour the field was supposed to control across the whole path.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       or(requestHeader('connection'), responseHeader('connection')),

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/connection/sender-must-not-send-end-to-end-fields-as-connection-options.rule.ts
@@ -35,7 +35,7 @@ export default httpRule(
   )
   .summary('Sender MUST NOT use end-to-end fields as connection options.')
   .explanation(
-    'The Connection header should only name fields meant for the immediate hop, never fields intended for everyone along the chain. So you must not list something like Cache-Control (or other end-to-end representation fields) as a connection option. Doing so marks an end-to-end field as hop-by-hop, causing intermediaries to strip it before it reaches its intended recipients, which breaks caching directives and other behaviour the field was supposed to control across the whole path.',
+    'The Connection header should only name fields meant for the immediate hop, never fields intended for everyone along the chain. So you must not list something like Cache-Control (or other end-to-end representation fields) as a connection option. Doing so marks an end-to-end field as hop-by-hop, causing intermediaries to strip it before it reaches its intended recipients, which breaks caching directives and other behavior the field was supposed to control across the whole path.',
   )
   .rule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/intermediary-must-not-forward-message-to-itself.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/intermediary-must-not-forward-message-to-itself.rule.ts
@@ -21,6 +21,9 @@ export default httpRule(
   .summary(
     'Intermediary MUST NOT forward message to itself without loop protection.',
   )
+  .explanation(
+    'A proxy must not forward a request to itself unless it has a safeguard against endless loops. It should recognize its own names, aliases, and IP addresses and answer such requests directly instead of relaying them onward. Without this, a message can bounce back to the same intermediary over and over, forming an infinite forwarding loop that exhausts connections and resources and never produces a response. The Via chain is used here to detect a hop the message has already passed through.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-check-and-update-max-forwards.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-check-and-update-max-forwards.rule.ts
@@ -12,6 +12,9 @@ export default httpRule(
     'Each intermediary that receives a TRACE or OPTIONS request containing a Max-Forwards header field MUST check and update its value prior to forwarding the request. The Max-Forwards mechanism limits the number of times a request can be forwarded.',
   )
   .summary('Intermediary MUST check and update Max-Forwards value.')
+  .explanation(
+    'When a proxy or gateway relays a TRACE or OPTIONS request that carries a Max-Forwards count, it must read that number and lower it before passing the request along, rather than forwarding it untouched. Max-Forwards is a hop counter that lets a client bound how far its request travels, which is how you diagnose requests that loop or stall somewhere mid-chain. If intermediaries forward it without decrementing, the counter never reaches zero and the safeguard against endless forwarding is defeated.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-generate-updated-max-forwards-when-forwarding.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-generate-updated-max-forwards-when-forwarding.rule.ts
@@ -12,6 +12,9 @@ export default httpRule(
     "If the received Max-Forwards value is greater than zero, the intermediary MUST generate an updated Max-Forwards field in the forwarded message with a field value that is the lesser of a) the received value decremented by one (1) or b) the recipient's maximum supported value for Max-Forwards.",
   )
   .summary('Intermediary MUST generate updated Max-Forwards when forwarding.')
+  .explanation(
+    'If the Max-Forwards count arrives greater than zero, the intermediary must forward the request with a new count that is the received value minus one (or lower, if its own supported maximum is smaller). In other words, every hop reduces the counter by at least one. This steady decrement is what guarantees the count eventually hits zero, so a looping or overly long forwarding chain gets stopped and the client can see exactly how far its trace reached.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-not-forward-when-max-forwards-is-zero.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-not-forward-when-max-forwards-is-zero.rule.ts
@@ -12,6 +12,9 @@ export default httpRule(
     'If the received Max-Forwards value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient. This prevents infinite forwarding loops in TRACE and OPTIONS requests.',
   )
   .summary('Intermediary MUST NOT forward request when Max-Forwards is zero.')
+  .explanation(
+    'When a TRACE or OPTIONS request arrives at an intermediary already carrying Max-Forwards: 0, the intermediary must stop and answer the request itself instead of passing it on to the next server. Zero means the client has budgeted no further hops. Honoring it is what prevents a request from being relayed indefinitely and lets the client pinpoint which intermediary sits at a given distance down the chain.',
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-respond-as-final-recipient-when-max-forward-is-zero.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/max-forwards/intermediary-must-respond-as-final-recipient-when-max-forward-is-zero.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
   .summary(
     'Intermediary MUST respond as final recipient when Max-Forwards is zero.',
   )
+  .explanation(
+    "When a TRACE or OPTIONS request reaches an intermediary with Max-Forwards: 0, that intermediary becomes the endpoint: it must generate the response itself rather than forward the request onward. A zero count is the client's instruction that this hop is as far as the request should go. Responding as the final recipient is what makes Max-Forwards a usable diagnostic, letting the client probe a specific point in the forwarding chain and receive an answer from it.",
+  )
   .appliesTo('intermediary')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/gateway-may-send-via-header-in-responses.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/gateway-may-send-via-header-in-responses')
     'An HTTP-to-HTTP gateway MAY send a Via header field in forwarded response messages. This is optional for responses, unlike requests where it is required.',
   )
   .summary('Gateway MAY send Via header in forwarded responses.')
+  .explanation(
+    'A gateway is permitted, but not required, to add a Via header to responses it forwards back toward the client. Via records which intermediaries a message passed through, so including it on responses gives downstream recipients extra visibility into the response path and the protocol versions along it. Because it is optional here, its presence is fine and its absence is equally acceptable; this rule simply surfaces where a gateway chose to use it.',
+  )
   .appliesTo('gateway')
   // Surfaces use of the optional mechanism: the hint fires when a gateway
   // response carries a Via header, never on its absence. It runs on captured

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/gateway-must-send-via-header-in-inbound-requests.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/gateway-must-send-via-header-in-inbound-requests.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message. This enables tracking of the message path and protocol capabilities along the request/response chain.',
   )
   .summary('Gateway MUST send Via header in inbound requests.')
+  .explanation(
+    'When an HTTP-to-HTTP gateway forwards a request toward the origin server, it must add itself to the Via header. Via is the running record of every proxy and gateway a message crossed, along with the protocol versions they used. Requiring the gateway to add its entry keeps that trail complete, which is what lets operators track the message path, detect and break forwarding loops, and judge which protocol features are safe to use along the chain.',
+  )
   .appliesTo('gateway')
   .rule((ctx) =>
     ctx.validateCapturedHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-forwarding/via/proxy-must-send-via-header.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/proxy-must-send-via-header')
     'A proxy MUST send an appropriate Via header field in each message that it forwards. The Via header field indicates the presence of intermediate protocols and recipients between the user agent and the server, and is used for tracking message forwards, avoiding request loops, and identifying protocol capabilities.',
   )
   .summary('Proxy MUST send Via header in forwarded messages.')
+  .explanation(
+    'Every time a proxy forwards a message, it must append its own entry to the Via header so the header lists each intermediary the message passed through, in order, together with the protocol versions involved. This trail is what lets operators trace the forwarding path, spot and stop request loops, and see the protocol capabilities of senders along the chain. A proxy that forwards without adding Via breaks that record and hides its presence from downstream recipients.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-may-transform-content-without-no-transform-directive.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-may-transform-content-without-no-transform-directive.rule.ts
@@ -14,6 +14,9 @@ export default httpRule(
     'A proxy MAY transform the content of a message that does not contain a no-transform cache directive. A proxy that transforms the content of a 200 (OK) response can inform downstream recipients that a transformation has been applied by changing the response status code to 203 (Non-Authoritative Information).',
   )
   .summary('Proxy MAY transform content without no-transform directive.')
+  .explanation(
+    'When a response does not carry a no-transform cache directive, a proxy is allowed to alter the content it forwards, for example transcoding an image to save space or bandwidth. This is a permitted optimization, not an error. If it rewrites the content of a 200 (OK) response, the proxy can flag that by switching the status to 203 (Non-Authoritative Information) so downstream recipients know the payload is no longer exactly what the origin sent. This rule simply surfaces where such a transformation occurred.',
+  )
   .appliesTo('proxy')
   // Surfaces use of the optional mechanism: the hint fires when a proxy is
   // observed transforming response content (the body it forwarded downstream

--- a/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-change-fqdn-hostname.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-change-fqdn-hostname.rule.ts
@@ -14,6 +14,9 @@ export default httpRule('rfc9110/proxy-must-not-change-fqdn-hostname')
   .summary(
     'Proxy MUST NOT change host name when it is a fully qualified domain name.',
   )
+  .explanation(
+    'If the target URI already names a complete, fully qualified host such as www.example.com, a proxy must forward it with that host name intact and must not rewrite it. A fully qualified name unambiguously identifies the intended destination, so altering it would misroute the request to the wrong server. (A proxy may still complete a bare, non-qualified host by appending its own domain, but that is a different case.) Preserving the host is what keeps the request reaching where the client meant it to go.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-modify-absolute-path-and-query.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-modify-absolute-path-and-query.rule.ts
@@ -14,6 +14,9 @@ export default httpRule('rfc9110/proxy-must-not-modify-absolute-path-and-query')
     'A proxy MUST NOT modify the "absolute-path" and "query" parts of the received target URI when forwarding it to the next inbound server except as required by that forwarding protocol. For example, a proxy forwarding a request to an origin server via HTTP/1.1 will replace an empty path with "/" or "*", depending on the request method.',
   )
   .summary('Proxy MUST NOT modify absolute-path and query parts of target URI.')
+  .explanation(
+    'A proxy must forward the path and query string of the target URI exactly as received, changing them only where the forwarding protocol itself demands it, such as substituting "/" or "*" for an empty path in HTTP/1.1. The path and query identify the specific resource and parameters the client asked for, so any unnecessary rewrite would silently point the request at a different resource. Passing them through unchanged is what guarantees the origin server sees the request the client actually made.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-must-not-transform-content-with-no-transform-directive.rule.ts
@@ -15,6 +15,9 @@ export default httpRule(
   .summary(
     'Proxy MUST NOT transform content when no-transform directive is present.',
   )
+  .explanation(
+    'When a response carries the no-transform cache directive, a proxy must forward its content byte-for-byte and must not alter it, for instance by transcoding or recompressing the payload. That directive is an explicit signal that the exact content matters, which is critical when integrity checks or digital signatures depend on it or for data like medical images and scientific results. Changes that leave the content itself unchanged, such as adding or removing transfer codings, are still allowed. Honoring no-transform is what preserves end-to-end content integrity.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-should-not-modify-endpoint-and-representation-headers.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/message-transformations/proxy-should-not-modify-endpoint-and-representation-headers.rule.ts
@@ -23,6 +23,9 @@ export default httpRule(
     "A proxy SHOULD NOT modify header fields that provide information about the endpoints of the communication chain, the resource state, or the selected representation (other than the content) unless the field's definition specifically allows such modification or the modification is deemed necessary for privacy or security.",
   )
   .summary('Proxy SHOULD NOT modify endpoint and representation headers.')
+  .explanation(
+    'A proxy should leave alone the header fields that describe the ends of the connection, the state of the resource, or which representation was selected, such as Content-Type, ETag, or Last-Modified, unless the field is defined to allow it or privacy and security genuinely require the change. These headers let clients and caches reason correctly about what the resource is and whether their copy is fresh. Rewriting them can corrupt caching, validation, and content handling, so they should pass through untouched.',
+  )
   .appliesTo('proxy')
   .rule((ctx) =>
     ctx.validateCapturedHttpTraces((trace, location) => {

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/client-may-send-upgrade-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/client-may-send-upgrade-header.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/client-may-send-upgrade-header')
     'A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.',
   )
   .summary('Client MAY send Upgrade header to invite protocol switch.')
+  .explanation(
+    'A client is allowed to list one or more protocol names in an Upgrade request header to ask the server to switch to a different protocol on the same connection, in order of preference. This is entirely optional and the server is free to ignore it, so Upgrade cannot force a change. It matters because it gives clients a lightweight, backward-compatible way to negotiate an upgrade (for example to WebSocket) without breaking servers that do not support it.',
+  )
   .appliesTo('client')
   // Surfaces use of the optional mechanism: the hint fires when a request
   // carries an Upgrade header, never on its absence.

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/sender-must-send-upgrade-connection-option.rule.ts
@@ -9,6 +9,9 @@ export default httpRule('rfc9110/sender-must-send-upgrade-connection-option')
     'A sender of Upgrade MUST also send an "Upgrade" connection option in the Connection header field to inform intermediaries not to forward this field. This ensures the Upgrade header is treated as a hop-by-hop header.',
   )
   .summary('Sender MUST include "Upgrade" in Connection header.')
+  .explanation(
+    'Whenever a message carries an Upgrade header, the sender must also list "Upgrade" as an option in the Connection header. The Connection header marks which fields are hop-by-hop, so listing Upgrade there tells proxies and other intermediaries to consume it rather than blindly forward it downstream. Without this, an intermediary could pass the Upgrade header on to a peer that never asked for a protocol switch, breaking the connection or causing an unintended and confusing upgrade attempt.',
+  )
   .rule((ctx) =>
     ctx.validateHttpTransactions(
       requestHeader('upgrade'),

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/server-may-send-upgrade-header-in-other-responses.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/server-may-send-upgrade-header-in-other-responses.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.',
   )
   .summary('Server MAY send Upgrade header in responses to advertise support.')
+  .explanation(
+    'A server is permitted to include an Upgrade header on ordinary responses, not just on 101 or 426, to advertise which protocols it can switch to (in order of preference) for a future request. This is optional. It matters because it lets a server hint at its upgrade capabilities ahead of time, so a client can decide whether to attempt an upgrade on a later request instead of guessing or making a wasted round trip.',
+  )
   .appliesTo('server')
   // Surfaces use of the optional advertising mechanism: the hint fires when a
   // response other than 101/426 (those carry Upgrade per their own MUST rules)

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-not-switch-to-non-indicated-protocol.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-not-switch-to-non-indicated-protocol.rule.ts
@@ -29,6 +29,9 @@ export default httpRule(
     "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field. The server can only switch to protocols explicitly requested by the client.",
   )
   .summary('Server MUST NOT switch to protocol not indicated by client.')
+  .explanation(
+    "When a server upgrades the connection, it may only switch to a protocol that the client actually named in its request Upgrade header; it cannot pick some other protocol on its own. The server may reorder the client's preferences or choose among them, but it must stay within that list. This matters because the client only knows how to speak the protocols it offered, so switching to an unrequested one would leave the client unable to understand the connection, breaking the exchange.",
+  )
   .appliesTo('server')
   .overrideAnalyticsRule((ctx) =>
     ctx.validateHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-send-upgrade-header-in-101-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-send-upgrade-header-in-101-response.rule.ts
@@ -13,6 +13,9 @@ export default httpRule(
     'A server that sends a 101 (Switching Protocols) response MUST send an Upgrade header field to indicate the new protocol(s) to which the connection is being switched. This informs the client which protocol is now in use.',
   )
   .summary('Server MUST send Upgrade header in 101 response.')
+  .explanation(
+    'A 101 (Switching Protocols) response must always carry an Upgrade header naming the protocol or protocols the connection is switching to. The 101 status only says a switch is happening; the Upgrade header says which protocol. It matters because without it the client is told the connection has changed but has no way to know what to speak next, leaving both ends out of sync and the connection unusable.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-send-upgrade-header-in-426-response.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/upgrade/server-must-send-upgrade-header-in-426-response.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference. This informs the client which protocols it should use.',
   )
   .summary('Server MUST send Upgrade header in 426 response.')
+  .explanation(
+    'A 426 (Upgrade Required) response must include an Upgrade header listing the acceptable protocols in order of preference. The 426 status tells the client its current protocol is not allowed and it must upgrade; the Upgrade header tells it what to upgrade to. It matters because without that list the client knows only that it must change protocols but has no idea which ones the server will accept, so it cannot complete the request.',
+  )
   .appliesTo('server')
   .rule((ctx) =>
     ctx.validateCommonHttpTransactions(

--- a/packages/rules-rfc-9110/src/rules/routing/user-agent-must-generate-host-or-authority-header.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/routing/user-agent-must-generate-host-or-authority-header.rule.ts
@@ -11,6 +11,9 @@ export default httpRule(
     'A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field. The target URI\'s authority information is critical for handling a request.',
   )
   .summary('User agent MUST generate a Host or :authority header in a request.')
+  .explanation(
+    'Every request must carry the target host and port, supplied either in a Host header (HTTP/1.1) or in the ":authority" pseudo-header (HTTP/2 and HTTP/3); a user agent must always include one of them. This information is what lets a server that hosts many sites on one address know which one the request is for. Without it the server cannot reliably route the request to the right resource, so the request is malformed and may be rejected.',
+  )
   .appliesTo('user-agent')
   .rule((ctx) =>
     ctx.validateHttpTransactions(


### PR DESCRIPTION
## What

Adds a user-facing `.explanation(...)` — a plain-language description of the rule plus why it matters — to **35 rules across the Routing, Message Abstraction, and Fields chapters** of `@thymian/rules-rfc-9110`. Part of the work for thymianofficial/thymian-internal#289.

## Which part of the specification

**RFC 9110 §7 — Routing**, **§6 — Message Abstraction**, and **§5 — Fields.**

- **Routing (§7):** target resource, `Host` / authority, `Connection` and connection options (§7.6.1), `Max-Forwards` (§7.6.2), `Via` (§7.6.3), `Upgrade` (§7.8), and message forwarding & transformations (§7.6–7.7).
- **Message Abstraction (§6):** message metadata and the `Trailer` field / trailer-section handling (§6.5–6.6).
- **Fields (§5):** field names (§5.1), field order (§5.3), and field-value construction — date/time formats and list-based field syntax (§5.6).

Each explanation is grounded in the exact RFC 9110 section the rule links via `.url(...)`.

## Scope & guarantees

- **Purely additive** — only `.explanation(...)` calls were added; no rule logic, metadata, `.description`, `.summary`, `.url`, or tests were changed (0 deletions).
- **Only user-facing rules** — rules whose `.type(...)` is purely `informational` (never surfaced to users) were intentionally left untouched.
- One `.explanation(...)` per rule.

## Verification

The full 171-rule change was verified green before splitting: `tsc --noEmit` clean, `eslint` 0 errors, `prettier` clean, and 105/105 package tests pass. This PR is a strict, additive subset of that verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
