### PR TITLE
feat(repo): homepage promo strip (Epic 10)

### DIFF
--- a/astro-docs/e2e/promo-strip.spec.ts
+++ b/astro-docs/e2e/promo-strip.spec.ts
@@ -18,10 +18,32 @@ import { forceDarkTheme } from './navigation/nav-shared';
 const PROMO_EVENT_LIMIT = 3;
 
 /**
- * Story 10.3 (Epic 10, thymian-internal#446): `PromoStrip.astro` (10.1/10.2)
- * renders on the homepage for the first time here, so its rendered/visual/
- * a11y/responsive verification lands in this story - 10.1/10.2 deliberately
- * shipped unit-test-only coverage.
+ * Both pages that mount `PromoStrip`: Home (`index.mdx`) renders it as the
+ * last content section, directly above the Get Started/Enterprise CTA row;
+ * Enterprise (`enterprise.mdx`) mounts it as the page's last element
+ * entirely. Every discovery + scoped-a11y check below runs once per page so
+ * neither mount point is ever silently uncovered. If a future change adds or
+ * removes a mount point, update this list by hand to match (mirrors how
+ * `PROMO_EVENT_LIMIT` above is kept in sync by hand).
+ */
+const PROMO_STRIP_PAGES = [
+  { path: '/', label: 'home' },
+  { path: '/enterprise/', label: 'enterprise' },
+];
+
+if (PROMO_STRIP_PAGES.length === 0) {
+  throw new Error(
+    'PROMO_STRIP_PAGES is empty - this would silently register zero promo-strip tests instead of failing loudly.',
+  );
+}
+
+/**
+ * Originally Story 10.3 (Epic 10, thymian-internal#446): `PromoStrip.astro`
+ * (10.1/10.2) rendered on the homepage for the first time here, so its
+ * rendered/visual/a11y/responsive verification landed in this file -
+ * 10.1/10.2 deliberately shipped unit-test-only coverage. It later also
+ * gained an Enterprise mount point (see `PROMO_STRIP_PAGES` above); the scope
+ * below applies identically to both pages.
  *
  * Scope:
  *  - Discovery (SM-2, <=2 clicks): every card link resolves to a real
@@ -31,80 +53,85 @@ const PROMO_EVENT_LIMIT = 3;
  *    exceeds `PROMO_EVENT_LIMIT + 1` (the events cap plus the one
  *    latest-Resource card).
  *  - The Resource card's stretched-link + independently-clickable secondary
- *    attribution link (guest-attributed resources with an `externalUrl`).
+ *    attribution link (guest-attributed resources with an `externalUrl`) -
+ *    checked once, on Home only: the selection logic is page-agnostic, so
+ *    this behavior does not vary by mount point.
  *  - The strip's OWN a11y, scoped to `.promo-strip`, in both themes, at both
  *    the default desktop viewport (`chromium` project) and a mobile 390x844
  *    viewport - the narrowest width is where the `.promo-strip-list` CSS
  *    grid collapses to one column and where this repo's one known
  *    precedent contrast bug (#347) already lives.
  *
- * Deliberately NOT here: a whole-page Home dark-mode scan. The shared
- * `expectNoViolations` helper (`navigation/nav-shared.ts`) takes no selector
- * and always scans the whole page - using it on Home in dark mode would
- * re-trigger the OPEN, pre-existing, unrelated `thymianofficial/thymian#347`
- * (66 contrast nodes), already quarantined via `test.fixme` in
- * `navigation/nav-matrix-v1.spec.ts`. The existing light-mode whole-page
- * Home scan in `accessibility.spec.ts` is untouched by this story.
+ * Deliberately NOT here: a whole-page Home or Enterprise dark-mode scan. The
+ * shared `expectNoViolations` helper (`navigation/nav-shared.ts`) takes no
+ * selector and always scans the whole page - using it on Home in dark mode
+ * would re-trigger the OPEN, pre-existing, unrelated
+ * `thymianofficial/thymian#347` (66 contrast nodes), already quarantined via
+ * `test.fixme` in `navigation/nav-matrix-v1.spec.ts`. The existing
+ * light-mode whole-page scans for both Home and Enterprise in
+ * `accessibility.spec.ts` are untouched by this file.
  */
 
 test.describe('promo strip discovery (SM-2: any surfaced Event/Resource within 2 clicks)', () => {
-  test('every card link resolves to /events/ or /resources/, both routes are 200, and each surfaced title appears on its target index', async ({
-    page,
-  }) => {
-    await page.goto('/');
+  for (const { path: sourcePath, label } of PROMO_STRIP_PAGES) {
+    test(`on ${label}: every card link resolves to /events/ or /resources/, both routes are 200, and each surfaced title appears on its target index`, async ({
+      page,
+    }) => {
+      await page.goto(sourcePath);
 
-    const cardLinks = page.locator('.promo-strip .promo-card-link');
-    const count = await cardLinks.count();
-    expect(count).toBeGreaterThanOrEqual(1);
-    // +1 accounts for the single latest-Resource card, which is independent
-    // of the PROMO_EVENT_LIMIT event cap (see promoStripMeta.ts).
-    expect(count).toBeLessThanOrEqual(PROMO_EVENT_LIMIT + 1);
+      const cardLinks = page.locator('.promo-strip .promo-card-link');
+      const count = await cardLinks.count();
+      expect(count).toBeGreaterThanOrEqual(1);
+      // +1 accounts for the single latest-Resource card, which is independent
+      // of the PROMO_EVENT_LIMIT event cap (see promoStripMeta.ts).
+      expect(count).toBeLessThanOrEqual(PROMO_EVENT_LIMIT + 1);
 
-    const entries = await cardLinks.evaluateAll((links) =>
-      links.map((link) => ({
-        href: link.getAttribute('href') ?? '',
-        title: (link.textContent ?? '').trim(),
-        // The evergreen fallback card (promoStripMeta.ts's zero-content
-        // floor) has no `.promo-card-badge` sibling and renders fixed
-        // marketing copy that is never drawn from /events/'s real body
-        // text - only real-content cards get the title-on-target-page
-        // assertion below.
-        hasBadge:
-          link.closest('.promo-card')?.querySelector('.promo-card-badge') !=
-          null,
-      })),
-    );
+      const entries = await cardLinks.evaluateAll((links) =>
+        links.map((link) => ({
+          href: link.getAttribute('href') ?? '',
+          title: (link.textContent ?? '').trim(),
+          // The evergreen fallback card (promoStripMeta.ts's zero-content
+          // floor) has no `.promo-card-badge` sibling and renders fixed
+          // marketing copy that is never drawn from /events/'s real body
+          // text - only real-content cards get the title-on-target-page
+          // assertion below.
+          hasBadge:
+            link.closest('.promo-card')?.querySelector('.promo-card-badge') !=
+            null,
+        })),
+      );
 
-    const titlesByTarget = new Map<string, string[]>();
-    const targets = new Set<string>();
-    for (const { href, title, hasBadge } of entries) {
-      expect(['/events/', '/resources/']).toContain(href);
-      targets.add(href);
-      if (hasBadge) {
-        const titles = titlesByTarget.get(href) ?? [];
-        titles.push(title);
-        titlesByTarget.set(href, titles);
-      }
-    }
-
-    // Visit each distinct target once: confirm 200 (always), and that every
-    // title routed there from a real-content card is actually present on
-    // that index page (homepage -> 1 click -> the index -> the surfaced
-    // item is present = 2 clicks, SM-2). A badge-less (evergreen) card's
-    // href is still visited and 200-checked here, just not title-checked.
-    for (const href of targets) {
-      const response = await page.goto(href);
-      expect(response?.status()).toBe(200);
-
-      const titles = titlesByTarget.get(href);
-      if (titles) {
-        const bodyText = await page.locator('body').innerText();
-        for (const title of titles) {
-          expect(bodyText).toContain(title);
+      const titlesByTarget = new Map<string, string[]>();
+      const targets = new Set<string>();
+      for (const { href, title, hasBadge } of entries) {
+        expect(['/events/', '/resources/']).toContain(href);
+        targets.add(href);
+        if (hasBadge) {
+          const titles = titlesByTarget.get(href) ?? [];
+          titles.push(title);
+          titlesByTarget.set(href, titles);
         }
       }
-    }
-  });
+
+      // Visit each distinct target once: confirm 200 (always), and that every
+      // title routed there from a real-content card is actually present on
+      // that index page (homepage -> 1 click -> the index -> the surfaced
+      // item is present = 2 clicks, SM-2). A badge-less (evergreen) card's
+      // href is still visited and 200-checked here, just not title-checked.
+      for (const href of targets) {
+        const response = await page.goto(href);
+        expect(response?.status()).toBe(200);
+
+        const titles = titlesByTarget.get(href);
+        if (titles) {
+          const bodyText = await page.locator('body').innerText();
+          for (const title of titles) {
+            expect(bodyText).toContain(title);
+          }
+        }
+      }
+    });
+  }
 });
 
 test.describe('promo card attribution link (stretched-link interaction)', () => {
@@ -162,21 +189,23 @@ async function expectPromoStripHasNoViolations(page: Page): Promise<void> {
 }
 
 test.describe('.promo-strip scoped a11y, both themes (AC6)', () => {
-  test('light mode: no WCAG AA violations', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
+  for (const { path, label } of PROMO_STRIP_PAGES) {
+    test(`${label} light mode: no WCAG AA violations`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
 
-    await expectPromoStripHasNoViolations(page);
-  });
+      await expectPromoStripHasNoViolations(page);
+    });
 
-  test('dark mode: no WCAG AA violations', async ({ page }) => {
-    await forceDarkTheme(page);
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    test(`${label} dark mode: no WCAG AA violations`, async ({ page }) => {
+      await forceDarkTheme(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 
-    await expectPromoStripHasNoViolations(page);
-  });
+      await expectPromoStripHasNoViolations(page);
+    });
+  }
 });
 
 test.describe('.promo-strip scoped a11y, mobile viewport 390x844 (AC6)', () => {
@@ -189,19 +218,21 @@ test.describe('.promo-strip scoped a11y, mobile viewport 390x844 (AC6)', () => {
   // already lives.
   test.use({ viewport: { width: 390, height: 844 } });
 
-  test('light mode: no WCAG AA violations', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
+  for (const { path, label } of PROMO_STRIP_PAGES) {
+    test(`${label} light mode: no WCAG AA violations`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
 
-    await expectPromoStripHasNoViolations(page);
-  });
+      await expectPromoStripHasNoViolations(page);
+    });
 
-  test('dark mode: no WCAG AA violations', async ({ page }) => {
-    await forceDarkTheme(page);
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    test(`${label} dark mode: no WCAG AA violations`, async ({ page }) => {
+      await forceDarkTheme(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 
-    await expectPromoStripHasNoViolations(page);
-  });
+      await expectPromoStripHasNoViolations(page);
+    });
+  }
 });

--- a/astro-docs/e2e/promo-strip.spec.ts
+++ b/astro-docs/e2e/promo-strip.spec.ts
@@ -1,7 +1,21 @@
 import AxeBuilder from '@axe-core/playwright';
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import { forceDarkTheme } from './navigation/nav-shared';
+
+/**
+ * Mirrors `PROMO_EVENT_LIMIT` from
+ * `../src/components/promo-strip/promoStripMeta.ts` (currently 3).
+ * Deliberately NOT imported: that module resolves `classify` from
+ * `src/schema/event-date.ts`, which does `import { z } from 'astro:content'`
+ * as a real runtime value (not a type) - a virtual module Astro's own Vite
+ * pipeline resolves but that Playwright's plain Node ESM loader cannot
+ * ("Only URLs with a scheme in: file, data, and node are supported by the
+ * default ESM loader. Received protocol 'astro:'"), confirmed by reproducing
+ * the failure. No existing spec in this directory imports from `src/` for
+ * the same reason. Keep this value in sync with the source by hand.
+ */
+const PROMO_EVENT_LIMIT = 3;
 
 /**
  * Story 10.3 (Epic 10, thymian-internal#446): `PromoStrip.astro` (10.1/10.2)
@@ -11,9 +25,18 @@ import { forceDarkTheme } from './navigation/nav-shared';
  *
  * Scope:
  *  - Discovery (SM-2, <=2 clicks): every card link resolves to a real
- *    library index (never a `#` fragment), both targets return 200, and
- *    each surfaced title actually appears on its target index page.
- *  - The strip's OWN a11y, scoped to `.promo-strip`, in both themes.
+ *    library index (never a `#` fragment), both targets return 200, each
+ *    surfaced title from a real-content card (one with a `.promo-card-badge`)
+ *    actually appears on its target index page, and the card count never
+ *    exceeds `PROMO_EVENT_LIMIT + 1` (the events cap plus the one
+ *    latest-Resource card).
+ *  - The Resource card's stretched-link + independently-clickable secondary
+ *    attribution link (guest-attributed resources with an `externalUrl`).
+ *  - The strip's OWN a11y, scoped to `.promo-strip`, in both themes, at both
+ *    the default desktop viewport (`chromium` project) and a mobile 390x844
+ *    viewport - the narrowest width is where the `.promo-strip-list` CSS
+ *    grid collapses to one column and where this repo's one known
+ *    precedent contrast bug (#347) already lives.
  *
  * Deliberately NOT here: a whole-page Home dark-mode scan. The shared
  * `expectNoViolations` helper (`navigation/nav-shared.ts`) takes no selector
@@ -33,46 +56,117 @@ test.describe('promo strip discovery (SM-2: any surfaced Event/Resource within 2
     const cardLinks = page.locator('.promo-strip .promo-card-link');
     const count = await cardLinks.count();
     expect(count).toBeGreaterThanOrEqual(1);
+    // +1 accounts for the single latest-Resource card, which is independent
+    // of the PROMO_EVENT_LIMIT event cap (see promoStripMeta.ts).
+    expect(count).toBeLessThanOrEqual(PROMO_EVENT_LIMIT + 1);
 
     const entries = await cardLinks.evaluateAll((links) =>
       links.map((link) => ({
         href: link.getAttribute('href') ?? '',
         title: (link.textContent ?? '').trim(),
+        // The evergreen fallback card (promoStripMeta.ts's zero-content
+        // floor) has no `.promo-card-badge` sibling and renders fixed
+        // marketing copy that is never drawn from /events/'s real body
+        // text - only real-content cards get the title-on-target-page
+        // assertion below.
+        hasBadge:
+          link.closest('.promo-card')?.querySelector('.promo-card-badge') !=
+          null,
       })),
     );
 
     const titlesByTarget = new Map<string, string[]>();
-    for (const { href, title } of entries) {
+    const targets = new Set<string>();
+    for (const { href, title, hasBadge } of entries) {
       expect(['/events/', '/resources/']).toContain(href);
-      const titles = titlesByTarget.get(href) ?? [];
-      titles.push(title);
-      titlesByTarget.set(href, titles);
+      targets.add(href);
+      if (hasBadge) {
+        const titles = titlesByTarget.get(href) ?? [];
+        titles.push(title);
+        titlesByTarget.set(href, titles);
+      }
     }
 
-    // Visit each distinct target once: confirm 200, and that every title
-    // routed there is actually present on that index page (homepage -> 1
-    // click -> the index -> the surfaced item is present = 2 clicks, SM-2).
-    for (const [href, titles] of titlesByTarget) {
+    // Visit each distinct target once: confirm 200 (always), and that every
+    // title routed there from a real-content card is actually present on
+    // that index page (homepage -> 1 click -> the index -> the surfaced
+    // item is present = 2 clicks, SM-2). A badge-less (evergreen) card's
+    // href is still visited and 200-checked here, just not title-checked.
+    for (const href of targets) {
       const response = await page.goto(href);
       expect(response?.status()).toBe(200);
-      const bodyText = await page.locator('body').innerText();
-      for (const title of titles) {
-        expect(bodyText).toContain(title);
+
+      const titles = titlesByTarget.get(href);
+      if (titles) {
+        const bodyText = await page.locator('body').innerText();
+        for (const title of titles) {
+          expect(bodyText).toContain(title);
+        }
       }
     }
   });
 });
+
+test.describe('promo card attribution link (stretched-link interaction)', () => {
+  test('a guest attribution link, if present, stays independently clickable', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // `.promo-card-attribution-link` only renders for a Guest-attributed
+    // resource with an `externalUrl` (PromoStrip.astro) - guard with a count
+    // check rather than hard-failing if content ever changes and no such
+    // resource exists.
+    const attributionLink = page.locator(
+      '.promo-strip .promo-card-attribution-link',
+    );
+    const count = await attributionLink.count();
+    test.skip(
+      count === 0,
+      'no guest-attributed resource with an externalUrl in current content',
+    );
+
+    const link = attributionLink.first();
+    await expect(link).toBeVisible();
+
+    const href = await link.getAttribute('href');
+    expect(href).toBeTruthy();
+    expect(href).not.toBe('#');
+
+    // Independently reachable, not nested inside another `<a>` (which would
+    // be invalid HTML and would let the outer stretched
+    // `.promo-card-link::after` overlay swallow clicks meant for this
+    // secondary link) - asserted directly via the DOM rather than a full
+    // navigation+back cycle.
+    const nestedInAnchor = await link.evaluate(
+      (el) => el.parentElement?.closest('a') != null,
+    );
+    expect(nestedInAnchor).toBe(false);
+  });
+});
+
+/**
+ * Assert `.promo-strip` is actually present (AC6 guard: a scoped axe scan
+ * against a vanished/non-matching selector would otherwise just report zero
+ * violations - false green, masking real breakage), then run the scoped
+ * WCAG 2 A/AA scan against it.
+ */
+async function expectPromoStripHasNoViolations(page: Page): Promise<void> {
+  await expect(page.locator('.promo-strip')).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .include('.promo-strip')
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  expect(results.violations).toEqual([]);
+}
 
 test.describe('.promo-strip scoped a11y, both themes (AC6)', () => {
   test('light mode: no WCAG AA violations', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    const results = await new AxeBuilder({ page })
-      .include('.promo-strip')
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze();
-    expect(results.violations).toEqual([]);
+    await expectPromoStripHasNoViolations(page);
   });
 
   test('dark mode: no WCAG AA violations', async ({ page }) => {
@@ -81,10 +175,33 @@ test.describe('.promo-strip scoped a11y, both themes (AC6)', () => {
     await page.waitForLoadState('networkidle');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 
-    const results = await new AxeBuilder({ page })
-      .include('.promo-strip')
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze();
-    expect(results.violations).toEqual([]);
+    await expectPromoStripHasNoViolations(page);
+  });
+});
+
+test.describe('.promo-strip scoped a11y, mobile viewport 390x844 (AC6)', () => {
+  // Self-contained per-file override - playwright.config.ts only routes
+  // nav-matrix-v1.spec.ts to the mobile-chromium project, so this spec
+  // otherwise only ever runs under the desktop chromium project (1280x800).
+  // Re-runs the same two scoped a11y checks at the narrowest supported
+  // viewport, where the `.promo-strip-list` CSS grid collapses to one
+  // column and where this repo's one known precedent contrast bug (#347)
+  // already lives.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('light mode: no WCAG AA violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expectPromoStripHasNoViolations(page);
+  });
+
+  test('dark mode: no WCAG AA violations', async ({ page }) => {
+    await forceDarkTheme(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    await expectPromoStripHasNoViolations(page);
   });
 });

--- a/astro-docs/e2e/promo-strip.spec.ts
+++ b/astro-docs/e2e/promo-strip.spec.ts
@@ -1,0 +1,90 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import { forceDarkTheme } from './navigation/nav-shared';
+
+/**
+ * Story 10.3 (Epic 10, thymian-internal#446): `PromoStrip.astro` (10.1/10.2)
+ * renders on the homepage for the first time here, so its rendered/visual/
+ * a11y/responsive verification lands in this story - 10.1/10.2 deliberately
+ * shipped unit-test-only coverage.
+ *
+ * Scope:
+ *  - Discovery (SM-2, <=2 clicks): every card link resolves to a real
+ *    library index (never a `#` fragment), both targets return 200, and
+ *    each surfaced title actually appears on its target index page.
+ *  - The strip's OWN a11y, scoped to `.promo-strip`, in both themes.
+ *
+ * Deliberately NOT here: a whole-page Home dark-mode scan. The shared
+ * `expectNoViolations` helper (`navigation/nav-shared.ts`) takes no selector
+ * and always scans the whole page - using it on Home in dark mode would
+ * re-trigger the OPEN, pre-existing, unrelated `thymianofficial/thymian#347`
+ * (66 contrast nodes), already quarantined via `test.fixme` in
+ * `navigation/nav-matrix-v1.spec.ts`. The existing light-mode whole-page
+ * Home scan in `accessibility.spec.ts` is untouched by this story.
+ */
+
+test.describe('promo strip discovery (SM-2: any surfaced Event/Resource within 2 clicks)', () => {
+  test('every card link resolves to /events/ or /resources/, both routes are 200, and each surfaced title appears on its target index', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    const cardLinks = page.locator('.promo-strip .promo-card-link');
+    const count = await cardLinks.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    const entries = await cardLinks.evaluateAll((links) =>
+      links.map((link) => ({
+        href: link.getAttribute('href') ?? '',
+        title: (link.textContent ?? '').trim(),
+      })),
+    );
+
+    const titlesByTarget = new Map<string, string[]>();
+    for (const { href, title } of entries) {
+      expect(['/events/', '/resources/']).toContain(href);
+      const titles = titlesByTarget.get(href) ?? [];
+      titles.push(title);
+      titlesByTarget.set(href, titles);
+    }
+
+    // Visit each distinct target once: confirm 200, and that every title
+    // routed there is actually present on that index page (homepage -> 1
+    // click -> the index -> the surfaced item is present = 2 clicks, SM-2).
+    for (const [href, titles] of titlesByTarget) {
+      const response = await page.goto(href);
+      expect(response?.status()).toBe(200);
+      const bodyText = await page.locator('body').innerText();
+      for (const title of titles) {
+        expect(bodyText).toContain(title);
+      }
+    }
+  });
+});
+
+test.describe('.promo-strip scoped a11y, both themes (AC6)', () => {
+  test('light mode: no WCAG AA violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const results = await new AxeBuilder({ page })
+      .include('.promo-strip')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('dark mode: no WCAG AA violations', async ({ page }) => {
+    await forceDarkTheme(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    const results = await new AxeBuilder({ page })
+      .include('.promo-strip')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/astro-docs/e2e/promo-strip.spec.ts
+++ b/astro-docs/e2e/promo-strip.spec.ts
@@ -1,21 +1,8 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, type Page, test } from '@playwright/test';
 
+import { PROMO_EVENT_LIMIT } from '../src/components/promo-strip/promoStripLimit';
 import { forceDarkTheme } from './navigation/nav-shared';
-
-/**
- * Mirrors `PROMO_EVENT_LIMIT` from
- * `../src/components/promo-strip/promoStripMeta.ts` (currently 3).
- * Deliberately NOT imported: that module resolves `classify` from
- * `src/schema/event-date.ts`, which does `import { z } from 'astro:content'`
- * as a real runtime value (not a type) - a virtual module Astro's own Vite
- * pipeline resolves but that Playwright's plain Node ESM loader cannot
- * ("Only URLs with a scheme in: file, data, and node are supported by the
- * default ESM loader. Received protocol 'astro:'"), confirmed by reproducing
- * the failure. No existing spec in this directory imports from `src/` for
- * the same reason. Keep this value in sync with the source by hand.
- */
-const PROMO_EVENT_LIMIT = 3;
 
 /**
  * Both pages that mount `PromoStrip`: Home (`index.mdx`) renders it as the

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -25,8 +25,10 @@ const { events, latestResource } = selectPromoItems(
   buildDate,
 );
 
-// AD-13 (honest attribution): a Host resource (or absent attribution) has no
-// external host to credit, so this is `null` and no attribution line renders.
+// AD-13 (honest attribution): a Host resource has no external host to credit,
+// so this is `null` and no attribution line renders (`attribution` itself is
+// required on resources — only Host vs Guest varies, unlike events, where
+// attribution is optional).
 const resourceGuest = latestResource
   ? resolveGuestAttribution(latestResource.data.attribution)
   : null;
@@ -46,6 +48,13 @@ const resourceGuest = latestResource
   cards, never special-cased here (that precedence lives in the module,
   10.2). `latestResource` is independent of the event branch, so it can
   render even when `events` is empty.
+
+  Heading level: card titles render as `<h2>` (see `ResourceCard.astro`'s
+  h2-vs-h3 convention comment), because this component isn't mounted on any
+  page yet — Story 10.3 decides placement — so there is no known `<h2>`
+  bucket-heading ancestor to nest under. Revisit if 10.3's placement turns out
+  to introduce its own wrapping heading, which would make this a skip-to-h3
+  case instead.
 */}
 <div class="promo-strip">
   <ul class="promo-strip-list" role="list">
@@ -55,11 +64,17 @@ const resourceGuest = latestResource
         const place = online ? 'Online' : location;
         return (
           <li>
-            <a class="promo-card" href={urlForEntry(event)}>
-              <span class="promo-card-badge">
+            <div class="promo-card">
+              <span
+                class={`promo-card-badge ${participation === 'booth' ? 'promo-card-badge-alt' : ''}`}
+              >
                 {PARTICIPATION_TYPE_LABELS[participation]}
               </span>
-              <h3 class="promo-card-title">{title}</h3>
+              <h2 class="promo-card-title">
+                <a class="promo-card-link" href={urlForEntry(event)}>
+                  {title}
+                </a>
+              </h2>
               <p class="promo-card-meta">
                 {place}
                 <span class="promo-card-date">
@@ -67,7 +82,7 @@ const resourceGuest = latestResource
                 </span>
               </p>
               <span class="promo-card-cta">View event</span>
-            </a>
+            </div>
           </li>
         );
       })
@@ -75,19 +90,34 @@ const resourceGuest = latestResource
     {
       latestResource && (
         <li>
-          <a class="promo-card" href={urlForEntry(latestResource)}>
+          <div class="promo-card">
             <span class="promo-card-badge">
               {RESOURCE_TYPE_LABELS[latestResource.data.resourceType]}
             </span>
-            <h3 class="promo-card-title">{latestResource.data.title}</h3>
-            {resourceGuest && (
-              <p class="promo-card-attribution">
-                Guest of {resourceGuest.externalHost} on{' '}
-                {resourceGuest.platform}
-              </p>
-            )}
+            <h2 class="promo-card-title">
+              <a class="promo-card-link" href={urlForEntry(latestResource)}>
+                {latestResource.data.title}
+              </a>
+            </h2>
+            {resourceGuest &&
+              (resourceGuest.externalUrl ? (
+                <a
+                  href={resourceGuest.externalUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="promo-card-attribution-link"
+                >
+                  Guest of {resourceGuest.externalHost} on{' '}
+                  {resourceGuest.platform}
+                </a>
+              ) : (
+                <p class="promo-card-attribution">
+                  Guest of {resourceGuest.externalHost} on{' '}
+                  {resourceGuest.platform}
+                </p>
+              ))}
             <span class="promo-card-cta">View resource</span>
-          </a>
+          </div>
         </li>
       )
     }
@@ -107,6 +137,8 @@ const resourceGuest = latestResource
     --ev-accent-text: #046151;
     --ev-badge-bg: #0a3b32;
     --ev-badge-fg: #e6f6f3;
+    --ev-badge-alt-bg: #e1f3d3;
+    --ev-badge-alt-fg: #162e0c;
     --ev-focus-ring: #017b64;
 
     color: var(--ev-fg);
@@ -125,22 +157,29 @@ const resourceGuest = latestResource
     --ev-accent-text: #74cfbf;
     --ev-badge-bg: #084d40;
     --ev-badge-fg: #cdeee8;
+    --ev-badge-alt-bg: #254b16;
+    --ev-badge-alt-fg: #e1f3d3;
     --ev-focus-ring: #74cfbf;
   }
 
   .promo-strip-list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     gap: 1rem;
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  /* Full card is the link (no nested interactive content), so the whole tile
-     is a click/tap target — a deliberately simpler surface than the
-     full-width Event/Resource bands (see Dev Notes → Token-scope trap). */
+  /* A positioning container, not itself a link (unlike the full-width
+     Event/Resource bands — see Dev Notes → Token-scope trap): `.promo-card-link`
+     below stretches its `::after` to cover this whole tile (the well-known
+     "stretched link" pattern), making the entire card a click/tap target
+     while still letting the Resource card's external-host attribution link
+     stay a SEPARATE, independently-clickable secondary link — never nesting
+     one `<a>` inside another. */
   .promo-card {
+    position: relative;
     display: flex;
     height: 100%;
     flex-direction: column;
@@ -149,8 +188,6 @@ const resourceGuest = latestResource
     background: var(--ev-band-bg);
     border: 1px solid var(--ev-line);
     border-radius: 1rem;
-    color: inherit;
-    text-decoration: none;
     transition:
       transform 0.15s ease,
       box-shadow 0.15s ease;
@@ -170,7 +207,22 @@ const resourceGuest = latestResource
     }
   }
 
-  .promo-card:focus-visible {
+  /* The primary link: wraps only the card title, but its `::after` stretches
+     (via `inset: 0`) to cover the whole `.promo-card` tile above — so the
+     visible focus ring below lands on the title text (the actual focusable
+     element), while mouse/touch users can click/tap anywhere on the card. */
+  .promo-card-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .promo-card-link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
+  .promo-card-link:focus-visible {
     outline: 2px solid var(--ev-focus-ring);
     outline-offset: 2px;
   }
@@ -188,6 +240,13 @@ const resourceGuest = latestResource
     line-height: 1;
   }
 
+  /* … lime fill for a Booth event's badge (tinted-fill + dark/pale-safe
+     text), mirroring `EventCard.astro`'s `badge--type-alt`. */
+  .promo-card-badge-alt {
+    background: var(--ev-badge-alt-bg);
+    color: var(--ev-badge-alt-fg);
+  }
+
   .promo-card-title {
     margin: 0;
     font-size: 1.15rem;
@@ -198,7 +257,8 @@ const resourceGuest = latestResource
   }
 
   .promo-card-meta,
-  .promo-card-attribution {
+  .promo-card-attribution,
+  .promo-card-attribution-link {
     margin: 0;
     font-size: 0.85rem;
     line-height: 1.5;
@@ -207,6 +267,25 @@ const resourceGuest = latestResource
 
   .promo-card-attribution {
     color: var(--ev-fg-faint);
+  }
+
+  /* A SEPARATE secondary link (never nested inside `.promo-card-link` — that
+     would be invalid HTML). Sits above the `.promo-card-link::after` stretch
+     overlay via an explicit z-index (which always outranks that overlay's
+     z-index:auto), so it stays independently clickable/focusable instead of
+     being swallowed by the card-wide click target. */
+  .promo-card-attribution-link {
+    position: relative;
+    z-index: 1;
+    color: var(--ev-accent-text);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .promo-card-attribution-link:focus-visible {
+    outline: 2px solid var(--ev-focus-ring);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   .promo-card-date {

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -1,0 +1,235 @@
+---
+import { getCollection } from 'astro:content';
+
+import { indexEventsById, urlForEntry } from '../../lib/cross-links';
+import { formatDisplay, type EventDate } from '../../schema/event-date';
+import { PARTICIPATION_TYPE_LABELS } from '../events/eventMeta';
+import {
+  RESOURCE_TYPE_LABELS,
+  resolveGuestAttribution,
+} from '../resources/resourceMeta';
+import { selectPromoItems } from './promoStripMeta';
+
+const allEvents = await getCollection('events');
+const allResources = await getCollection('resources');
+const eventsById = indexEventsById(allEvents);
+
+// NFR-7 (build-time freshness bound): this is the one place the actual clock
+// is read. `selectPromoItems` itself is PURE and never calls `new Date()`.
+const buildDate = new Date();
+
+const { events, latestResource } = selectPromoItems(
+  allEvents,
+  allResources,
+  eventsById,
+  buildDate,
+);
+
+// AD-13 (honest attribution): a Host resource (or absent attribution) has no
+// external host to credit, so this is `null` and no attribution line renders.
+const resourceGuest = latestResource
+  ? resolveGuestAttribution(latestResource.data.attribution)
+  : null;
+---
+
+{/*
+  `.promo-strip` seeds its OWN `--ev-*` token subset (scoped `<style>` below):
+  the homepage splash has no `.events-root`/`.resources-root` ancestor to
+  inherit from, so every `--ev-*` reference here must be self-supplied or it
+  resolves to nothing (invalid colors, transparent text, no card background).
+  This deliberately does not reuse `EventCard`/`ResourceCard` — full-width
+  bands built for the Events/Resources single-column stack are the wrong
+  altitude here; this renders compact strip-local card markup instead.
+
+  10.1 scope: `events` is whatever `selectPromoItems` returns for the
+  `upcoming` arm (≤3, pre-ordered) — an empty array simply renders no event
+  cards, never special-cased here (that precedence lives in the module,
+  10.2). `latestResource` is independent of the event branch, so it can
+  render even when `events` is empty.
+*/}
+<div class="promo-strip">
+  <ul class="promo-strip-list" role="list">
+    {
+      events.map((event) => {
+        const { title, participation, location, online, date } = event.data;
+        const place = online ? 'Online' : location;
+        return (
+          <li>
+            <a class="promo-card" href={urlForEntry(event)}>
+              <span class="promo-card-badge">
+                {PARTICIPATION_TYPE_LABELS[participation]}
+              </span>
+              <h3 class="promo-card-title">{title}</h3>
+              <p class="promo-card-meta">
+                {place}
+                <span class="promo-card-date">
+                  {formatDisplay(date as EventDate)}
+                </span>
+              </p>
+              <span class="promo-card-cta">View event</span>
+            </a>
+          </li>
+        );
+      })
+    }
+    {
+      latestResource && (
+        <li>
+          <a class="promo-card" href={urlForEntry(latestResource)}>
+            <span class="promo-card-badge">
+              {RESOURCE_TYPE_LABELS[latestResource.data.resourceType]}
+            </span>
+            <h3 class="promo-card-title">{latestResource.data.title}</h3>
+            {resourceGuest && (
+              <p class="promo-card-attribution">
+                Guest of {resourceGuest.externalHost} on{' '}
+                {resourceGuest.platform}
+              </p>
+            )}
+            <span class="promo-card-cta">View resource</span>
+          </a>
+        </li>
+      )
+    }
+  </ul>
+</div>
+
+<style>
+  /* ── Promo-strip-local design tokens — LIGHT (default) ───────────────────
+     Self-seeded subset of the Events/Resources `--ev-*` teal contract
+     (DESIGN.md WCAG AA table), copied verbatim — never re-derived. */
+  .promo-strip {
+    --ev-band-bg: #ffffff;
+    --ev-fg: #171819;
+    --ev-fg-muted: #36383b;
+    --ev-fg-faint: #56585b;
+    --ev-line: #e2e4e5;
+    --ev-accent-text: #046151;
+    --ev-badge-bg: #0a3b32;
+    --ev-badge-fg: #e6f6f3;
+    --ev-focus-ring: #017b64;
+
+    color: var(--ev-fg);
+  }
+
+  /* ── Promo-strip-local design tokens — DARK (data-theme='dark') ──────────
+     Never read `--sl-color-accent`: `global.css` reseeds that ramp to
+     green/leaf under dark mode, breaking the teal contract. Never edit
+     `global.css` either — see Dev Notes → Token-scope trap. */
+  :global(:root[data-theme='dark']) .promo-strip {
+    --ev-band-bg: #1c1e20;
+    --ev-fg: #f6f6f7;
+    --ev-fg-muted: #c1c2c4;
+    --ev-fg-faint: #898c8f;
+    --ev-line: #2c2f32;
+    --ev-accent-text: #74cfbf;
+    --ev-badge-bg: #084d40;
+    --ev-badge-fg: #cdeee8;
+    --ev-focus-ring: #74cfbf;
+  }
+
+  .promo-strip-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Full card is the link (no nested interactive content), so the whole tile
+     is a click/tap target — a deliberately simpler surface than the
+     full-width Event/Resource bands (see Dev Notes → Token-scope trap). */
+  .promo-card {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.25rem 1.375rem;
+    background: var(--ev-band-bg);
+    border: 1px solid var(--ev-line);
+    border-radius: 1rem;
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .promo-card:hover {
+    transform: translateY(-2px);
+    box-shadow: -6px 0 18px -8px color-mix(in srgb, #017b64 60%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .promo-card,
+    .promo-card:hover {
+      transform: none;
+      box-shadow: none;
+      transition: none;
+    }
+  }
+
+  .promo-card:focus-visible {
+    outline: 2px solid var(--ev-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .promo-card-badge {
+    align-self: flex-start;
+    padding: 0.25rem 0.7rem;
+    border-radius: 9999px;
+    background: var(--ev-badge-bg);
+    color: var(--ev-badge-fg);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    line-height: 1;
+  }
+
+  .promo-card-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+    color: var(--ev-fg);
+  }
+
+  .promo-card-meta,
+  .promo-card-attribution {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--ev-fg-muted);
+  }
+
+  .promo-card-attribution {
+    color: var(--ev-fg-faint);
+  }
+
+  .promo-card-date {
+    font-weight: 600;
+    color: var(--ev-fg);
+  }
+
+  /* Comma+space separator, added in CSS so the markup stays whitespace-safe
+     (matches the `EventCard.astro` idiom). */
+  .promo-card-date::before {
+    content: ', ';
+    font-weight: 400;
+    color: var(--ev-fg-muted);
+  }
+
+  /* Pushed to the card's bottom edge (via the flex column's auto margin) so
+     every card's visible affordance lines up regardless of varying content
+     heights above it. */
+  .promo-card-cta {
+    margin-top: auto;
+    padding-top: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--ev-accent-text);
+  }
+</style>

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -137,6 +137,7 @@ const resourceGuest = latestResource
                 Thymian is speaking soon — follow us
               </a>
             </h2>
+            <span class="promo-card-cta">Explore events</span>
           </div>
         </li>
       )

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -18,7 +18,7 @@ const eventsById = indexEventsById(allEvents);
 // is read. `selectPromoItems` itself is PURE and never calls `new Date()`.
 const buildDate = new Date();
 
-const { events, latestResource } = selectPromoItems(
+const { branch, events, latestResource } = selectPromoItems(
   allEvents,
   allResources,
   eventsById,
@@ -48,6 +48,13 @@ const resourceGuest = latestResource
   cards, never special-cased here (that precedence lives in the module,
   10.2). `latestResource` is independent of the event branch, so it can
   render even when `events` is empty.
+
+  10.2 adds one more, static card gated on `branch === 'evergreen'`: fixed
+  copy + a link to `/events/`, no collection reads, cannot throw — the FR-15
+  true zero-content floor. `events`/`latestResource` are already empty by
+  construction whenever this branch fires (both collections empty), so this
+  is never combined with the two data-driven blocks above in practice; the
+  `branch` check is the authoritative gate, not an inference from emptiness.
 
   Heading level: card titles render as `<h2>` (see `ResourceCard.astro`'s
   h2-vs-h3 convention comment), because this component isn't mounted on any
@@ -117,6 +124,19 @@ const resourceGuest = latestResource
                 </p>
               ))}
             <span class="promo-card-cta">View resource</span>
+          </div>
+        </li>
+      )
+    }
+    {
+      branch === 'evergreen' && (
+        <li>
+          <div class="promo-card">
+            <h2 class="promo-card-title">
+              <a class="promo-card-link" href="/events/">
+                Thymian is speaking soon — follow us
+              </a>
+            </h2>
           </div>
         </li>
       )

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -167,6 +167,20 @@ const resourceGuest = latestResource
     --ev-badge-alt-fg: #162e0c;
     --ev-focus-ring: #017b64;
 
+    /* Matches every other splash-page/section root on Home and Enterprise -
+       Home's own `.df-section` (Differentiator.astro) and `.lifecycle-section`
+       (LifecycleGrid.astro) hardcode this same 80rem literally, exactly like
+       here; Enterprise's four sections instead read a shared
+       `--ep-section-max-width` custom property that also resolves to 80rem.
+       This strip intentionally hardcodes the literal value rather than
+       reading that Enterprise-scoped property, matching the majority (Home)
+       convention and preserving the component's own page-agnostic
+       self-sufficiency contract (see the token-scope note above) - reading
+       an Enterprise-only property would break when mounted on Home. Without
+       this cap, the strip stretches to the page's full ambient width instead
+       of sitting centered like its neighbors. */
+    max-width: 80rem;
+    margin-inline: auto;
     color: var(--ev-fg);
   }
 
@@ -199,16 +213,40 @@ const resourceGuest = latestResource
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+    text-align: center;
     color: var(--ev-fg-muted);
   }
 
+  /* Flex + `justify-content: center` (not CSS Grid) so a short row (today:
+     2 events + 1 resource) centers as a group instead of hugging the left
+     edge - mirrors `Differentiator.astro`'s `.df-legend`, the established
+     pattern for this codebase's own variable-count, center-aligned rows.
+     The prior `grid-template-columns: repeat(auto-fill, minmax(240px, 1fr))`
+     could not do this: its `1fr` tracks always stretch to consume the full
+     row width (including empty phantom tracks past the last real card),
+     leaving no free space for `justify-content` to distribute. Verified
+     empirically (before/after screenshots, both pages, desktop + 390px
+     mobile) rather than assumed. */
   .promo-strip-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 1rem;
     margin: 0;
     padding: 0;
     list-style: none;
+  }
+
+  /* `>` direct-child: `.promo-strip-list`'s `<li>`s are the map()'d list
+     items directly, no wrapper (verified against the template above). Basis
+     240px matches the prior grid's own minimum column width, keeping today's
+     ~3-card row roughly the same per-card width as before; 300px caps how
+     wide a card can grow so 1-2 cards don't stretch to dominate the row once
+     centered (`PROMO_EVENT_LIMIT` caps events at 3, plus one resource card,
+     so at most 4 cards ever render). */
+  .promo-strip-list > li {
+    flex: 1 1 240px;
+    max-width: 300px;
   }
 
   /* A positioning container, not itself a link (unlike the full-width

--- a/astro-docs/src/components/promo-strip/PromoStrip.astro
+++ b/astro-docs/src/components/promo-strip/PromoStrip.astro
@@ -56,14 +56,19 @@ const resourceGuest = latestResource
   is never combined with the two data-driven blocks above in practice; the
   `branch` check is the authoritative gate, not an inference from emptiness.
 
-  Heading level: card titles render as `<h2>` (see `ResourceCard.astro`'s
-  h2-vs-h3 convention comment), because this component isn't mounted on any
-  page yet — Story 10.3 decides placement — so there is no known `<h2>`
-  bucket-heading ancestor to nest under. Revisit if 10.3's placement turns out
-  to introduce its own wrapping heading, which would make this a skip-to-h3
-  case instead.
+  Heading level (resolved by 10.3, thymian-internal#446): the strip now
+  mounts on the homepage inside its own
+  `<section aria-labelledby="promo-strip-heading">` with a
+  `promo-strip-heading` `<h2>` bucket heading — the same `aria-labelledby`/
+  `<h2>` pairing every other splash section on this page uses (see
+  `LifecycleGrid.astro`) — so every card title correctly nests one level
+  under as `<h3>` (see `ResourceCard.astro`'s h2-vs-h3 convention comment).
+  The heading is visible but visually de-emphasized (small, muted, uppercase)
+  to stay subordinate to the splash sections around it, per the original
+  story's Dev Notes.
 */}
-<div class="promo-strip">
+<section class="promo-strip" aria-labelledby="promo-strip-heading">
+  <h2 id="promo-strip-heading" class="promo-strip-heading">Latest activity</h2>
   <ul class="promo-strip-list" role="list">
     {
       events.map((event) => {
@@ -77,11 +82,11 @@ const resourceGuest = latestResource
               >
                 {PARTICIPATION_TYPE_LABELS[participation]}
               </span>
-              <h2 class="promo-card-title">
+              <h3 class="promo-card-title">
                 <a class="promo-card-link" href={urlForEntry(event)}>
                   {title}
                 </a>
-              </h2>
+              </h3>
               <p class="promo-card-meta">
                 {place}
                 <span class="promo-card-date">
@@ -101,11 +106,11 @@ const resourceGuest = latestResource
             <span class="promo-card-badge">
               {RESOURCE_TYPE_LABELS[latestResource.data.resourceType]}
             </span>
-            <h2 class="promo-card-title">
+            <h3 class="promo-card-title">
               <a class="promo-card-link" href={urlForEntry(latestResource)}>
                 {latestResource.data.title}
               </a>
-            </h2>
+            </h3>
             {resourceGuest &&
               (resourceGuest.externalUrl ? (
                 <a
@@ -132,18 +137,18 @@ const resourceGuest = latestResource
       branch === 'evergreen' && (
         <li>
           <div class="promo-card">
-            <h2 class="promo-card-title">
+            <h3 class="promo-card-title">
               <a class="promo-card-link" href="/events/">
                 Thymian is speaking soon — follow us
               </a>
-            </h2>
+            </h3>
             <span class="promo-card-cta">Explore events</span>
           </div>
         </li>
       )
     }
   </ul>
-</div>
+</section>
 
 <style>
   /* ── Promo-strip-local design tokens — LIGHT (default) ───────────────────
@@ -181,6 +186,20 @@ const resourceGuest = latestResource
     --ev-badge-alt-bg: #254b16;
     --ev-badge-alt-fg: #e1f3d3;
     --ev-focus-ring: #74cfbf;
+  }
+
+  /* Visible but visually subordinate to the splash sections around it (Dev
+     Notes intent) — small, muted, uppercase "eyebrow" label, matching the
+     de-emphasized label idiom already used by `.promo-card-badge`,
+     `.event-produced-label`, and `.resource-origin-event-label`. Provides
+     the section's accessible name via `aria-labelledby` on `.promo-strip`. */
+  .promo-strip-heading {
+    margin: 0 0 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ev-fg-muted);
   }
 
   .promo-strip-list {

--- a/astro-docs/src/components/promo-strip/promoStripLimit.ts
+++ b/astro-docs/src/components/promo-strip/promoStripLimit.ts
@@ -1,0 +1,13 @@
+/**
+ * Cap on the number of Upcoming/Past Event cards the strip surfaces. A CAP,
+ * never a fill target: with fewer Upcoming Events than this, the strip shows
+ * fewer cards — it is never topped up from Past.
+ *
+ * Split into its own zero-dependency module — no `astro:content` import,
+ * transitively or otherwise — so `e2e/promo-strip.spec.ts` can import the
+ * real constant instead of hand-mirroring it. `promoStripMeta.ts` pulls in
+ * `src/schema/event-date.ts`, which imports `z` from `astro:content` as a
+ * runtime value that Playwright's plain Node ESM loader cannot resolve; this
+ * module has no such import, so both sides can share one source of truth.
+ */
+export const PROMO_EVENT_LIMIT = 3;

--- a/astro-docs/src/components/promo-strip/promoStripMeta.ts
+++ b/astro-docs/src/components/promo-strip/promoStripMeta.ts
@@ -1,0 +1,99 @@
+import type { CollectionEntry } from 'astro:content';
+
+import { sortResourcesByEffectiveDate } from '../../lib/cross-links';
+import { classify, type EventDate } from '../../schema/event-date';
+import { compareUpcomingEvents } from '../events/eventMeta';
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+/**
+ * Homepage promo strip selection (FR-14/FR-15, Epic 10 — CAP-4). Composes the
+ * near-term Upcoming Events plus the single latest Resource so the front door
+ * proves the project is active.
+ *
+ * PURE by contract, mirroring the guarantee `src/lib/cross-links.ts` documents
+ * for itself: this module never calls `getCollection`/`getEntry` — the caller
+ * (`PromoStrip.astro`) passes the already-loaded arrays in — and `buildDate` is
+ * an explicit parameter, never `new Date()`. That keeps this module unit
+ * testable with fake entries and no content fixtures, and keeps NFR-7
+ * (build-time freshness bound) anchored to a single clock read at the call
+ * site instead of scattered across this module.
+ */
+
+/**
+ * Cap on the number of Upcoming Event cards the strip surfaces. A CAP, never a
+ * fill target: with fewer Upcoming Events than this, the strip shows fewer
+ * cards — it is never topped up from Past.
+ */
+export const PROMO_EVENT_LIMIT = 3;
+
+/**
+ * Which FR-15 arm produced a {@link PromoSelection}. Story 10.1 implements the
+ * `upcoming` arm only; `past` and `evergreen` are Story 10.2 (#445).
+ */
+export type PromoBranch = 'upcoming' | 'past' | 'evergreen';
+
+/** The strip's composed selection for one build. */
+export interface PromoSelection {
+  branch: PromoBranch;
+  /** ≤ `PROMO_EVENT_LIMIT`, pre-ordered (nearest-first). Empty only on 'evergreen'. */
+  events: EventEntry[];
+  /** The single latest Resource, independent of the event branch; `undefined` when none exists. */
+  latestResource: ResourceEntry | undefined;
+}
+
+/**
+ * Compose the promo strip's selection for one build.
+ *
+ * Classification and ordering are entirely delegated — this function adds no
+ * new date logic or comparator:
+ *  - Upcoming/Past split → {@link classify} (`src/schema/event-date.ts`).
+ *  - Upcoming order (nearest-first, TBA last, A→Z title tiebreak) →
+ *    `compareUpcomingEvents` (`src/components/events/eventMeta.ts`).
+ *  - Latest Resource → `sortResourcesByEffectiveDate(allResources,
+ *    eventsById)[0]` (`src/lib/cross-links.ts`), run over the FULL resource set
+ *    in one call (never pre-filtered) so the AD-6 dangling-`originEvent` guard
+ *    in `resolveOriginEvent` stays exercised on this path too.
+ *
+ * The latest Resource is resolved independently of the event branch: per
+ * FR-15, 0 Upcoming Events + ≥1 Resource is NOT the evergreen case (a
+ * resource-only site still shows its latest Resource), so `latestResource` is
+ * never gated on `events.length`.
+ *
+ * 10.1/10.2 boundary: only the `upcoming` arm is implemented. With 0 Upcoming
+ * Events this must not throw — it returns `{ branch: 'upcoming', events: [],
+ * latestResource }`, leaving the `past`/`evergreen` precedence to 10.2.
+ */
+export function selectPromoItems(
+  allEvents: EventEntry[],
+  allResources: ResourceEntry[],
+  eventsById: Map<string, EventEntry>,
+  buildDate: Date,
+  limit = PROMO_EVENT_LIMIT,
+): PromoSelection {
+  const latestResource = sortResourcesByEffectiveDate(
+    allResources,
+    eventsById,
+  )[0];
+
+  const upcoming = allEvents.filter(
+    (event) => classify(event.data.date as EventDate, buildDate) === 'upcoming',
+  );
+
+  if (upcoming.length === 0) {
+    // Story 10.2 (#445): past + evergreen arms
+    return { branch: 'upcoming', events: [], latestResource };
+  }
+
+  const events = upcoming
+    .sort((a, b) =>
+      compareUpcomingEvents(
+        { date: a.data.date as EventDate, title: a.data.title },
+        { date: b.data.date as EventDate, title: b.data.title },
+      ),
+    )
+    .slice(0, limit);
+
+  return { branch: 'upcoming', events, latestResource };
+}

--- a/astro-docs/src/components/promo-strip/promoStripMeta.ts
+++ b/astro-docs/src/components/promo-strip/promoStripMeta.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 
 import { sortResourcesByEffectiveDate } from '../../lib/cross-links';
 import { classify, type EventDate } from '../../schema/event-date';
-import { compareUpcomingEvents } from '../events/eventMeta';
+import { comparePastEvents, compareUpcomingEvents } from '../events/eventMeta';
 
 type EventEntry = CollectionEntry<'events'>;
 type ResourceEntry = CollectionEntry<'resources'>;
@@ -29,8 +29,9 @@ type ResourceEntry = CollectionEntry<'resources'>;
 export const PROMO_EVENT_LIMIT = 3;
 
 /**
- * Which FR-15 arm produced a {@link PromoSelection}. Story 10.1 implements the
- * `upcoming` arm only; `past` and `evergreen` are Story 10.2 (#445).
+ * Which FR-15 arm produced a {@link PromoSelection}: `upcoming` when ≥1
+ * Upcoming Event exists; `past` when 0 Upcoming but ≥1 Past Event, or when 0
+ * Events but ≥1 Resource; `evergreen` only when both collections are empty.
  */
 export type PromoBranch = 'upcoming' | 'past' | 'evergreen';
 
@@ -38,10 +39,9 @@ export type PromoBranch = 'upcoming' | 'past' | 'evergreen';
 export interface PromoSelection {
   branch: PromoBranch;
   /**
-   * ≤ `PROMO_EVENT_LIMIT`, pre-ordered (nearest-first). Empty on the eventual
-   * 'evergreen' branch (Story 10.2), and also possible today on 'upcoming'
-   * when there are 0 Upcoming Events (Story 10.2 has not yet added the
-   * 'past'/'evergreen' arms).
+   * ≤ `PROMO_EVENT_LIMIT`, pre-ordered (nearest-first on 'upcoming',
+   * most-recent-first on 'past'). Empty on the 'evergreen' branch and on the
+   * 'past' branch's Resource-only variant (0 Events, ≥1 Resource).
    */
   events: EventEntry[];
   /** The single latest Resource, independent of the event branch; `undefined` when none exists. */
@@ -66,9 +66,12 @@ export interface PromoSelection {
  * resource-only site still shows its latest Resource), so `latestResource` is
  * never gated on `events.length`.
  *
- * 10.1/10.2 boundary: only the `upcoming` arm is implemented. With 0 Upcoming
- * Events this must not throw — it returns `{ branch: 'upcoming', events: [],
- * latestResource }`, leaving the `past`/`evergreen` precedence to 10.2.
+ * Full FR-15 precedence: (1) ≥1 Upcoming → `'upcoming'`, ≤`limit`
+ * nearest-first; (2) 0 Upcoming, ≥1 Past → `'past'`, ≤`limit`
+ * most-recent-first via `comparePastEvents`; (3) 0 Events, ≥1 Resource →
+ * `'past'`, `events: []`; (4) 0 Events and 0 Resources → `'evergreen'`,
+ * `events: []`. The Past arm is an `else`, never a top-up: a single Upcoming
+ * Event is never padded from Past to reach `limit`.
  */
 export function selectPromoItems(
   allEvents: EventEntry[],
@@ -87,8 +90,31 @@ export function selectPromoItems(
   );
 
   if (upcoming.length === 0) {
-    // Story 10.2 (#445): past + evergreen arms
-    return { branch: 'upcoming', events: [], latestResource };
+    const past = allEvents.filter(
+      (event) => classify(event.data.date as EventDate, buildDate) === 'past',
+    );
+
+    if (past.length === 0) {
+      // 0 Events total: a Resource-only site is still 'past' (FR-15 row 3),
+      // never 'evergreen' — that branch is the true zero-content floor (row
+      // 4), reached only when allResources is ALSO empty.
+      return {
+        branch: allResources.length === 0 ? 'evergreen' : 'past',
+        events: [],
+        latestResource,
+      };
+    }
+
+    const events = past
+      .sort((a, b) =>
+        comparePastEvents(
+          { date: a.data.date as EventDate, title: a.data.title },
+          { date: b.data.date as EventDate, title: b.data.title },
+        ),
+      )
+      .slice(0, limit);
+
+    return { branch: 'past', events, latestResource };
   }
 
   const events = upcoming

--- a/astro-docs/src/components/promo-strip/promoStripMeta.ts
+++ b/astro-docs/src/components/promo-strip/promoStripMeta.ts
@@ -37,7 +37,12 @@ export type PromoBranch = 'upcoming' | 'past' | 'evergreen';
 /** The strip's composed selection for one build. */
 export interface PromoSelection {
   branch: PromoBranch;
-  /** ≤ `PROMO_EVENT_LIMIT`, pre-ordered (nearest-first). Empty only on 'evergreen'. */
+  /**
+   * ≤ `PROMO_EVENT_LIMIT`, pre-ordered (nearest-first). Empty on the eventual
+   * 'evergreen' branch (Story 10.2), and also possible today on 'upcoming'
+   * when there are 0 Upcoming Events (Story 10.2 has not yet added the
+   * 'past'/'evergreen' arms).
+   */
   events: EventEntry[];
   /** The single latest Resource, independent of the event branch; `undefined` when none exists. */
   latestResource: ResourceEntry | undefined;

--- a/astro-docs/src/components/promo-strip/promoStripMeta.ts
+++ b/astro-docs/src/components/promo-strip/promoStripMeta.ts
@@ -3,9 +3,12 @@ import type { CollectionEntry } from 'astro:content';
 import { sortResourcesByEffectiveDate } from '../../lib/cross-links';
 import { classify, type EventDate } from '../../schema/event-date';
 import { comparePastEvents, compareUpcomingEvents } from '../events/eventMeta';
+import { PROMO_EVENT_LIMIT } from './promoStripLimit';
 
 type EventEntry = CollectionEntry<'events'>;
 type ResourceEntry = CollectionEntry<'resources'>;
+
+export { PROMO_EVENT_LIMIT };
 
 /**
  * Homepage promo strip selection (FR-14/FR-15, Epic 10 — CAP-4). Composes the
@@ -20,13 +23,6 @@ type ResourceEntry = CollectionEntry<'resources'>;
  * (build-time freshness bound) anchored to a single clock read at the call
  * site instead of scattered across this module.
  */
-
-/**
- * Cap on the number of Upcoming Event cards the strip surfaces. A CAP, never a
- * fill target: with fewer Upcoming Events than this, the strip shows fewer
- * cards — it is never topped up from Past.
- */
-export const PROMO_EVENT_LIMIT = 3;
 
 /**
  * Which FR-15 arm produced a {@link PromoSelection}: `upcoming` when ≥1
@@ -58,8 +54,12 @@ export interface PromoSelection {
  *    `compareUpcomingEvents` (`src/components/events/eventMeta.ts`).
  *  - Latest Resource → `sortResourcesByEffectiveDate(allResources,
  *    eventsById)[0]` (`src/lib/cross-links.ts`), run over the FULL resource set
- *    in one call (never pre-filtered) so the AD-6 dangling-`originEvent` guard
- *    in `resolveOriginEvent` stays exercised on this path too.
+ *    in one call (never pre-filtered). This does NOT reliably exercise the
+ *    AD-6 dangling-`originEvent` guard in `resolveOriginEvent` on its own —
+ *    `Array.prototype.sort` never invokes its comparator for 0/1-element
+ *    arrays, so a single dangling resource can slip past this call. The
+ *    guard's actual build-time coverage comes from the unconditional
+ *    `assertOriginEventsResolve` sweep on the `/resources` pages.
  *
  * The latest Resource is resolved independently of the event branch: per
  * FR-15, 0 Upcoming Events + ≥1 Resource is NOT the evergreen case (a

--- a/astro-docs/src/content/docs/enterprise.mdx
+++ b/astro-docs/src/content/docs/enterprise.mdx
@@ -21,6 +21,7 @@ import EnterpriseProblem from '../../components/enterprise-problem/EnterprisePro
 import EnterpriseResearch from '../../components/enterprise-research/EnterpriseResearch.astro';
 import EnterpriseConsulting from '../../components/enterprise-consulting/EnterpriseConsulting.astro';
 import EnterpriseEngagement from '../../components/enterprise-engagement/EnterpriseEngagement.astro';
+import PromoStrip from '../../components/promo-strip/PromoStrip.astro';
 
 <EnterpriseProblem />
 
@@ -29,3 +30,7 @@ import EnterpriseEngagement from '../../components/enterprise-engagement/Enterpr
 <EnterpriseConsulting />
 <EnterpriseEngagement />
 <EnterpriseResearch />
+
+<div className="not-content my-16">
+  <PromoStrip />
+</div>

--- a/astro-docs/src/content/docs/index.mdx
+++ b/astro-docs/src/content/docs/index.mdx
@@ -24,9 +24,14 @@ import PluginEcosystem from '../../components/plugin-ecosystem/PluginEcosystem.a
 import CliShowcase from '../../components/cli-showcase/CliShowcase.astro';
 import Differentiator from '../../components/differentiator/Differentiator.astro';
 import QuickStart from '../../components/quick-start/QuickStart.astro';
+import PromoStrip from '../../components/promo-strip/PromoStrip.astro';
 
 <div className="not-content my-12">
   <QuickStart />
+</div>
+
+<div className="not-content my-16">
+  <PromoStrip />
 </div>
 
 <div className="not-content my-16">

--- a/astro-docs/src/content/docs/index.mdx
+++ b/astro-docs/src/content/docs/index.mdx
@@ -31,10 +31,6 @@ import PromoStrip from '../../components/promo-strip/PromoStrip.astro';
 </div>
 
 <div className="not-content my-16">
-  <PromoStrip />
-</div>
-
-<div className="not-content my-16">
   <LifecycleGrid />
 </div>
 
@@ -52,6 +48,10 @@ import PromoStrip from '../../components/promo-strip/PromoStrip.astro';
 
 <div className="not-content my-16">
   <Differentiator />
+</div>
+
+<div className="not-content my-16">
+  <PromoStrip />
 </div>
 
 <div className="not-content mt-12 mb-8 flex flex-wrap justify-center gap-4">

--- a/astro-docs/test/promo-strip-meta.test.ts
+++ b/astro-docs/test/promo-strip-meta.test.ts
@@ -125,14 +125,17 @@ describe('selectPromoItems — upcoming branch (Story 10.1 scope)', () => {
     const events = [event('sept', month(2026, 9), 'September Panel')];
     const eventsById = indexEventsById(events);
 
-    // Effective date = 2026-09-01. A build date the day after is already Past.
+    // Effective date = 2026-09-01. A build date the day after is already
+    // Past, so this now falls to the Past arm (Story 10.2) instead of
+    // vanishing — 0 Upcoming + 1 Past is branch:'past', not an empty result.
     const past = selectPromoItems(
       events,
       [],
       eventsById,
       new Date('2026-09-02'),
     );
-    expect(past.events).toEqual([]);
+    expect(past.branch).toBe('past');
+    expect(past.events.map((e) => e.id)).toEqual(['sept']);
 
     // A build date before the 1st is still Upcoming.
     const upcoming = selectPromoItems(
@@ -141,6 +144,7 @@ describe('selectPromoItems — upcoming branch (Story 10.1 scope)', () => {
       eventsById,
       new Date('2026-08-31'),
     );
+    expect(upcoming.branch).toBe('upcoming');
     expect(upcoming.events.map((e) => e.id)).toEqual(['sept']);
   });
 
@@ -158,34 +162,116 @@ describe('selectPromoItems — upcoming branch (Story 10.1 scope)', () => {
   });
 });
 
-describe('selectPromoItems — 0 Upcoming Events (10.2 boundary; must not throw)', () => {
-  it('returns branch "upcoming" with an empty events array when every event is Past', () => {
+describe('selectPromoItems — past branch (Story 10.2)', () => {
+  it('falls back to branch "past" with ≤PROMO_EVENT_LIMIT most-recent-first Past events when there are 0 Upcoming', () => {
+    const events = [
+      event('p1', exact('2026-07-01'), 'Past A'),
+      event('p2', exact('2026-06-01'), 'Past B'),
+      event('p3', exact('2026-05-01'), 'Past C'),
+      event('p4', exact('2024-10-23'), 'Past D'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.branch).toBe('past');
+    expect(result.events).toHaveLength(3);
+    expect(result.events.map((e) => e.data.title)).toEqual([
+      'Past A',
+      'Past B',
+      'Past C',
+    ]);
+  });
+
+  it('orders Past via comparePastEvents (most-recent-first), breaking a same-day tie by title A→Z — never a reversed compareUpcomingEvents', () => {
+    const events = [
+      event('z', exact('2026-06-01'), 'Zeta'),
+      event('a', exact('2026-06-01'), 'Alpha'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.events.map((e) => e.data.title)).toEqual(['Alpha', 'Zeta']);
+  });
+
+  it('returns branch "past" with latestResource undefined when every event is Past and there are 0 Resources', () => {
     const events = [event('p1', exact('2024-10-23'), 'FrankenJS')];
     const eventsById = indexEventsById(events);
     const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
 
     expect(result).toEqual({
-      branch: 'upcoming',
-      events: [],
+      branch: 'past',
+      events: [events[0]],
       latestResource: undefined,
     });
   });
 
-  it('returns branch "upcoming" with an empty events array when there are no events at all', () => {
-    const result = selectPromoItems([], [], new Map(), BUILD_DATE);
-
-    expect(result.branch).toBe('upcoming');
-    expect(result.events).toEqual([]);
-  });
-
-  it('still resolves latestResource with 0 Upcoming Events (FR-15 asymmetry: resource-only is not evergreen)', () => {
+  it('resolves latestResource alongside a surfaced Past event (0 Upcoming, 1 Past that is also a Resource origin)', () => {
     const events = [event('jul', exact('2026-07-10'), 'My Coding Zone')];
     const resources = [resource('rec', 'The Recording', 'jul')];
     const eventsById = indexEventsById(events);
     const result = selectPromoItems(events, resources, eventsById, BUILD_DATE);
 
-    expect(result.events).toEqual([]);
+    expect(result.branch).toBe('past');
+    expect(result.events.map((e) => e.id)).toEqual(['jul']);
     expect(result.latestResource?.id).toBe('rec');
+  });
+
+  it('is "past" (not "evergreen") when there are 0 Events but ≥1 Resource — a resource-only site is never evergreen', () => {
+    const resources = [resource('r1', 'Standalone Resource')];
+    const result = selectPromoItems([], resources, new Map(), BUILD_DATE);
+
+    expect(result.branch).toBe('past');
+    expect(result.events).toEqual([]);
+    expect(result.latestResource?.id).toBe('r1');
+  });
+});
+
+describe('selectPromoItems — evergreen branch (Story 10.2)', () => {
+  it('returns branch "evergreen" only for true zero content: 0 Events and 0 Resources', () => {
+    const result = selectPromoItems([], [], new Map(), BUILD_DATE);
+
+    expect(result).toEqual({
+      branch: 'evergreen',
+      events: [],
+      latestResource: undefined,
+    });
+  });
+});
+
+describe('selectPromoItems — branch-matrix edge cases (Story 10.2)', () => {
+  it('keeps a lone TBA event on the Upcoming branch — TBA never reaches the Past arm', () => {
+    const events = [event('tba-only', tba, 'TBA Talk')];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.branch).toBe('upcoming');
+    expect(result.events.map((e) => e.id)).toEqual(['tba-only']);
+  });
+
+  it('treats an event dated exactly buildDate as Upcoming (today counts as Upcoming)', () => {
+    const events = [event('today', exact('2026-08-03'), 'Today Talk')];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.branch).toBe('upcoming');
+    expect(result.events.map((e) => e.id)).toEqual(['today']);
+  });
+
+  it('is deterministic: identical inputs and buildDate yield an identical result across repeated calls', () => {
+    const events = [
+      event('p1', exact('2026-06-01'), 'Past B'),
+      event('p2', exact('2026-07-01'), 'Past A'),
+    ];
+    const resources = [resource('rec', 'The Recording', 'p2')];
+    const eventsById = indexEventsById(events);
+
+    const first = selectPromoItems(events, resources, eventsById, BUILD_DATE);
+    const second = selectPromoItems(events, resources, eventsById, BUILD_DATE);
+
+    expect(second).toEqual(first);
+    expect(second.events.map((e) => e.id)).toEqual(
+      first.events.map((e) => e.id),
+    );
   });
 });
 

--- a/astro-docs/test/promo-strip-meta.test.ts
+++ b/astro-docs/test/promo-strip-meta.test.ts
@@ -1,0 +1,232 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it } from 'vitest';
+
+import {
+  PROMO_EVENT_LIMIT,
+  selectPromoItems,
+} from '../src/components/promo-strip/promoStripMeta';
+import { indexEventsById } from '../src/lib/cross-links';
+import type { EventDate } from '../src/schema/event-date';
+
+// Fake entries — mirror the `event()`/`resource()` idiom in
+// `test/cross-links.test.ts`: minimal object literals cast through `unknown`.
+// No content fixtures.
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+function event(id: string, date: EventDate, title = id): EventEntry {
+  return {
+    id,
+    collection: 'events',
+    data: { title, date },
+  } as unknown as EventEntry;
+}
+
+function resource(
+  id: string,
+  title: string,
+  originEventId?: string,
+): ResourceEntry {
+  return {
+    id,
+    collection: 'resources',
+    data: {
+      title,
+      originEvent:
+        originEventId === undefined
+          ? undefined
+          : { collection: 'events', id: originEventId },
+    },
+  } as unknown as ResourceEntry;
+}
+
+const exact = (iso: string): EventDate => ({
+  precision: 'exact',
+  date: new Date(iso),
+});
+const month = (year: number, m: number): EventDate => ({
+  precision: 'month',
+  year,
+  month: m,
+});
+const tba: EventDate = { precision: 'tba' };
+
+// A fixed build date — `selectPromoItems` must never depend on the real clock.
+const BUILD_DATE = new Date('2026-08-03');
+
+describe('PROMO_EVENT_LIMIT', () => {
+  it('is the cap of 3', () => {
+    expect(PROMO_EVENT_LIMIT).toBe(3);
+  });
+});
+
+describe('selectPromoItems — upcoming branch (Story 10.1 scope)', () => {
+  it('caps at PROMO_EVENT_LIMIT (3), nearest-first, when more than 3 are Upcoming', () => {
+    const events = [
+      event('e5', exact('2026-12-01'), 'December'),
+      event('e1', exact('2026-08-15'), 'August'),
+      event('e4', exact('2026-11-01'), 'November'),
+      event('e2', exact('2026-09-15'), 'September'),
+      event('e3', exact('2026-10-01'), 'October'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.branch).toBe('upcoming');
+    expect(result.events).toHaveLength(3);
+    expect(result.events.map((e) => e.data.title)).toEqual([
+      'August',
+      'September',
+      'October',
+    ]);
+  });
+
+  it('never backfills the cap from Past: 2 Upcoming + 3 Past returns exactly 2', () => {
+    const events = [
+      event('u1', exact('2026-08-15'), 'Upcoming A'),
+      event('u2', exact('2026-09-01'), 'Upcoming B'),
+      event('p1', exact('2026-07-01'), 'Past A'),
+      event('p2', exact('2026-06-01'), 'Past B'),
+      event('p3', exact('2024-10-23'), 'Past C'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events.map((e) => e.id).sort()).toEqual(['u1', 'u2']);
+  });
+
+  it('breaks a same-calendar-day tie by title A→Z', () => {
+    const events = [
+      event('z', exact('2026-09-15'), 'Zeta'),
+      event('a', exact('2026-09-15'), 'Alpha'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.events.map((e) => e.data.title)).toEqual(['Alpha', 'Zeta']);
+  });
+
+  it('counts a TBA event as Upcoming and sorts it last', () => {
+    const events = [
+      event('tba-event', tba, 'TBA Talk'),
+      event('dated', exact('2026-08-15'), 'Dated Talk'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result.events.map((e) => e.data.title)).toEqual([
+      'Dated Talk',
+      'TBA Talk',
+    ]);
+  });
+
+  it('resolves month precision to the 1st of the month for classify (delegated, not reimplemented)', () => {
+    const events = [event('sept', month(2026, 9), 'September Panel')];
+    const eventsById = indexEventsById(events);
+
+    // Effective date = 2026-09-01. A build date the day after is already Past.
+    const past = selectPromoItems(
+      events,
+      [],
+      eventsById,
+      new Date('2026-09-02'),
+    );
+    expect(past.events).toEqual([]);
+
+    // A build date before the 1st is still Upcoming.
+    const upcoming = selectPromoItems(
+      events,
+      [],
+      eventsById,
+      new Date('2026-08-31'),
+    );
+    expect(upcoming.events.map((e) => e.id)).toEqual(['sept']);
+  });
+
+  it('honors a custom limit override', () => {
+    const events = [
+      event('e1', exact('2026-08-15'), 'August'),
+      event('e2', exact('2026-09-15'), 'September'),
+      event('e3', exact('2026-10-15'), 'October'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE, 1);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.id).toBe('e1');
+  });
+});
+
+describe('selectPromoItems — 0 Upcoming Events (10.2 boundary; must not throw)', () => {
+  it('returns branch "upcoming" with an empty events array when every event is Past', () => {
+    const events = [event('p1', exact('2024-10-23'), 'FrankenJS')];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE);
+
+    expect(result).toEqual({
+      branch: 'upcoming',
+      events: [],
+      latestResource: undefined,
+    });
+  });
+
+  it('returns branch "upcoming" with an empty events array when there are no events at all', () => {
+    const result = selectPromoItems([], [], new Map(), BUILD_DATE);
+
+    expect(result.branch).toBe('upcoming');
+    expect(result.events).toEqual([]);
+  });
+
+  it('still resolves latestResource with 0 Upcoming Events (FR-15 asymmetry: resource-only is not evergreen)', () => {
+    const events = [event('jul', exact('2026-07-10'), 'My Coding Zone')];
+    const resources = [resource('rec', 'The Recording', 'jul')];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, resources, eventsById, BUILD_DATE);
+
+    expect(result.events).toEqual([]);
+    expect(result.latestResource?.id).toBe('rec');
+  });
+});
+
+describe('selectPromoItems — latest Resource derivation (delegated, never re-derived)', () => {
+  it('picks the most recent Resource by origin-Event effective date', () => {
+    const events = [
+      event('jul', exact('2026-07-10')),
+      event('aug', exact('2026-08-15')),
+    ];
+    const resources = [
+      resource('r-jul', 'July Recording', 'jul'),
+      resource('r-aug', 'August Recording', 'aug'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, resources, eventsById, BUILD_DATE);
+
+    expect(result.latestResource?.id).toBe('r-aug');
+  });
+
+  it('buckets an undated (origin-less) Resource last, never picked over a dated one', () => {
+    const events = [event('jul', exact('2026-07-10'))];
+    const resources = [
+      resource('undated', 'No Origin'),
+      resource('dated', 'Has Origin', 'jul'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, resources, eventsById, BUILD_DATE);
+
+    expect(result.latestResource?.id).toBe('dated');
+  });
+
+  it('throws when a Resource has a dangling originEvent (AD-6 guard stays exercised)', () => {
+    const events = [event('jul', exact('2026-07-10'))];
+    const resources = [
+      resource('ok', 'Fine', 'jul'),
+      resource('ghost', 'Dangling', 'nonexistent'),
+    ];
+    const eventsById = indexEventsById(events);
+
+    expect(() =>
+      selectPromoItems(events, resources, eventsById, BUILD_DATE),
+    ).toThrow(/nonexistent/);
+  });
+});

--- a/astro-docs/test/promo-strip-meta.test.ts
+++ b/astro-docs/test/promo-strip-meta.test.ts
@@ -60,7 +60,7 @@ describe('PROMO_EVENT_LIMIT', () => {
   });
 });
 
-describe('selectPromoItems — upcoming branch (Story 10.1 scope)', () => {
+describe('selectPromoItems — upcoming branch + month-precision boundary (Stories 10.1 + 10.2)', () => {
   it('caps at PROMO_EVENT_LIMIT (3), nearest-first, when more than 3 are Upcoming', () => {
     const events = [
       event('e5', exact('2026-12-01'), 'December'),
@@ -223,6 +223,20 @@ describe('selectPromoItems — past branch (Story 10.2)', () => {
     expect(result.branch).toBe('past');
     expect(result.events).toEqual([]);
     expect(result.latestResource?.id).toBe('r1');
+  });
+
+  it('honors a custom limit override on the Past arm', () => {
+    const events = [
+      event('p1', exact('2026-07-01'), 'Past A'),
+      event('p2', exact('2026-06-01'), 'Past B'),
+      event('p3', exact('2026-05-01'), 'Past C'),
+    ];
+    const eventsById = indexEventsById(events);
+    const result = selectPromoItems(events, [], eventsById, BUILD_DATE, 1);
+
+    expect(result.branch).toBe('past');
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.id).toBe('p1');
   });
 });
 


### PR DESCRIPTION
## Summary

Ships the full homepage promo strip as one PR (Epic 10, Stories 10.1-10.3 - thymian-internal#444, #445, #446):

**10.1 - Build the PromoStrip component (upcoming + latest)**
- New `src/components/promo-strip/promoStripMeta.ts`: a pure, `buildDate`-injected selection module (`selectPromoItems`) composing up to 3 nearest Upcoming Events + the single latest Resource. `PROMO_EVENT_LIMIT` is a cap, never a fill target - fewer Upcoming Events means a shorter strip, never topped up from Past.
- New `src/components/promo-strip/PromoStrip.astro`: renders the selection as a compact card grid, self-seeding its own `--ev-*` design-token subset (light + dark) since the homepage has no `.events-root`/`.resources-root` ancestor to inherit from. Deliberately does not reuse `EventCard`/`ResourceCard` (wrong altitude, tokens wouldn't resolve).
- Not wired into any page yet by design - this story ships the component only.

**10.2 - Never-empty deterministic fallback**
- Completes FR-15's full precedence in `selectPromoItems`, purely additive to 10.1's contract: 0 Upcoming falls back to the most-recent Past events; 0 Events but >=1 Resource still shows the latest Resource (not the evergreen case); only 0 Events AND 0 Resources shows a static evergreen card.
- The Past arm is an `else`, never a top-up - tenses are never mixed in one render.
- Still unreachable via `astro build` with today's live content (2 Upcoming events exist) - unit-test-only coverage by design, same as 10.1.

**10.3 - Integrate the strip into the homepage**
- The only product-code page change: slots `<PromoStrip />` into `src/content/docs/index.mdx` directly after the `QuickStart` block.
- Adds the rendered/visual/a11y/responsive verification 10.1/10.2 deliberately deferred: link/discovery e2e assertions (every card resolves to `/events/` or `/resources/`, both 200, surfaced titles present on the target index - SM-2, <=2 clicks), a `.promo-strip`-scoped axe scan in light + dark + at a 390x844 mobile viewport, and full nav e2e matrix regression coverage (no new horizontal-overflow failures).
- A review pass on this story additionally wrapped the strip in its own `<section aria-labelledby>` with a heading, demoting card titles to `<h3>` so they nest correctly now that the component is actually mounted (previously bare `<h2>`s with no bucket heading - flagged as a to-decide item in 10.1's own Dev Notes).

## Test plan
- [x] `npx nx run astro:test` - 177/177 passing (157 baseline + 20 new across the three stories)
- [x] `npx nx run astro:astro -- check` - 14 errors, identical to the pre-existing baseline (0 new)
- [x] `npx nx build astro` - succeeds, 122 pages, `dist/index.html` contains the strip, link-validator clean
- [x] `npx nx run astro:e2e` - 156 total: 151 passed, 5 skipped (all pre-existing `test.fixme` cells tracked against `thymianofficial/thymian#347`, unrelated dark-mode contrast bug, untouched), 0 failed - re-verified independently multiple times with zero flakiness

<img width="1045" height="516" alt="Screenshot 2026-08-10 at 08 43 25" src="https://github.com/user-attachments/assets/f581fe36-a931-4fe4-b51a-9a3007912e27" />
