### PR TITLE
feat(common-cli): wrap CLI output to terminal width

### DIFF
--- a/e2e-tests/src/env-utils.ts
+++ b/e2e-tests/src/env-utils.ts
@@ -17,6 +17,12 @@ export function getCleanEnv(): Record<string, string> {
   }
   env['FORCE_COLOR'] = '0';
 
+  // Pin the wrap width so custom-rendered CLI output wraps at a deterministic
+  // 80 columns regardless of the test runner's TTY (mirrors oclif's own
+  // `stdtermwidth` source). Without this, `terminalWidth()` would read the
+  // runner's real/absent TTY width and vary between environments.
+  env['OCLIF_COLUMNS'] = '80';
+
   // Force production mode so that oclif's ts-path.js does NOT attempt to
   // remap the compiled `dist/commands` directory back to the `src/commands`
   // source path.  The published npm package only ships `dist/`, so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -31791,6 +31791,7 @@
         "@inquirer/prompts": "^7.6.0",
         "@oclif/core": "^4.3.3",
         "@thymian/core": "0.0.0-PLACEHOLDER",
+        "string-width": "^4.2.3",
         "tslib": "^2.3.0",
         "wrap-ansi": "^7.0.0",
         "yaml": "^2.8.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31792,6 +31792,7 @@
         "@oclif/core": "^4.3.3",
         "@thymian/core": "0.0.0-PLACEHOLDER",
         "tslib": "^2.3.0",
+        "wrap-ansi": "^7.0.0",
         "yaml": "^2.8.3"
       }
     },

--- a/packages/common-cli/package.json
+++ b/packages/common-cli/package.json
@@ -46,6 +46,7 @@
     "@inquirer/prompts": "^7.6.0",
     "tslib": "^2.3.0",
     "yaml": "^2.8.3",
+    "wrap-ansi": "^7.0.0",
     "@oclif/core": "^4.3.3",
     "@thymian/core": "0.0.0-PLACEHOLDER"
   }

--- a/packages/common-cli/package.json
+++ b/packages/common-cli/package.json
@@ -47,6 +47,7 @@
     "tslib": "^2.3.0",
     "yaml": "^2.8.3",
     "wrap-ansi": "^7.0.0",
+    "string-width": "^4.2.3",
     "@oclif/core": "^4.3.3",
     "@thymian/core": "0.0.0-PLACEHOLDER"
   }

--- a/packages/common-cli/src/index.ts
+++ b/packages/common-cli/src/index.ts
@@ -13,6 +13,7 @@ export * as oclif from './oclif.js';
 export * as prompts from './prompts.js';
 export * from './read-plugins.js';
 export * from './render/cli-report.js';
+export { terminalWidth, wrap, wrapIndented } from './render/utils.js';
 export * from './thymian-base-command.js';
 export * from './thymian-config.js';
 export * from './thymian-config-schema.js';

--- a/packages/common-cli/src/render/cli-report.ts
+++ b/packages/common-cli/src/render/cli-report.ts
@@ -25,7 +25,12 @@ import {
   groupTestCaseExecutions,
   renderTestCaseExecution,
 } from './test-executions.js';
-import { pluralize, sortRecordByKey, sortRecordBySeverity } from './utils.js';
+import {
+  pluralize,
+  sortRecordByKey,
+  sortRecordBySeverity,
+  wrap,
+} from './utils.js';
 
 export function collectSeverityCounts(
   report: Report,
@@ -142,7 +147,9 @@ export function renderReport(
   lines.push('');
   lines.push('');
   lines.push(
-    `Summary: ${counts.error} ${ux.colorize(SEVERITY_COLORS.error, pluralize('error', counts.error))}, ${counts.warn} ${ux.colorize(SEVERITY_COLORS.warn, pluralize('warning', counts.warn))}, ${counts.hint} ${ux.colorize(SEVERITY_COLORS.hint, pluralize('hint', counts.hint))}, ${counts.info} ${ux.colorize(SEVERITY_COLORS.info, pluralize('info', counts.info))}.`,
+    wrap(
+      `Summary: ${counts.error} ${ux.colorize(SEVERITY_COLORS.error, pluralize('error', counts.error))}, ${counts.warn} ${ux.colorize(SEVERITY_COLORS.warn, pluralize('warning', counts.warn))}, ${counts.hint} ${ux.colorize(SEVERITY_COLORS.hint, pluralize('hint', counts.hint))}, ${counts.info} ${ux.colorize(SEVERITY_COLORS.info, pluralize('info', counts.info))}.`,
+    ),
   );
 
   return lines.join('\n').trimEnd();

--- a/packages/common-cli/src/render/cli-report.ts
+++ b/packages/common-cli/src/render/cli-report.ts
@@ -29,6 +29,7 @@ import {
   pluralize,
   sortRecordByKey,
   sortRecordBySeverity,
+  terminalWidth,
   wrap,
 } from './utils.js';
 
@@ -55,6 +56,20 @@ export function collectSeverityCounts(
   return counts;
 }
 
+/**
+ * `tool · type · ────` run separator, sized so the rule line fills the terminal
+ * width like the rest of the render layer (falling back to 80 columns when there
+ * is no finite width, e.g. piped output). The dash run always keeps at least one
+ * character so narrow terminals still show a divider.
+ */
+function runHeading(toolName: string, runType: string): string {
+  const prefix = `${toolName} · ${runType} · `;
+  const width = terminalWidth();
+  const fill = Number.isFinite(width) ? width : 80;
+
+  return prefix + '─'.repeat(Math.max(1, fill - prefix.length));
+}
+
 export function renderReport(
   report: Report,
   options: { format?: ThymianFormat; sortReportsBy?: SortReportsBy } = {},
@@ -78,11 +93,7 @@ export function renderReport(
   const resolveLocation = createLocationResolver(reportForLocationResolution);
 
   for (const [idx, run] of report.runs.entries()) {
-    lines.push(
-      `${run.tool.name} · ${run.runType} · ${'─'.repeat(
-        Math.max(1, 70 - run.tool.name.length),
-      )}`,
-    );
+    lines.push(runHeading(run.tool.name, run.runType));
     lines.push('');
 
     const ruleIndex = buildRuleIndex(run.rules);

--- a/packages/common-cli/src/render/create-execution-renderer.ts
+++ b/packages/common-cli/src/render/create-execution-renderer.ts
@@ -18,7 +18,7 @@ import {
 } from '@thymian/core';
 
 import { renderStatus } from './status.js';
-import { indent, sortRecordByKey } from './utils.js';
+import { indent, sortRecordByKey, wrapIndented } from './utils.js';
 
 type Groupable = LintExecution | TestCaseExecution | AnalyzeExecution;
 
@@ -88,7 +88,10 @@ export function createExecutionsRenderer<T extends Groupable>(
       }
 
       lines.push(
-        indent(indentationLevel) + renderHeading(key, group, ruleIndex),
+        ...wrapIndented(
+          renderHeading(key, group, ruleIndex),
+          indent(indentationLevel),
+        ),
       );
       lines.push('');
 
@@ -231,7 +234,7 @@ function endpointEntryRenderer<T extends Groupable>(
       rule?.summary?.text ?? rule?.description?.text ?? rule?.name,
     );
 
-    const lines = [indent(indentationLevel) + statusLine];
+    const lines = wrapIndented(statusLine, indent(indentationLevel));
 
     // The rule id is only rendered when we have the resolved descriptor,
     // because `rule` is itself looked up from `execution.ruleId` via the rule
@@ -301,10 +304,10 @@ function groupedEntryRenderer<T extends Groupable>(
 
     let detailIndentationLevel = indentationLevel + 1;
 
-    const lines = [`${indent(indentationLevel)}${symbol} ${label}`];
+    const lines = wrapIndented(label, `${indent(indentationLevel)}${symbol} `);
 
     if (message) {
-      lines.push(indent(indentationLevel + 1) + '➜ ' + message);
+      lines.push(...wrapIndented(message, `${indent(indentationLevel + 1)}➜ `));
       // if we print a message we must increase the indentation of the details
       detailIndentationLevel++;
     }

--- a/packages/common-cli/src/render/findings.ts
+++ b/packages/common-cli/src/render/findings.ts
@@ -6,7 +6,7 @@ import {
   successSymbol,
 } from '@thymian/core';
 
-import { indent } from './utils.js';
+import { indent, wrapIndented } from './utils.js';
 
 export function renderFindings(
   findings: FindingRecord[],
@@ -25,21 +25,34 @@ function renderFinding(
 ): string[] {
   switch (finding.kind) {
     case 'informational':
-      return [indent(indentationLevel) + `${infoSymbol} ${finding.title}`];
+      return wrapIndented(
+        finding.title,
+        `${indent(indentationLevel)}${infoSymbol} `,
+      );
     case 'assertion-success':
-      return [indent(indentationLevel) + `${successSymbol} ${finding.title}`];
+      return wrapIndented(
+        finding.title,
+        `${indent(indentationLevel)}${successSymbol} `,
+      );
     case 'assertion-failure': {
-      const lines = [
-        indent(indentationLevel) + `${errorSymbol} ${finding.title}`,
-      ];
+      const lines = wrapIndented(
+        finding.title,
+        `${indent(indentationLevel)}${errorSymbol} `,
+      );
       const { expected, actual } = finding as ReportAssertionFailure;
 
       if (actual !== undefined && expected !== undefined) {
         lines.push(
-          `${indent(indentationLevel + 2)}expected: ${JSON.stringify(expected)}`,
+          ...wrapIndented(
+            `expected: ${JSON.stringify(expected)}`,
+            indent(indentationLevel + 2),
+          ),
         );
         lines.push(
-          `${indent(indentationLevel + 2)}actual: ${JSON.stringify(actual)}`,
+          ...wrapIndented(
+            `actual: ${JSON.stringify(actual)}`,
+            indent(indentationLevel + 2),
+          ),
         );
       }
 
@@ -52,7 +65,10 @@ function renderFinding(
       // reaches that status line, so render each step's title here to avoid
       // silently dropping the other steps' violations.
       return options.renderRuleViolationTitle
-        ? [indent(indentationLevel) + `${errorSymbol} ${finding.title}`]
+        ? wrapIndented(
+            finding.title,
+            `${indent(indentationLevel)}${errorSymbol} `,
+          )
         : [];
     default:
       // Superseded/unknown finding kinds are intentionally not rendered.

--- a/packages/common-cli/src/render/test-executions.ts
+++ b/packages/common-cli/src/render/test-executions.ts
@@ -5,7 +5,7 @@ import type {
   RenderExecutionDetailsFn,
 } from './create-execution-renderer.js';
 import { renderFindings } from './findings.js';
-import { indent } from './utils.js';
+import { indent, wrapIndented } from './utils.js';
 
 export const groupTestCaseExecutions: GroupExecutionsFn<TestCaseExecution> = (
   execution,
@@ -24,7 +24,10 @@ export const renderTestCaseExecution: RenderExecutionDetailsFn<
   for (const [idx, step] of execution.steps.entries()) {
     lines.push(indent(indentationLevel) + '│');
     lines.push(
-      `${indent(indentationLevel)}${idx === lastStepIdx ? '└──' : '├──'} ${step.name}: ${locationResolver(step.location, toolRun.thymianFormatVersion)}`,
+      ...wrapIndented(
+        `${step.name}: ${locationResolver(step.location, toolRun.thymianFormatVersion)}`,
+        `${indent(indentationLevel)}${idx === lastStepIdx ? '└──' : '├──'} `,
+      ),
     );
     lines.push(
       ...renderFindings(step.findings, indentationLevel + 3, {

--- a/packages/common-cli/src/render/utils.ts
+++ b/packages/common-cli/src/render/utils.ts
@@ -1,5 +1,6 @@
 import { settings } from '@oclif/core';
 import { compareSeverityGroupKeys } from '@thymian/core';
+import stringWidth from 'string-width';
 import wrapAnsi from 'wrap-ansi';
 
 const SINGLE_INDENTATION = '  ';
@@ -31,13 +32,20 @@ function termwidth(stream: NodeJS.WriteStream): number {
   return width;
 }
 
-/** A positive integer parsed from `value`, or `undefined` if it is not one. */
+/**
+ * A positive integer parsed from `value`, or `undefined` if it is not one.
+ * Strings are parsed strictly via `Number(...)` (not `parseInt`), so a
+ * partially-numeric override like `"80cols"` is rejected rather than silently
+ * pinning the width to 80.
+ */
 function positiveInt(value: string | number | undefined): number | undefined {
-  const parsed = typeof value === 'string' ? Number.parseInt(value, 10) : value;
+  if (value === undefined) {
+    return undefined;
+  }
 
-  return typeof parsed === 'number' && Number.isInteger(parsed) && parsed > 0
-    ? parsed
-    : undefined;
+  const parsed = typeof value === 'string' ? Number(value) : value;
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 /**
@@ -121,12 +129,15 @@ export function wrapIndented(
   );
 }
 
-const ESC = String.fromCharCode(27);
-const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;]*m`, 'g');
-
-/** Visible column width of a string, ignoring ANSI SGR escape codes. */
+/**
+ * Visible terminal-column width of a string. Uses `string-width` — the same
+ * measurement `wrap-ansi` applies to content — so hanging-indent columns stay
+ * consistent with where the wrapped text actually breaks, including for wide
+ * (CJK/emoji) glyphs and surrogate pairs where a raw `.length` would diverge.
+ * ANSI SGR escape codes are ignored (stripped internally by `string-width`).
+ */
 function visibleWidth(value: string): number {
-  return value.replace(ANSI_PATTERN, '').length;
+  return stringWidth(value);
 }
 
 export function pluralize(word: string, length: number): string {

--- a/packages/common-cli/src/render/utils.ts
+++ b/packages/common-cli/src/render/utils.ts
@@ -1,9 +1,94 @@
+import { settings } from '@oclif/core';
 import { compareSeverityGroupKeys } from '@thymian/core';
+import wrapAnsi from 'wrap-ansi';
 
 const SINGLE_INDENTATION = '  ';
 
 export function indent(times: number): string {
   return SINGLE_INDENTATION.repeat(times);
+}
+
+/**
+ * Mirror of `@oclif/core`'s internal `screen.js` `termwidth`, reachable only
+ * via the public API (the private module is not exported). Clamps a real TTY
+ * width the same way oclif does: non-TTY → 80, `< 1` → 80, `< 40` → 40.
+ */
+function termwidth(stream: NodeJS.WriteStream): number {
+  if (!stream.isTTY) {
+    return 80;
+  }
+
+  const width = stream.getWindowSize?.()[0] ?? 80;
+
+  if (width < 1) {
+    return 80;
+  }
+
+  if (width < 40) {
+    return 40;
+  }
+
+  return width;
+}
+
+/**
+ * The terminal width oclif itself wraps help/errors at: `OCLIF_COLUMNS` env,
+ * then `settings.columns` (`globalThis.oclif`), else the clamped real
+ * `process.stdout` width. Computed per-call so `OCLIF_COLUMNS` and stdout
+ * changes are honoured (e.g. in tests).
+ */
+export function terminalWidth(): number {
+  const columns =
+    Number.parseInt(process.env.OCLIF_COLUMNS ?? '', 10) || settings.columns;
+
+  return columns || termwidth(process.stdout);
+}
+
+/**
+ * ANSI-aware hard wrap at the current terminal width, reserving `indentColumns`
+ * for indentation already consumed on the line (glyphs + leading spaces).
+ * Returns the wrapped text WITHOUT re-applying the indent — callers that need
+ * hanging indentation should use {@link wrapIndented}.
+ */
+export function wrap(text: string, indentColumns = 0): string {
+  const width = Math.max(terminalWidth() - indentColumns, 1);
+
+  return wrapAnsi(text, width, { hard: true });
+}
+
+/**
+ * Wraps leaf prose and re-applies indentation as a HANGING indent: the caller
+ * supplies the first line's prefix (indent + optional tree glyph, e.g.
+ * `"  ├── "`); continuation lines are prefixed with an equal number of spaces
+ * so they align under the content and the glyph is never repeated. Wrapping
+ * happens at `terminalWidth() - continuationColumns` (the visible, ANSI-stripped
+ * width of `firstPrefix` by default) so the content column is consistent across
+ * all lines.
+ *
+ * @param text the prose to wrap (may contain ANSI codes)
+ * @param firstPrefix the exact prefix for the first line (indent + glyph)
+ * @param continuationColumns spaces to indent continuation lines to; defaults
+ *   to the visible width of `firstPrefix`
+ */
+export function wrapIndented(
+  text: string,
+  firstPrefix: string,
+  continuationColumns = visibleWidth(firstPrefix),
+): string[] {
+  const wrapped = wrap(text, continuationColumns).split('\n');
+  const continuation = ' '.repeat(continuationColumns);
+
+  return wrapped.map((line, index) =>
+    index === 0 ? firstPrefix + line : continuation + line,
+  );
+}
+
+const ESC = String.fromCharCode(27);
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;]*m`, 'g');
+
+/** Visible column width of a string, ignoring ANSI SGR escape codes. */
+function visibleWidth(value: string): number {
+  return value.replace(ANSI_PATTERN, '').length;
 }
 
 export function pluralize(word: string, length: number): string {

--- a/packages/common-cli/src/render/utils.ts
+++ b/packages/common-cli/src/render/utils.ts
@@ -31,29 +31,61 @@ function termwidth(stream: NodeJS.WriteStream): number {
   return width;
 }
 
-/**
- * The terminal width oclif itself wraps help/errors at: `OCLIF_COLUMNS` env,
- * then `settings.columns` (`globalThis.oclif`), else the clamped real
- * `process.stdout` width. Computed per-call so `OCLIF_COLUMNS` and stdout
- * changes are honoured (e.g. in tests).
- */
-export function terminalWidth(): number {
-  const columns =
-    Number.parseInt(process.env.OCLIF_COLUMNS ?? '', 10) || settings.columns;
+/** A positive integer parsed from `value`, or `undefined` if it is not one. */
+function positiveInt(value: string | number | undefined): number | undefined {
+  const parsed = typeof value === 'string' ? Number.parseInt(value, 10) : value;
 
-  return columns || termwidth(process.stdout);
+  return typeof parsed === 'number' && Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : undefined;
 }
 
 /**
- * ANSI-aware hard wrap at the current terminal width, reserving `indentColumns`
+ * The terminal width oclif itself wraps help/errors at: an explicit
+ * `OCLIF_COLUMNS` env, then `settings.columns` (`globalThis.oclif`), else the
+ * clamped real `process.stdout` width. Computed per-call so `OCLIF_COLUMNS` and
+ * stdout changes are honoured (e.g. in tests). Only *positive* overrides are
+ * accepted, so a bogus `OCLIF_COLUMNS` (e.g. `-1` or a non-number) falls
+ * through instead of collapsing every line to a single column.
+ *
+ * Returns `Infinity` when stdout is not a TTY and no width was pinned: piped or
+ * redirected output must be emitted verbatim so paths, JSON and other tokens
+ * survive `grep`/copy-paste rather than being reflowed at an arbitrary width.
+ */
+export function terminalWidth(): number {
+  const override =
+    positiveInt(process.env.OCLIF_COLUMNS) ?? positiveInt(settings.columns);
+
+  if (override !== undefined) {
+    return override;
+  }
+
+  return process.stdout.isTTY
+    ? termwidth(process.stdout)
+    : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * ANSI-aware soft wrap at the current terminal width, reserving `indentColumns`
  * for indentation already consumed on the line (glyphs + leading spaces).
  * Returns the wrapped text WITHOUT re-applying the indent — callers that need
  * hanging indentation should use {@link wrapIndented}.
+ *
+ * When there is no finite target width (non-TTY, no pinned columns) the text is
+ * returned verbatim. Wrapping is soft (`hard: false`) so unbreakable tokens —
+ * file paths, URLs, JSON blobs, rule identifiers — are never split mid-token
+ * and stay copy-paste/`grep`-able; only whitespace-separated prose reflows.
  */
 export function wrap(text: string, indentColumns = 0): string {
-  const width = Math.max(terminalWidth() - indentColumns, 1);
+  const available = terminalWidth();
 
-  return wrapAnsi(text, width, { hard: true });
+  if (!Number.isFinite(available)) {
+    return text;
+  }
+
+  const width = Math.max(available - indentColumns, 1);
+
+  return wrapAnsi(text, width, { hard: false });
 }
 
 /**
@@ -75,6 +107,12 @@ export function wrapIndented(
   firstPrefix: string,
   continuationColumns = visibleWidth(firstPrefix),
 ): string[] {
+  // Empty content would otherwise emit a lone prefix/glyph line (e.g. a bare
+  // tree branch with nothing after it); render nothing instead.
+  if (text === '') {
+    return [];
+  }
+
   const wrapped = wrap(text, continuationColumns).split('\n');
   const continuation = ' '.repeat(continuationColumns);
 

--- a/packages/common-cli/test/cli-report-renderer.test.ts
+++ b/packages/common-cli/test/cli-report-renderer.test.ts
@@ -1,5 +1,5 @@
 import { ThymianFormat } from '@thymian/core';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { renderReport } from '../src/render/cli-report.js';
 
@@ -734,6 +734,106 @@ describe('cli report renderer', () => {
       );
       // Findings still render beneath each case.
       expect(output).toContain('✖ boom a');
+    });
+  });
+
+  describe('wraps long leaf prose while preserving indentation and tree alignment', () => {
+    const originalColumns = process.env.OCLIF_COLUMNS;
+
+    afterEach(() => {
+      if (originalColumns === undefined) {
+        delete process.env.OCLIF_COLUMNS;
+      } else {
+        process.env.OCLIF_COLUMNS = originalColumns;
+      }
+    });
+
+    it('hang-indents a long multi-step finding under its tree branch', () => {
+      process.env.OCLIF_COLUMNS = '50';
+
+      const longTitle =
+        'the response body did not match the expected schema and this message is deliberately long enough to force wrapping';
+
+      const output = stripAnsi(
+        renderReport({
+          reportId: 'report-1',
+          createdAt: new Date().toISOString(),
+          runs: [
+            {
+              runId: 'run-1',
+              tool: { name: '@thymian/plugin-http-tester' },
+              runType: 'test',
+              runAt: new Date().toISOString(),
+              executions: [
+                {
+                  kind: 'test',
+                  status: { kind: 'failed' },
+                  name: 'happy path',
+                  steps: [
+                    {
+                      name: 'Step 1',
+                      location: { type: 'custom', value: 'GET /pets' },
+                      findings: [
+                        {
+                          id: 'a-1',
+                          kind: 'assertion-success',
+                          title: 'ok',
+                        },
+                      ],
+                    },
+                    {
+                      name: 'Step 2',
+                      location: { type: 'custom', value: 'POST /pets' },
+                      findings: [
+                        {
+                          id: 'a-2',
+                          kind: 'assertion-failure',
+                          title: longTitle,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      const lines = output.split('\n');
+
+      // Prose lines stay within the pinned 50-col width. The run-heading
+      // separator (`tool · type · ────`) is a fixed-shape divider, not wrapped
+      // prose, so it is exempt.
+      for (const line of lines) {
+        if (line.includes('·')) {
+          continue;
+        }
+        expect(line.length).toBeLessThanOrEqual(50);
+      }
+
+      // The finding wrapped onto more than one line.
+      const firstFindingLineIdx = lines.findIndex((line) =>
+        line.includes('✖ the response body did not'),
+      );
+      expect(firstFindingLineIdx).toBeGreaterThanOrEqual(0);
+
+      const firstFindingLine = lines[firstFindingLineIdx]!;
+      const continuationLine = lines[firstFindingLineIdx + 1]!;
+
+      // The glyph appears on the first line only; continuation hangs under the
+      // content column (after `✖ `) and never repeats the glyph.
+      const glyphColumn = firstFindingLine.indexOf('✖');
+      const contentColumn = glyphColumn + 2; // '✖ '
+      expect(continuationLine).not.toContain('✖');
+      expect(continuationLine.slice(0, contentColumn)).toBe(
+        ' '.repeat(contentColumn),
+      );
+      expect(continuationLine.trimStart().length).toBeGreaterThan(0);
+
+      // Tree branch glyphs still render for the steps.
+      expect(output).toContain('├── Step 1: GET /pets');
+      expect(output).toContain('└── Step 2: POST /pets');
     });
   });
 

--- a/packages/common-cli/test/cli-report-renderer.test.ts
+++ b/packages/common-cli/test/cli-report-renderer.test.ts
@@ -802,13 +802,9 @@ describe('cli report renderer', () => {
 
       const lines = output.split('\n');
 
-      // Prose lines stay within the pinned 50-col width. The run-heading
-      // separator (`tool · type · ────`) is a fixed-shape divider, not wrapped
-      // prose, so it is exempt.
+      // Every line — prose and the width-aware run-heading divider alike — stays
+      // within the pinned 50-col width.
       for (const line of lines) {
-        if (line.includes('·')) {
-          continue;
-        }
         expect(line.length).toBeLessThanOrEqual(50);
       }
 

--- a/packages/common-cli/test/terminal-width.test.ts
+++ b/packages/common-cli/test/terminal-width.test.ts
@@ -55,10 +55,23 @@ describe('terminalWidth', () => {
     expect(terminalWidth()).toBe(100);
   });
 
-  it('falls back to a stable 80 for non-TTY output', () => {
+  it('reports no finite width for non-TTY output (so it is not wrapped)', () => {
     setTty(false);
 
-    expect(terminalWidth()).toBe(80);
+    expect(terminalWidth()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('ignores a non-positive or non-numeric OCLIF_COLUMNS', () => {
+    setTty(true, 120);
+
+    process.env.OCLIF_COLUMNS = '-1';
+    expect(terminalWidth()).toBe(120);
+
+    process.env.OCLIF_COLUMNS = '0';
+    expect(terminalWidth()).toBe(120);
+
+    process.env.OCLIF_COLUMNS = 'wide';
+    expect(terminalWidth()).toBe(120);
   });
 
   it('falls back to oclif settings.columns when OCLIF_COLUMNS is unset', () => {
@@ -100,6 +113,10 @@ describe('terminalWidth', () => {
 
 describe('wrap', () => {
   const originalColumns = process.env.OCLIF_COLUMNS;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process.stdout,
+    'isTTY',
+  );
 
   afterEach(() => {
     if (originalColumns === undefined) {
@@ -107,11 +124,15 @@ describe('wrap', () => {
     } else {
       process.env.OCLIF_COLUMNS = originalColumns;
     }
+
+    if (originalDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', originalDescriptor);
+    }
   });
 
-  it('hard-wraps long text at the terminal width', () => {
+  it('soft-wraps whitespace-separated prose at the terminal width', () => {
     process.env.OCLIF_COLUMNS = '20';
-    const text = 'x'.repeat(50);
+    const text = 'the quick brown fox jumps over the lazy dog';
 
     const wrapped = wrap(text);
     const lines = wrapped.split('\n');
@@ -122,9 +143,30 @@ describe('wrap', () => {
     }
   });
 
+  it('never splits an unbreakable token mid-token', () => {
+    process.env.OCLIF_COLUMNS = '20';
+    const path =
+      'specs/deeply/nested/openapi-specification-file-v3.yaml#/components';
+
+    // A token with no break points must stay on a single line so it can still
+    // be copy-pasted and grepped, even though it overflows the width.
+    expect(wrap(path)).toBe(path);
+  });
+
+  it('emits text verbatim when there is no finite width (non-TTY)', () => {
+    delete process.env.OCLIF_COLUMNS;
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    const text = 'the quick brown fox jumps over the lazy dog';
+
+    expect(wrap(text)).toBe(text);
+  });
+
   it('reserves indentColumns from the available width', () => {
     process.env.OCLIF_COLUMNS = '20';
-    const text = 'x'.repeat(50);
+    const text = 'the quick brown fox jumps over the lazy dog';
 
     const wrapped = wrap(text, 5);
 
@@ -165,6 +207,10 @@ describe('wrapIndented', () => {
     } else {
       process.env.OCLIF_COLUMNS = originalColumns;
     }
+  });
+
+  it('renders nothing for empty content (no dangling glyph line)', () => {
+    expect(wrapIndented('', '  ├── ')).toEqual([]);
   });
 
   it('applies the glyph to the first line only and hang-indents the rest', () => {

--- a/packages/common-cli/test/terminal-width.test.ts
+++ b/packages/common-cli/test/terminal-width.test.ts
@@ -13,11 +13,13 @@ const visibleWidth = (value: string): number => stripAnsi(value).length;
 
 describe('terminalWidth', () => {
   const originalColumns = process.env.OCLIF_COLUMNS;
+  const hadSettingsColumns = 'columns' in settings;
   const originalSettingsColumns = settings.columns;
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     process.stdout,
     'isTTY',
   );
+  const originalGetWindowSize = process.stdout.getWindowSize;
 
   beforeEach(() => {
     delete process.env.OCLIF_COLUMNS;
@@ -31,11 +33,21 @@ describe('terminalWidth', () => {
       process.env.OCLIF_COLUMNS = originalColumns;
     }
 
-    settings.columns = originalSettingsColumns;
+    // Restore `settings.columns` faithfully: delete it when it was originally
+    // absent rather than leaving an explicit `undefined` behind.
+    if (hadSettingsColumns) {
+      settings.columns = originalSettingsColumns;
+    } else {
+      delete settings.columns;
+    }
 
     if (originalDescriptor) {
       Object.defineProperty(process.stdout, 'isTTY', originalDescriptor);
     }
+
+    // `setTty` may have stubbed `getWindowSize`; restore the real one so it does
+    // not leak into later tests.
+    process.stdout.getWindowSize = originalGetWindowSize;
   });
 
   const setTty = (isTTY: boolean, columns?: number): void => {
@@ -71,6 +83,11 @@ describe('terminalWidth', () => {
     expect(terminalWidth()).toBe(120);
 
     process.env.OCLIF_COLUMNS = 'wide';
+    expect(terminalWidth()).toBe(120);
+
+    // Partially-numeric values are rejected (strict `Number(...)`, not
+    // `parseInt`), so `"80cols"` does not accidentally pin the width to 80.
+    process.env.OCLIF_COLUMNS = '80cols';
     expect(terminalWidth()).toBe(120);
   });
 
@@ -211,6 +228,21 @@ describe('wrapIndented', () => {
 
   it('renders nothing for empty content (no dangling glyph line)', () => {
     expect(wrapIndented('', '  ├── ')).toEqual([]);
+  });
+
+  it('hang-indents by terminal-column width for wide-glyph prefixes', () => {
+    process.env.OCLIF_COLUMNS = '20';
+    // `你` is a double-width (2-column) glyph; the prefix `你 ` occupies 3
+    // columns even though its `.length` is 2. Continuation lines must align to
+    // the 3-column content position, matching where `wrap-ansi` breaks.
+    const lines = wrapIndented('word '.repeat(20).trim(), '你 ');
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]!.startsWith('你 ')).toBe(true);
+    for (const line of lines.slice(1)) {
+      expect(line.startsWith('   ')).toBe(true); // 3 spaces, not 2
+      expect(line[3]).not.toBe(' ');
+    }
   });
 
   it('applies the glyph to the first line only and hang-indents the rest', () => {

--- a/packages/common-cli/test/terminal-width.test.ts
+++ b/packages/common-cli/test/terminal-width.test.ts
@@ -1,0 +1,204 @@
+import { settings } from '@oclif/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { terminalWidth, wrap, wrapIndented } from '../src/render/utils.js';
+
+// ANSI SGR helper so we can assert visible-width wrapping while colour codes
+// stay intact.
+const ESC = String.fromCharCode(27);
+const red = (value: string): string => `${ESC}[31m${value}${ESC}[39m`;
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;]*m`, 'g');
+const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');
+const visibleWidth = (value: string): number => stripAnsi(value).length;
+
+describe('terminalWidth', () => {
+  const originalColumns = process.env.OCLIF_COLUMNS;
+  const originalSettingsColumns = settings.columns;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process.stdout,
+    'isTTY',
+  );
+
+  beforeEach(() => {
+    delete process.env.OCLIF_COLUMNS;
+    delete settings.columns;
+  });
+
+  afterEach(() => {
+    if (originalColumns === undefined) {
+      delete process.env.OCLIF_COLUMNS;
+    } else {
+      process.env.OCLIF_COLUMNS = originalColumns;
+    }
+
+    settings.columns = originalSettingsColumns;
+
+    if (originalDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', originalDescriptor);
+    }
+  });
+
+  const setTty = (isTTY: boolean, columns?: number): void => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: isTTY,
+    });
+    if (columns !== undefined) {
+      process.stdout.getWindowSize = () => [columns, 24];
+    }
+  };
+
+  it('honours OCLIF_COLUMNS over the real TTY width', () => {
+    process.env.OCLIF_COLUMNS = '100';
+    setTty(true, 200);
+
+    expect(terminalWidth()).toBe(100);
+  });
+
+  it('falls back to a stable 80 for non-TTY output', () => {
+    setTty(false);
+
+    expect(terminalWidth()).toBe(80);
+  });
+
+  it('falls back to oclif settings.columns when OCLIF_COLUMNS is unset', () => {
+    settings.columns = 123;
+    // Even a real/non-TTY width must not win over an explicit settings.columns.
+    setTty(false);
+
+    expect(terminalWidth()).toBe(123);
+  });
+
+  it('prefers OCLIF_COLUMNS over settings.columns', () => {
+    process.env.OCLIF_COLUMNS = '100';
+    settings.columns = 55;
+    setTty(true, 200);
+
+    expect(terminalWidth()).toBe(100);
+  });
+
+  it('clamps a very narrow TTY width up to 40', () => {
+    setTty(true, 20);
+
+    expect(terminalWidth()).toBe(40);
+  });
+
+  it('passes a wide TTY width through unclamped', () => {
+    setTty(true, 200);
+
+    expect(terminalWidth()).toBe(200);
+  });
+
+  it('reads OCLIF_COLUMNS per-call (not memoised at import)', () => {
+    process.env.OCLIF_COLUMNS = '50';
+    expect(terminalWidth()).toBe(50);
+
+    process.env.OCLIF_COLUMNS = '120';
+    expect(terminalWidth()).toBe(120);
+  });
+});
+
+describe('wrap', () => {
+  const originalColumns = process.env.OCLIF_COLUMNS;
+
+  afterEach(() => {
+    if (originalColumns === undefined) {
+      delete process.env.OCLIF_COLUMNS;
+    } else {
+      process.env.OCLIF_COLUMNS = originalColumns;
+    }
+  });
+
+  it('hard-wraps long text at the terminal width', () => {
+    process.env.OCLIF_COLUMNS = '20';
+    const text = 'x'.repeat(50);
+
+    const wrapped = wrap(text);
+    const lines = wrapped.split('\n');
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('reserves indentColumns from the available width', () => {
+    process.env.OCLIF_COLUMNS = '20';
+    const text = 'x'.repeat(50);
+
+    const wrapped = wrap(text, 5);
+
+    for (const line of wrapped.split('\n')) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it('measures by visible width and keeps ANSI codes intact', () => {
+    process.env.OCLIF_COLUMNS = '10';
+    const coloured = red('hello world this is long');
+
+    const wrapped = wrap(coloured);
+
+    // Colour codes survive.
+    expect(wrapped).toContain(`${ESC}[31m`);
+    // Every wrapped line is measured by visible width (ANSI ignored), so no
+    // line's visible content exceeds the pinned width.
+    const wrappedLines = wrapped.split('\n');
+    expect(wrappedLines.length).toBeGreaterThan(1);
+    for (const line of wrappedLines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(10);
+    }
+    // All the original words survive across the wrapped lines (wrap-ansi drops
+    // the whitespace it wraps at, so re-join on spaces to compare word order).
+    expect(stripAnsi(wrapped).split(/\s+/).join(' ')).toBe(
+      'hello world this is long',
+    );
+  });
+});
+
+describe('wrapIndented', () => {
+  const originalColumns = process.env.OCLIF_COLUMNS;
+
+  afterEach(() => {
+    if (originalColumns === undefined) {
+      delete process.env.OCLIF_COLUMNS;
+    } else {
+      process.env.OCLIF_COLUMNS = originalColumns;
+    }
+  });
+
+  it('applies the glyph to the first line only and hang-indents the rest', () => {
+    process.env.OCLIF_COLUMNS = '20';
+    const text = 'a very long finding message that must wrap several times';
+
+    const lines = wrapIndented(text, '  ├── ');
+
+    expect(lines.length).toBeGreaterThan(1);
+    // First line carries the glyph.
+    expect(lines[0]!.startsWith('  ├── ')).toBe(true);
+    // Continuation lines align under the content with equal-width spaces and
+    // never repeat the glyph.
+    for (const line of lines.slice(1)) {
+      expect(line.startsWith('      ')).toBe(true);
+      expect(line).not.toContain('├──');
+    }
+    // Every produced line stays within the pinned width.
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('preserves the content column across all lines', () => {
+    process.env.OCLIF_COLUMNS = '24';
+    const lines = wrapIndented('word '.repeat(20).trim(), '    - ');
+
+    const contentColumn = 6; // '    - '.length
+    for (const line of lines) {
+      expect(line.slice(0, contentColumn).trim()).toMatch(/^(-)?$/);
+    }
+    expect(lines[0]!.startsWith('    - ')).toBe(true);
+    for (const line of lines.slice(1)) {
+      expect(line.startsWith('      ')).toBe(true);
+    }
+  });
+});

--- a/packages/thymian/src/commands/feedback.ts
+++ b/packages/thymian/src/commands/feedback.ts
@@ -3,6 +3,7 @@ import {
   oclif,
   prompts,
   ThymianBaseCommand,
+  wrap,
 } from '@thymian/common-cli';
 import open from 'open';
 
@@ -22,12 +23,14 @@ export class Feedback extends ThymianBaseCommand<typeof Feedback> {
   override async run(): Promise<void> {
     const lastError = await this.errorCache?.read();
 
-    this.log('✨ Thank you for your feedback! ✨');
+    this.log(wrap('✨ Thank you for your feedback! ✨'));
     this.log();
 
     if (lastError) {
       this.log(
-        `${oclif.ux.colorize('yellow', '⚠')} It looks like you encountered an error while running the ${oclif.ux.colorize('cyan', lastError.commandName)} command recently.`,
+        wrap(
+          `${oclif.ux.colorize('yellow', '⚠')} It looks like you encountered an error while running the ${oclif.ux.colorize('cyan', lastError.commandName)} command recently.`,
+        ),
       );
       this.log();
 

--- a/packages/thymian/src/commands/generate/config.ts
+++ b/packages/thymian/src/commands/generate/config.ts
@@ -6,6 +6,7 @@ import {
   defaultConfig,
   specFlag,
   ThymianBaseCommand,
+  wrap,
 } from '@thymian/common-cli';
 import { Flags, ux } from '@thymian/common-cli/oclif';
 import { confirm, input, select } from '@thymian/common-cli/prompts';
@@ -62,7 +63,7 @@ export default class GenerateConfig extends ThymianBaseCommand<
     // Continuation flow: if default config exists and no explicit output, offer named config
     if (!this.flags.output && existsSync(outputPath)) {
       if (interactive) {
-        this.log(`A configuration file already exists at ${outputPath}.`);
+        this.log(wrap(`A configuration file already exists at ${outputPath}.`));
         const customPath = await input({
           message:
             'Enter a path for the new configuration file (e.g. my-api.config.yaml):',
@@ -131,7 +132,9 @@ export default class GenerateConfig extends ThymianBaseCommand<
           // In non-interactive mode with multiple specs, use the first one
           selectedSpecs = [{ type: 'openapi', location: detectedFiles[0]! }];
           this.log(
-            `Multiple specification files detected. Using the first one: ${detectedFiles[0]}`,
+            wrap(
+              `Multiple specification files detected. Using the first one: ${detectedFiles[0]}`,
+            ),
           );
         }
       }
@@ -149,7 +152,9 @@ export default class GenerateConfig extends ThymianBaseCommand<
     await writeFile(outputPath, yamlContent, { encoding: 'utf-8' });
 
     this.log(
-      `${ux.colorize('green', 'Configuration written to')} ${relative(cwd, outputPath)}`,
+      wrap(
+        `${ux.colorize('green', 'Configuration written to')} ${relative(cwd, outputPath)}`,
+      ),
     );
   }
 
@@ -158,7 +163,7 @@ export default class GenerateConfig extends ThymianBaseCommand<
   ): Promise<string> {
     if (detectedFiles.length === 0) {
       // No files detected — ask for manual entry
-      this.log('No OpenAPI/Swagger specification files detected.');
+      this.log(wrap('No OpenAPI/Swagger specification files detected.'));
       const manualPath = await input({
         message: 'Enter the path to your OpenAPI specification file:',
       });

--- a/packages/thymian/src/commands/generate/rule.ts
+++ b/packages/thymian/src/commands/generate/rule.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import { EOL } from 'node:os';
 import { join, relative } from 'node:path';
 
-import { ThymianBaseCommand } from '@thymian/common-cli';
+import { ThymianBaseCommand, wrap } from '@thymian/common-cli';
 import { Flags, ux } from '@thymian/common-cli/oclif';
 import { checkbox, input, select } from '@thymian/common-cli/prompts';
 import {
@@ -191,7 +191,9 @@ export default class GenerateRule extends ThymianBaseCommand<
       const outputPath = join(this.flags.cwd, this.flags.output);
       await writeFile(outputPath, template, { encoding: 'utf-8' });
       this.log(
-        `${ux.colorize('green', 'Rule written to')} ${relative(this.flags.cwd, outputPath)}`,
+        wrap(
+          `${ux.colorize('green', 'Rule written to')} ${relative(this.flags.cwd, outputPath)}`,
+        ),
       );
     } else {
       this.log(template);

--- a/packages/thymian/src/commands/plugins/list.ts
+++ b/packages/thymian/src/commands/plugins/list.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 
-import { BaseCliRunCommand } from '@thymian/common-cli';
+import { BaseCliRunCommand, wrap } from '@thymian/common-cli';
 import { ux } from '@thymian/common-cli/oclif';
 
 export default class List extends BaseCliRunCommand<typeof List> {
@@ -11,7 +11,7 @@ export default class List extends BaseCliRunCommand<typeof List> {
       this.log(
         this.thymian.plugins
           .map((plugin) =>
-            ux.colorize(this.config?.theme?.topic, plugin.plugin.name),
+            wrap(ux.colorize(this.config?.theme?.topic, plugin.plugin.name)),
           )
           .join(EOL),
       );

--- a/packages/thymian/src/commands/request.ts
+++ b/packages/thymian/src/commands/request.ts
@@ -1,4 +1,10 @@
-import { BaseCliRunCommand, oclif, prompts } from '@thymian/common-cli';
+import {
+  BaseCliRunCommand,
+  oclif,
+  prompts,
+  wrap,
+  wrapIndented,
+} from '@thymian/common-cli';
 import { Flags, ux } from '@thymian/common-cli/oclif';
 import {
   createContextFromEmitter,
@@ -128,17 +134,21 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
       testResults.cases.forEach((testResult) => {
         if (testResult.status === 'failed') {
           this.log(
-            oclif.ux.colorize(
-              'red',
-              `✖ ${testResult.name}: ${testResult.reason}`,
+            wrap(
+              oclif.ux.colorize(
+                'red',
+                `✖ ${testResult.name}: ${testResult.reason}`,
+              ),
             ),
           );
         }
         if (testResult.status === 'skipped') {
           this.log(
-            oclif.ux.colorize(
-              'yellow',
-              `⚠ ${testResult.name}: ${testResult.reason}`,
+            wrap(
+              oclif.ux.colorize(
+                'yellow',
+                `⚠ ${testResult.name}: ${testResult.reason}`,
+              ),
             ),
           );
         }
@@ -166,9 +176,16 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
           );
 
           if (assertionFailure.length > 0) {
-            this.log(ux.colorize('red', 'The following assertions failed:'));
+            this.log(
+              wrap(ux.colorize('red', 'The following assertions failed:')),
+            );
             assertionFailure.forEach((r) => {
-              this.log(ux.colorize('red', `  * ${r.message}`));
+              this.log(
+                wrapIndented(
+                  ux.colorize('red', r.message),
+                  ux.colorize('red', '  * '),
+                ).join('\n'),
+              );
             });
           }
         }
@@ -188,7 +205,7 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
         ? ux.colorize('green', `${status} ${statusText}`)
         : ux.colorize('red', `${status} ${statusText}`);
 
-    this.log(ux.colorize('bold', `${protocol} ${statusColor}`));
+    this.log(wrap(ux.colorize('bold', `${protocol} ${statusColor}`)));
 
     this.printHeaders(response.headers);
 
@@ -205,9 +222,9 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
     const path = urlObj.pathname + urlObj.search;
     const method = ux.colorize('blue', request.method.toUpperCase());
 
-    this.log(ux.colorize('bold', `${method} ${path} HTTP/1.1`));
+    this.log(wrap(ux.colorize('bold', `${method} ${path} HTTP/1.1`)));
 
-    this.log(`${ux.colorize('cyan', 'Host')}: ${urlObj.host}`);
+    this.log(wrap(`${ux.colorize('cyan', 'Host')}: ${urlObj.host}`));
     this.printHeaders(request.headers);
 
     this.log();
@@ -251,7 +268,7 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
       }
 
       const headerValue = Array.isArray(value) ? value.join(', ') : value;
-      this.log(`${ux.colorize('cyan', key)}: ${headerValue}`);
+      this.log(wrap(`${ux.colorize('cyan', key)}: ${headerValue}`));
     });
   }
 }

--- a/packages/thymian/src/commands/request.ts
+++ b/packages/thymian/src/commands/request.ts
@@ -205,7 +205,10 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
         ? ux.colorize('green', `${status} ${statusText}`)
         : ux.colorize('red', `${status} ${statusText}`);
 
-    this.log(wrap(ux.colorize('bold', `${protocol} ${statusColor}`)));
+    // Raw HTTP wire values are emitted verbatim (never wrapped): reflowing a
+    // status line or header would break copy-paste and alter values that
+    // contain significant whitespace.
+    this.log(ux.colorize('bold', `${protocol} ${statusColor}`));
 
     this.printHeaders(response.headers);
 
@@ -222,9 +225,9 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
     const path = urlObj.pathname + urlObj.search;
     const method = ux.colorize('blue', request.method.toUpperCase());
 
-    this.log(wrap(ux.colorize('bold', `${method} ${path} HTTP/1.1`)));
+    this.log(ux.colorize('bold', `${method} ${path} HTTP/1.1`));
 
-    this.log(wrap(`${ux.colorize('cyan', 'Host')}: ${urlObj.host}`));
+    this.log(`${ux.colorize('cyan', 'Host')}: ${urlObj.host}`);
     this.printHeaders(request.headers);
 
     this.log();
@@ -268,7 +271,9 @@ export default class RunRequest extends BaseCliRunCommand<typeof RunRequest> {
       }
 
       const headerValue = Array.isArray(value) ? value.join(', ') : value;
-      this.log(wrap(`${ux.colorize('cyan', key)}: ${headerValue}`));
+      // Header values are wire data — emit verbatim, never wrapped (see
+      // printRawHttp).
+      this.log(`${ux.colorize('cyan', key)}: ${headerValue}`);
     });
   }
 }

--- a/packages/thymian/src/commands/rules/list.ts
+++ b/packages/thymian/src/commands/rules/list.ts
@@ -9,6 +9,8 @@ import {
   mergeRuleSets,
   oclif,
   resolveRuleSeverity,
+  wrap,
+  wrapIndented,
 } from '@thymian/common-cli';
 import { Flags } from '@thymian/common-cli/oclif';
 import { loadRules, type Rule, type RuleType, ruleTypes } from '@thymian/core';
@@ -63,7 +65,7 @@ export default class ListRules extends BaseCliRunCommand<typeof ListRules> {
       : rules;
 
     if (filtered.length === 0) {
-      this.log('No rules found.');
+      this.log(wrap('No rules found.'));
       return;
     }
 
@@ -98,11 +100,13 @@ export default class ListRules extends BaseCliRunCommand<typeof ListRules> {
     }
 
     const topicColor = this.config?.theme?.topic;
-    const lines = sorted.map((rule) => formatRule(rule, topicColor));
+    const lines = sorted.flatMap((rule) =>
+      wrapIndented(formatRule(rule, topicColor).trimStart(), '  '),
+    );
 
     this.log(lines.join(EOL));
     this.log();
-    this.log(`${sorted.length} rule(s) loaded.`);
+    this.log(wrap(`${sorted.length} rule(s) loaded.`));
   }
 }
 

--- a/packages/thymian/src/commands/rules/list.ts
+++ b/packages/thymian/src/commands/rules/list.ts
@@ -101,7 +101,7 @@ export default class ListRules extends BaseCliRunCommand<typeof ListRules> {
 
     const topicColor = this.config?.theme?.topic;
     const lines = sorted.flatMap((rule) =>
-      wrapIndented(formatRule(rule, topicColor).trimStart(), '  '),
+      wrapIndented(formatRule(rule, topicColor), '  '),
     );
 
     this.log(lines.join(EOL));
@@ -152,7 +152,9 @@ function formatRule(rule: Rule, topicColor?: string): string {
   const coloredSeverity = colorizeSeverity(severity);
   const types = type.join(', ');
 
-  const parts = [`  ${coloredName}`, `[${coloredSeverity}]`, `(${types})`];
+  // The caller owns the list indentation (via `wrapIndented('  ', …)`), so the
+  // rule text is built without a leading indent.
+  const parts = [coloredName, `[${coloredSeverity}]`, `(${types})`];
 
   if (summary) {
     parts.push(`- ${summary}`);

--- a/packages/thymian/src/commands/serve.ts
+++ b/packages/thymian/src/commands/serve.ts
@@ -1,4 +1,4 @@
-import { BaseCliRunCommand } from '@thymian/common-cli';
+import { BaseCliRunCommand, wrap } from '@thymian/common-cli';
 
 export default class Serve extends BaseCliRunCommand<typeof Serve> {
   static override description = 'Run Thymian in serve mode.';
@@ -36,6 +36,6 @@ export default class Serve extends BaseCliRunCommand<typeof Serve> {
 
     await this.thymian.ready();
 
-    this.log(`Thymian is now in "serve" mode. Press "${quit}" to exit.`);
+    this.log(wrap(`Thymian is now in "serve" mode. Press "${quit}" to exit.`));
   }
 }

--- a/packages/thymian/src/commands/validate.ts
+++ b/packages/thymian/src/commands/validate.ts
@@ -1,6 +1,8 @@
 import {
   BaseCliRunCommand,
   classificationToExitCode,
+  wrap,
+  wrapIndented,
 } from '@thymian/common-cli';
 import { ux } from '@thymian/common-cli/oclif';
 
@@ -42,12 +44,15 @@ export default class Validate extends BaseCliRunCommand<typeof Validate> {
             ? '✖'
             : '⚠';
 
-      ux.stdout(`${icon} ${result.location}`);
+      ux.stdout(wrapIndented(result.location, `${icon} `).join('\n'));
 
       if (result.issues.length > 0) {
         for (const issue of result.issues) {
           ux.stdout(
-            `    - ${issue.message}${issue.path ? ` (at ${issue.path})` : ''}`,
+            wrapIndented(
+              `${issue.message}${issue.path ? ` (at ${issue.path})` : ''}`,
+              '    - ',
+            ).join('\n'),
           );
         }
         ux.stdout();
@@ -55,14 +60,20 @@ export default class Validate extends BaseCliRunCommand<typeof Validate> {
     }
 
     if (exitCode === 0) {
-      ux.stdout('\nAll specifications are valid.');
+      ux.stdout('\n' + wrap('All specifications are valid.'));
     } else if (exitCode === 1) {
       ux.stdout(
-        `\n${outcome.results.filter((r) => r.status === 'failed').length} of ${totalResults} specifications are invalid.`,
+        '\n' +
+          wrap(
+            `${outcome.results.filter((r) => r.status === 'failed').length} of ${totalResults} specifications are invalid.`,
+          ),
       );
     } else {
       ux.stdout(
-        `\n${outcome.results.filter((r) => r.status === 'unsupported' || r.status === 'error').length} of ${totalResults} specifications could not be validated.`,
+        '\n' +
+          wrap(
+            `${outcome.results.filter((r) => r.status === 'unsupported' || r.status === 'error').length} of ${totalResults} specifications could not be validated.`,
+          ),
       );
     }
 

--- a/packages/thymian/src/hooks/feedback.ts
+++ b/packages/thymian/src/hooks/feedback.ts
@@ -1,9 +1,9 @@
-import { oclif, type ThymianFeedbackHook } from '@thymian/common-cli';
+import { oclif, type ThymianFeedbackHook, wrap } from '@thymian/common-cli';
 
 const hook: ThymianFeedbackHook = async () => {
   const message = `${oclif.ux.colorize('blueBright', `🚀  Tip: Found a bug or wanna give feedback? Run ${oclif.ux.colorize('bold', 'thymian feedback')}.`)}`;
 
-  console.log(message);
+  console.log(wrap(message));
   console.log();
 };
 


### PR DESCRIPTION
## What & why

Custom-rendered CLI output (reports, `validate`, `rules list`, `request`, etc.) was emitted without any width management, so long lines ran past the terminal edge and wrapped inconsistently with oclif's own help/error output. This PR makes our custom render layer wrap to the terminal width the same way oclif does, then hardens that wrapping so it never corrupts machine-readable or copy-pasted output.

Closes #471.

## How it works

A small render layer in `packages/common-cli/src/render/utils.ts`:

- **`terminalWidth()`** mirrors oclif's own resolution order — explicit `OCLIF_COLUMNS`, then `settings.columns`, then the clamped real `process.stdout` width — computed per call so tests and live terminals both work.
- **`wrap()`** wraps prose to that width, ANSI-aware (colour codes survive, wrapping is measured by visible width).
- **`wrapIndented()`** wraps leaf prose with a *hanging* indent: the caller supplies the first line's prefix (indent + optional tree glyph, e.g. `"  ├── "`) and continuation lines align under the content without repeating the glyph.

These are wired through the report renderer, `validate`, `rules list`, `request`, `plugins list`, `feedback`, `generate`, and `serve`.

## Safety hardening (from code review)

Wrapping user-facing output must never make it wrong. The following make wrapping copy-paste- and pipe-safe:

- **Soft wrapping (`hard: false`)** — unbreakable tokens (file paths, URLs, JSON blobs, rule identifiers) are never split mid-token, so they stay copy-paste- and `grep`-able. Only whitespace-separated prose reflows.
- **Non-TTY output is emitted verbatim** — `terminalWidth()` reports no finite width when stdout is not a TTY (and no width is pinned), so `thymian … > out.txt` and `… | grep` receive unwrapped output. Machine consumption of piped/redirected output is preserved.
- **Bogus width guarded** — only a *positive* `OCLIF_COLUMNS`/`settings.columns` is honoured, so `-1`/`0`/non-numeric no longer collapses every line to one column per line.
- **Raw HTTP wire values are never wrapped** — in `request.ts` the status/request line, `Host`, and header values are printed verbatim so values containing significant whitespace are not mutated.
- **Width-aware run-heading divider** — the `tool · type · ────` separator in the report is sized from `terminalWidth()` (80 fallback) instead of a hardcoded 70, so it wraps uniformly with everything else.
- **No dangling glyph lines** — `wrapIndented('')` renders nothing instead of a lone tree/bullet glyph.
- **Dead indent removed** — `rules list` `formatRule` no longer builds a leading indent that the caller stripped and re-added; `wrapIndented` owns the indent.

## Testing

- `common-cli`, `thymian`, and `core` unit suites pass.
- `terminal-width.test.ts` covers soft-wrap keeping tokens intact, non-TTY verbatim output, non-positive `OCLIF_COLUMNS`, indent reservation, and the empty-text guard.
- `cli-report-renderer.test.ts` asserts every line (prose and the now width-aware divider) stays within the pinned width.
- Lint + build clean for the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)