### PR TITLE
fix(rules-rfc-9110): correct "server" misspelling in two public rule ids

### DIFF
--- a/packages/rules-rfc-9110/src/rules/methods/general-purpose-servers-must-support-get-and-head.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/general-purpose-servers-must-support-get-and-head.rule.ts
@@ -2,7 +2,7 @@ import { method, not, or, statusCode } from '@thymian/core';
 import { httpRule, singleTestCase } from '@thymian/core';
 
 export default httpRule(
-  'rfc9110/general-purpose-severs-must-support-get-and-head',
+  'rfc9110/general-purpose-servers-must-support-get-and-head',
 )
   .severity('error')
   .type('test', 'analytics')

--- a/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/origin-server-may-accept-connect-request.rule.ts
+++ b/packages/rules-rfc-9110/src/rules/methods/method-definitions/connect/origin-server-may-accept-connect-request.rule.ts
@@ -1,7 +1,7 @@
 import { method, statusCode } from '@thymian/core';
 import { httpRule } from '@thymian/core';
 
-export default httpRule('rfc9110/origin-sever-may-accept-connect-request')
+export default httpRule('rfc9110/origin-server-may-accept-connect-request')
   .severity('hint')
   .type('test', 'analytics')
   .url('https://www.rfc-editor.org/rfc/rfc9110.html#name-connect')


### PR DESCRIPTION
Closes thymianofficial/thymian-internal#477

Two rules in `@thymian/rules-rfc-9110` shipped public rule ids with `server` misspelled — in both the filename and the `httpRule()` id string.

| Before | After |
| --- | --- |
| `rfc9110/origin-sever-may-accept-connect-request` | `rfc9110/origin-server-may-accept-connect-request` |
| `rfc9110/general-purpose-severs-must-support-get-and-head` | `rfc9110/general-purpose-servers-must-support-get-and-head` |

Rule ids are public API — users reference them to configure, suppress and explain individual rules — so the typos were user-visible and permanent until renamed. The `description`/`explanation` prose already spelled "servers" correctly, so only the identifiers changed.

## Scope

Nothing else in the repo referenced either id — no tests, snapshots or fixtures — so this is a file rename plus the id string. Verified with a sweep for `sever`/`severs` across all `packages/*/src`, which now comes back empty.

## Verification

- `nx build rules-rfc-9110` — passes
- `nx test rules-rfc-9110` — passes
- Fresh build contains **402** loadable rules with **no duplicate ids**, and both corrected ids resolve; no `sever` spelling remains in the built output

## ⚠️ Breaking change

A user config that disables or overrides either rule by its **old** id will silently stop matching rather than error — it will simply have no effect.

This follows the precedent of two sibling typos already renamed without a deprecation shim:

- `origin-sever-may-send-allow-header` → `origin-server-may-send-allow-header` (`04ff471e`)
- `origin-sever-must-generate-allow-header-for-405-response` → `origin-server-must-generate-allow-header-for-405-response` (`90524bd2`)

Say the word if you'd prefer an alias/deprecation path instead, and worth a changelog entry either way.

## Context

Surfaced while auditing the 4,138 specs of `APIs-guru/openapi-directory` with 0.1.13 for the public audit report ([openapi-public-audit#2](https://github.com/thymianofficial/openapi-public-audit/pull/2)). The first id showed up in the rule inventory, which prompted a sweep for the rest of the class.

Note the `0.1.14` version bump appears to be in flight, so this can ride along with that release.