### PR TITLE
feat(core): human-readable plugin & config validation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,6 +8374,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/@segment/ajv-human-errors": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@segment/ajv-human-errors/-/ajv-human-errors-2.16.0.tgz",
+      "integrity": "sha512-cHNfZcbHrmuYOA7/Sn7HlIDHanamiRTZtngfxcAuFaKQjP7cSqsVHjLz38FI2FQ8JDLz3syGLaz10Gn2ddo7+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
     "node_modules/@shikijs/core": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
@@ -31801,6 +31810,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/deepmerge": "^3.1.0",
+        "@segment/ajv-human-errors": "^2.16.0",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.4.1",

--- a/packages/common-cli/src/validate-config.ts
+++ b/packages/common-cli/src/validate-config.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 
-import { ajv } from '@thymian/core';
+import { ajv, formatAjvErrors } from '@thymian/core';
 
 import thymianSchema from './thymian-config-schema.json' with { type: 'json' };
 
@@ -21,11 +21,14 @@ export function validateConfig(config: unknown): ConfigValidationResult {
   if (valid) {
     return { valid };
   } else {
+    const { message, details } = formatAjvErrors(validationFn.errors);
+
     return {
       valid,
       message:
-        validationFn.errors?.map((e) => EOL + '   * ' + e.message).join('') ??
-        'Unknown error',
+        details.length > 0
+          ? details.map((detail) => EOL + '   * ' + detail).join('')
+          : message,
     };
   }
 }

--- a/packages/common-cli/test/validate-config.test.ts
+++ b/packages/common-cli/test/validate-config.test.ts
@@ -178,7 +178,7 @@ describe('validate-config', () => {
           expect(result.valid).toBe(false);
           if (result.valid === false) {
             expect(result.message).toContain(
-              "must have required property 'plugins'",
+              "is missing the required field 'plugins'",
             );
           }
         });
@@ -192,7 +192,7 @@ describe('validate-config', () => {
 
           expect(result.valid).toBe(false);
           if (result.valid === false) {
-            expect(result.message).toContain('must be object');
+            expect(result.message).toContain('/plugins must be an object');
           }
         });
 
@@ -206,7 +206,7 @@ describe('validate-config', () => {
 
           expect(result.valid).toBe(false);
           if (result.valid === false) {
-            expect(result.message).toContain('must be boolean');
+            expect(result.message).toContain('/autoload must be a boolean');
           }
         });
 
@@ -220,9 +220,8 @@ describe('validate-config', () => {
 
           expect(result.valid).toBe(false);
           if (result.valid === false) {
-            expect(result.message).toContain(
-              'must NOT have additional properties',
-            );
+            expect(result.message).toContain('unexpected property');
+            expect(result.message).toContain('unknownProperty');
           }
         });
 
@@ -263,7 +262,7 @@ describe('validate-config', () => {
 
           expect(result.valid).toBe(false);
           if (result.valid === false) {
-            expect(result.message).toContain('must have required property');
+            expect(result.message).toContain('is missing the required field');
           }
         });
       });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@fastify/deepmerge": "^3.1.0",
+    "@segment/ajv-human-errors": "^2.16.0",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "chalk": "^5.4.1",

--- a/packages/core/src/ajv.ts
+++ b/packages/core/src/ajv.ts
@@ -1,11 +1,66 @@
+import { AggregateAjvError } from '@segment/ajv-human-errors';
+import type { ErrorObject } from 'ajv';
 import { Ajv2020, type JSONSchemaType } from 'ajv/dist/2020.js';
 
 const ajv = new Ajv2020({
   allowUnionTypes: true,
+  allErrors: true,
+  verbose: true,
 });
 
 function validate<T>(schema: JSONSchemaType<T>, data: unknown): data is T {
   return ajv.validate(schema, data);
 }
 
-export { ajv, type JSONSchemaType, validate };
+// Cap how many individual errors we surface. `allErrors: true` collects every
+// failing constraint, so a deeply-invalid config/options object can produce a
+// huge list; bounding it keeps error output (and the interpolated message)
+// readable and avoids flooding logs on adversarial input.
+const MAX_DETAILS = 20;
+
+/**
+ * Wrap raw Ajv errors into a human-readable summary using
+ * `@segment/ajv-human-errors`. The shared `ajv` instance is configured with
+ * `allErrors` + `verbose` (both required by the library) so the errors carry
+ * enough context to produce readable messages.
+ *
+ * Never throws and never returns an empty message for a non-empty error list:
+ * `@segment/ajv-human-errors` can throw (e.g. `additionalProperties: false`
+ * without `properties`, or `patternProperties`) or yield no renderable
+ * messages, so we fall back to Ajv's own `errorsText` in those cases.
+ */
+function formatAjvErrors(errors: ErrorObject[] | null | undefined): {
+  message: string;
+  details: string[];
+} {
+  if (!errors?.length) {
+    return { message: 'Unknown validation error', details: [] };
+  }
+
+  let details: string[] = [];
+  try {
+    const aggregate = new AggregateAjvError(errors);
+    details = [...aggregate]
+      .map((error) => error.message)
+      .filter((message): message is string => Boolean(message));
+  } catch {
+    // Library could not render these errors — fall through to Ajv's text.
+    details = [];
+  }
+
+  if (details.length === 0) {
+    const text = ajv.errorsText(errors);
+    return { message: text, details: [text] };
+  }
+
+  if (details.length > MAX_DETAILS) {
+    details = [
+      ...details.slice(0, MAX_DETAILS),
+      `…and ${details.length - MAX_DETAILS} more validation error(s).`,
+    ];
+  }
+
+  return { message: details.join(' '), details };
+}
+
+export { ajv, formatAjvErrors, type JSONSchemaType, validate };

--- a/packages/core/src/thymian.ts
+++ b/packages/core/src/thymian.ts
@@ -17,7 +17,7 @@ import {
   workflowLintActionSchema,
   workflowTestActionSchema,
 } from './actions/index.js';
-import { ajv, type JSONSchemaType, validate } from './ajv.js';
+import { ajv, formatAjvErrors, type JSONSchemaType, validate } from './ajv.js';
 import { corePlugin } from './core-plugin.js';
 import { ThymianEmitter } from './emitter/index.js';
 import { ThymianFormat } from './format/index.js';
@@ -187,18 +187,20 @@ export class Thymian {
   // (not just `suggestions`) because the WS proxy serializes errors down to
   // { name, message } — so the message is the only channel that reaches the
   // #300 WS client. `validate()` populates `ajv.errors` synchronously on the
-  // shared instance, so it is read immediately after the failed call.
+  // shared instance, so it is read immediately after the failed call. We route
+  // through `formatAjvErrors` (rather than raw `errorsText`) so the message
+  // matches the human-readable phrasing used by the other validation paths.
   #assertValidWorkflowInput<T>(
     actionName: string,
     schema: JSONSchemaType<T>,
     input: unknown,
   ): asserts input is T {
     if (!validate(schema, input)) {
-      const detail = ajv.errorsText(ajv.errors, { dataVar: 'input' });
-      throw new ThymianBaseError(`Invalid ${actionName} input: ${detail}.`, {
+      const { message } = formatAjvErrors(ajv.errors);
+      throw new ThymianBaseError(`Invalid ${actionName} input: ${message}.`, {
         name: 'InvalidActionInputError',
         ref: 'https://thymian.dev/references/errors/invalid-action-input-error/',
-        suggestions: [detail],
+        suggestions: [message],
       });
     }
   }
@@ -225,8 +227,9 @@ export class Thymian {
       const validOptions = validate(plugin.options, options);
 
       if (!validOptions) {
+        const { message } = formatAjvErrors(ajv.errors);
         throw new PluginRegistrationError(
-          `Invalid options for plugin "${plugin.name}".`,
+          `Invalid options for plugin "${plugin.name}": ${message}`,
         );
       }
     }

--- a/packages/core/test/ajv.test.ts
+++ b/packages/core/test/ajv.test.ts
@@ -1,0 +1,101 @@
+import type { JSONSchemaType } from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+
+import { ajv, formatAjvErrors } from '../src/ajv.js';
+
+type Person = {
+  name: string;
+  age: number;
+};
+
+const personSchema: JSONSchemaType<Person> = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'number', minimum: 0 },
+  },
+  required: ['name', 'age'],
+  additionalProperties: false,
+};
+
+describe('formatAjvErrors', () => {
+  it('produces readable messages for a multi-property failure', () => {
+    const valid = ajv.validate(personSchema, { age: -1, extra: true });
+
+    expect(valid).toBe(false);
+
+    const { message, details } = formatAjvErrors(ajv.errors);
+
+    // allErrors:true means every failing constraint is collected, not just
+    // the first, so we get a detail per violated property.
+    expect(details.length).toBeGreaterThan(1);
+    expect(message.length).toBeGreaterThan(0);
+
+    // The combined message and the per-error details are human-readable and
+    // reference the offending fields.
+    const combined = [message, ...details].join('\n');
+    expect(combined).toContain('name');
+    expect(combined).toContain('age');
+    expect(message).toContain(details[0]!);
+  });
+
+  it('returns a safe fallback for null errors', () => {
+    expect(formatAjvErrors(null)).toEqual({
+      message: 'Unknown validation error',
+      details: [],
+    });
+  });
+
+  it('returns a safe fallback for an empty errors array', () => {
+    expect(formatAjvErrors([])).toEqual({
+      message: 'Unknown validation error',
+      details: [],
+    });
+  });
+
+  it('never throws and stays informative when the library cannot render the errors', () => {
+    // `@segment/ajv-human-errors` throws for `additionalProperties: false`
+    // schemas that omit `properties` (and for `patternProperties`). The helper
+    // must fall back to Ajv's own text rather than propagate a TypeError.
+    const openSchema = {
+      type: 'object',
+      additionalProperties: false,
+    } as unknown as JSONSchemaType<Record<string, never>>;
+
+    const valid = ajv.validate(openSchema, { unexpected: 1 });
+    expect(valid).toBe(false);
+
+    let result!: ReturnType<typeof formatAjvErrors>;
+    expect(() => {
+      result = formatAjvErrors(ajv.errors);
+    }).not.toThrow();
+
+    expect(result.message.length).toBeGreaterThan(0);
+    expect(result.message).not.toBe('Unknown validation error');
+    expect(result.details.length).toBeGreaterThan(0);
+  });
+
+  it('caps a very large error list and reports the overflow', () => {
+    const properties: Record<string, { type: 'string' }> = {};
+    const data: Record<string, number> = {};
+    // 30 string properties, each fed a number → 30 type violations.
+    for (let i = 0; i < 30; i++) {
+      properties[`field${i}`] = { type: 'string' };
+      data[`field${i}`] = i;
+    }
+    const schema = {
+      type: 'object',
+      properties,
+      required: Object.keys(properties),
+    } as unknown as JSONSchemaType<Record<string, string>>;
+
+    const valid = ajv.validate(schema, data);
+    expect(valid).toBe(false);
+
+    const { details } = formatAjvErrors(ajv.errors);
+
+    // 20 detail lines + 1 overflow summary line.
+    expect(details.length).toBe(21);
+    expect(details.at(-1)).toContain('more validation error');
+  });
+});

--- a/packages/core/test/thymian.test.ts
+++ b/packages/core/test/thymian.test.ts
@@ -1,3 +1,4 @@
+import type { JSONSchemaType } from 'ajv/dist/2020.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -8,9 +9,11 @@ import {
   createTestCaseExecution,
   createToolRun,
   type LintWorkflowInput,
+  PluginRegistrationError,
   reportSchema,
   Thymian,
   ThymianBaseError,
+  type ThymianPlugin,
 } from '../src/index.js';
 
 describe('Thymian workflows', () => {
@@ -271,5 +274,61 @@ describe('core.workflow.* actions', () => {
     expect(ajv.errors).toBeNull();
 
     await t.close();
+  });
+});
+
+describe('Thymian.register plugin-options validation', () => {
+  type PluginOptions = {
+    endpoint: string;
+    retries: number;
+  };
+
+  const optionsSchema: JSONSchemaType<PluginOptions> = {
+    type: 'object',
+    properties: {
+      endpoint: { type: 'string' },
+      retries: { type: 'number', minimum: 0 },
+    },
+    required: ['endpoint', 'retries'],
+    additionalProperties: false,
+  };
+
+  const buildPlugin = (): ThymianPlugin<PluginOptions> => ({
+    name: '@example/plugin',
+    version: '*',
+    plugin: async () => undefined,
+    options: optionsSchema,
+  });
+
+  it('throws PluginRegistrationError with human-readable detail for invalid options', () => {
+    const thymian = new Thymian();
+
+    let thrown: unknown;
+    try {
+      thymian.register(buildPlugin(), {
+        retries: -1,
+      } as unknown as PluginOptions);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(PluginRegistrationError);
+    const error = thrown as PluginRegistrationError;
+
+    expect(error.message).toMatch(/^Invalid options for plugin "/);
+    expect(error.message).toContain('@example/plugin');
+    // Carries the human-readable Ajv detail after the stable stem.
+    expect(error.message).toContain('endpoint');
+  });
+
+  it('registers without throwing for valid options', () => {
+    const thymian = new Thymian();
+
+    expect(() =>
+      thymian.register(buildPlugin(), {
+        endpoint: 'https://example.com',
+        retries: 3,
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/plugin-har/src/har-schema.ts
+++ b/packages/plugin-har/src/har-schema.ts
@@ -1,4 +1,4 @@
-import { ajv } from '@thymian/core';
+import { ajv, formatAjvErrors } from '@thymian/core';
 
 import type { HarLog } from './har-types.js';
 
@@ -96,5 +96,5 @@ export function validateHar(data: unknown): data is HarLog {
 }
 
 export function getValidationErrors(): string {
-  return ajv.errorsText(validateFn.errors);
+  return formatAjvErrors(validateFn.errors).message;
 }

--- a/packages/plugin-har/test/har-schema.test.ts
+++ b/packages/plugin-har/test/har-schema.test.ts
@@ -61,6 +61,6 @@ describe('har-schema', () => {
 
   it('validateHar should reject non-object payloads', () => {
     expect(validateHar('not-a-har')).toBe(false);
-    expect(getValidationErrors()).toContain('must be object');
+    expect(getValidationErrors()).toContain('must be an object');
   });
 });


### PR DESCRIPTION
## Summary

Closes [#35](https://github.com/thymianofficial/thymian-internal/issues/35).

Ajv's raw validation output (`must have required property 'x'`, `must be object`, `must NOT have additional properties`) is hard for users to act on. This PR introduces a shared `formatAjvErrors` helper in `@thymian/core` that wraps raw Ajv errors with [`@segment/ajv-human-errors`](https://github.com/segmentio/ajv-human-errors), and routes every validation consumer through it so error messages are consistent and readable across the codebase.

## Changes

- **`@thymian/core` — `ajv.ts`**
  - Configure the shared Ajv instance with `allErrors: true` + `verbose: true` (both required by `@segment/ajv-human-errors` to render messages and to list every failing constraint).
  - Add `formatAjvErrors(errors)` returning `{ message, details }`:
    - `details` is a bounded, per-error list (capped at 20 to keep output readable on deeply-invalid / adversarial input).
    - Falls back to Ajv's own `errorsText` when the library can't render a given error shape (e.g. `additionalProperties: false` without `properties`, `patternProperties`).
    - Returns an `"Unknown validation error"` message for an empty/null error list — never an empty message.
- **`@thymian/core` — `thymian.ts`**
  - Emit human-readable detail for invalid plugin options.
  - Migrate `#assertValidWorkflowInput` from raw `errorsText` to `formatAjvErrors` so WS action-input errors (#300 client) use the same friendly phrasing.
- **`@thymian/common-cli` — `validate-config.ts`**
  - Render one bullet per error, and fall back to the summary `message` when no per-error `details` are available — restoring the previous non-empty-message guarantee (the old `?? 'Unknown error'` behaviour).
- **`@thymian/plugin-har` — `har-schema.ts`**
  - Surface human-readable HAR validation errors via the shared helper instead of raw `errorsText`.

## Tests

- New `packages/core/test/ajv.test.ts` covering `formatAjvErrors` (rendering, fallback, empty-list, and cap behaviour).
- Updated assertions in `core`, `common-cli`, and `plugin-har` test suites to match the new human-readable phrasing.

All affected suites pass; `prettier --check` and core `tsc` are clean.

## Review notes

This PR incorporated findings from a high-effort code review:
- Fixed a blank-message regression in `validate-config` when the Ajv error list is empty.
- Made the workflow-input and HAR validation paths reuse the shared helper for consistency.
- Kept `allErrors` and `verbose` on the shared Ajv instance intentionally (multi-error listing + library requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)