### PR TITLE
feat(thymian): add thymian explain rule command

### DIFF
--- a/packages/thymian/src/commands/explain/rule.ts
+++ b/packages/thymian/src/commands/explain/rule.ts
@@ -12,7 +12,9 @@ import {
 
 export default class ExplainRule extends BaseCliRunCommand<typeof ExplainRule> {
   static override description =
-    'Explain a single rule: what it checks, why it matters, and how to act on it.';
+    'Explain a single rule: what it checks, why it matters, and how to act on it. ' +
+    'Any rule in the configured rule sets can be explained regardless of its ' +
+    'severity, so the inherited --rule-severity flag has no effect here.';
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> rfc9110/origin-server-should-send-501-response-for-unrecognized-method',
@@ -52,9 +54,10 @@ export default class ExplainRule extends BaseCliRunCommand<typeof ExplainRule> {
       );
     }
 
-    // Canonical lookup keyed by the stable `<ruleset>/<name>` id that reports use.
-    const ruleMap = new Map(rules.map((rule) => [rule.meta.name, rule]));
-    const rule = ruleMap.get(this.args.ruleName);
+    // Look up by the stable `<ruleset>/<name>` id that reports use. `find`
+    // takes the first match, so an earlier rule set wins over a later
+    // same-named rule instead of it being silently shadowed.
+    const rule = rules.find((r) => r.meta.name === this.args.ruleName);
 
     if (!rule) {
       this.error(
@@ -68,9 +71,9 @@ export default class ExplainRule extends BaseCliRunCommand<typeof ExplainRule> {
 
 /**
  * Render focused, educational detail for a single rule. Optional fields are
- * omitted entirely when absent — no empty headings or placeholders. Field order
- * follows UX Decision 11: id → summary → description → "Why this matters"
- * (explanation) → "Recommendation" → Severity → Applies to → Reference.
+ * omitted entirely when absent — no empty headings or placeholders. Section
+ * order (per UX Decision 11): RULE → SUMMARY → DESCRIPTION → EXPLANATION →
+ * RECOMMENDATION → SEVERITY → APPLIES TO → REFERENCE.
  *
  * Content is identical across TTY and non-TTY; only color (stripped by
  * `oclif.ux.colorize` when the stream is not a TTY) differs. Unicode severity

--- a/packages/thymian/src/commands/explain/rule.ts
+++ b/packages/thymian/src/commands/explain/rule.ts
@@ -90,30 +90,38 @@ function formatRuleDetail(rule: Rule): string[] {
 
   const lines: string[] = [];
 
-  lines.push('');
-  lines.push(oclif.ux.colorize('bold', 'RULE'));
-  lines.push(name);
-  lines.push('');
+  // Each section is a blank spacer + bold heading + value. Optional fields are
+  // pushed only when present, so absent fields leave no empty heading (AC3).
+  const section = (heading: string, value: string): void => {
+    lines.push('', oclif.ux.colorize('bold', heading), value);
+  };
 
-  lines.push(oclif.ux.colorize('bold', 'SEVERITY'));
-  lines.push(formatSeverity(severity));
+  section('RULE', name);
+
+  if (summary) {
+    section('SUMMARY', summary);
+  }
+
+  if (description) {
+    section('DESCRIPTION', description);
+  }
 
   if (explanation) {
-    lines.push('');
-    lines.push(oclif.ux.colorize('bold', 'EXPLANATION'));
-    lines.push(explanation);
+    section('EXPLANATION', explanation);
   }
 
   if (recommendation) {
-    lines.push('');
-    lines.push(oclif.ux.colorize('bold', 'RECOMMENDATION'));
-    lines.push(recommendation);
+    section('RECOMMENDATION', recommendation);
+  }
+
+  section('SEVERITY', formatSeverity(severity));
+
+  if (appliesTo && appliesTo.length > 0) {
+    section('APPLIES TO', appliesTo.join(', '));
   }
 
   if (url) {
-    lines.push('');
-    lines.push(oclif.ux.colorize('bold', 'REFERENCE'));
-    lines.push(url);
+    section('REFERENCE', url);
   }
 
   return lines;

--- a/packages/thymian/src/commands/explain/rule.ts
+++ b/packages/thymian/src/commands/explain/rule.ts
@@ -1,0 +1,136 @@
+import { EOL } from 'node:os';
+
+import { BaseCliRunCommand, mergeRuleSets, oclif } from '@thymian/common-cli';
+import { Args } from '@thymian/common-cli/oclif';
+import {
+  loadRules,
+  type Rule,
+  type RuleSeverity,
+  SEVERITY_COLORS,
+  SEVERITY_SYMBOLS,
+} from '@thymian/core';
+
+export default class ExplainRule extends BaseCliRunCommand<typeof ExplainRule> {
+  static override description =
+    'Explain a single rule: what it checks, why it matters, and how to act on it.';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> rfc9110/origin-server-should-send-501-response-for-unrecognized-method',
+  ];
+
+  // Read-only lookup: no specifications, traffic, or workflow execution required.
+  static override requiresSpecifications = false;
+
+  static override args = {
+    ruleName: Args.string({
+      required: true,
+      description:
+        'Canonical rule id, e.g. rfc9110/<rule-name> (as shown by `thymian rules list`).',
+    }),
+  };
+
+  override async run(): Promise<void> {
+    const ruleSets = mergeRuleSets(
+      this.thymianConfig.ruleSets,
+      this.flags['rule-set'],
+    );
+
+    // `explain` is a threshold-independent lookup: load every rule in the
+    // configured rule sets — including disabled (`off`) ones — so any rule the
+    // user names can be explained regardless of the active severity threshold.
+    // (Unlike `rules list`, whose purpose is to show what is currently active.)
+    const rules = await loadRules(
+      ruleSets,
+      () => true,
+      this.thymianConfig.rules,
+      this.flags.cwd,
+    );
+
+    if (rules.length === 0) {
+      this.error(
+        'No rules are loaded. Configure a rule set (e.g. `--rule-set @thymian/rules-rfc-9110`) or add one to your Thymian config.',
+      );
+    }
+
+    // Canonical lookup keyed by the stable `<ruleset>/<name>` id that reports use.
+    const ruleMap = new Map(rules.map((rule) => [rule.meta.name, rule]));
+    const rule = ruleMap.get(this.args.ruleName);
+
+    if (!rule) {
+      this.error(
+        `Unknown rule "${this.args.ruleName}". Run \`thymian rules list\` to see the available rules.`,
+      );
+    }
+
+    this.log(formatRuleDetail(rule).join(EOL));
+  }
+}
+
+/**
+ * Render focused, educational detail for a single rule. Optional fields are
+ * omitted entirely when absent — no empty headings or placeholders. Field order
+ * follows UX Decision 11: id → summary → description → "Why this matters"
+ * (explanation) → "Recommendation" → Severity → Applies to → Reference.
+ *
+ * Content is identical across TTY and non-TTY; only color (stripped by
+ * `oclif.ux.colorize` when the stream is not a TTY) differs. Unicode severity
+ * symbols are always preserved.
+ */
+function formatRuleDetail(rule: Rule): string[] {
+  const {
+    name,
+    summary,
+    description,
+    explanation,
+    recommendation,
+    severity,
+    appliesTo,
+    url,
+  } = rule.meta;
+
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(oclif.ux.colorize('bold', 'RULE'));
+  lines.push(name);
+  lines.push('');
+
+  lines.push(oclif.ux.colorize('bold', 'SEVERITY'));
+  lines.push(formatSeverity(severity));
+
+  if (explanation) {
+    lines.push('');
+    lines.push(oclif.ux.colorize('bold', 'EXPLANATION'));
+    lines.push(explanation);
+  }
+
+  if (recommendation) {
+    lines.push('');
+    lines.push(oclif.ux.colorize('bold', 'RECOMMENDATION'));
+    lines.push(recommendation);
+  }
+
+  if (url) {
+    lines.push('');
+    lines.push(oclif.ux.colorize('bold', 'REFERENCE'));
+    lines.push(url);
+  }
+
+  return lines;
+}
+
+/**
+ * Colorized `<symbol> <severity>` label, mirroring the report renderer
+ * (`render/status.ts`). `off` has no report symbol/color, so it is dimmed like
+ * the sibling `rules list` command.
+ */
+function formatSeverity(severity: RuleSeverity): string {
+  if (severity === 'off') {
+    return oclif.ux.colorize('dim', severity);
+  }
+
+  return oclif.ux.colorize(
+    SEVERITY_COLORS[severity],
+    `${SEVERITY_SYMBOLS[severity]} ${severity}`,
+  );
+}

--- a/packages/thymian/test/commands/explain/rule.test.ts
+++ b/packages/thymian/test/commands/explain/rule.test.ts
@@ -72,6 +72,11 @@ describe('explain rule command', () => {
     });
 
     expect(stdout).toContain('rfc9110/example-rule');
+    expect(stdout).toContain('SUMMARY');
+    expect(stdout).toContain('A short one-liner.');
+    expect(stdout).toContain('DESCRIPTION');
+    expect(stdout).toContain('A longer description of what the rule checks.');
+    expect(stdout).toContain('EXPLANATION');
     expect(stdout).toContain(
       'This matters because interoperability depends on it.',
     );
@@ -79,6 +84,8 @@ describe('explain rule command', () => {
     expect(stdout).toContain('Do the recommended thing to fix it.');
     expect(stdout).toContain('SEVERITY');
     expect(stdout).toContain('error');
+    expect(stdout).toContain('APPLIES TO');
+    expect(stdout).toContain('origin server, client');
     expect(stdout).toContain('REFERENCE');
     expect(stdout).toContain(
       'https://www.rfc-editor.org/rfc/rfc9110.html#name-overview',
@@ -145,7 +152,7 @@ describe('explain rule command', () => {
     expect(filter(makeRule({ name: 'o', severity: 'off' }))).toBe(true);
   });
 
-  it('omits the "Applies to" line for an empty appliesTo array', async () => {
+  it('omits the "APPLIES TO" section for an empty appliesTo array', async () => {
     mockedLoadRules.mockResolvedValue([
       makeRule({
         name: 'rfc9110/empty-applies-to',
@@ -159,6 +166,6 @@ describe('explain rule command', () => {
       await ExplainRule.run(['rfc9110/empty-applies-to', '--no-autoload']);
     });
 
-    expect(stdout).not.toContain('Applies to:');
+    expect(stdout).not.toContain('APPLIES TO');
   });
 });

--- a/packages/thymian/test/commands/explain/rule.test.ts
+++ b/packages/thymian/test/commands/explain/rule.test.ts
@@ -1,0 +1,164 @@
+import { join } from 'node:path';
+
+import { captureOutput } from '@oclif/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.OCLIF_TEST_ROOT = join(import.meta.url, '../../../..');
+
+vi.mock('@thymian/core', async () => {
+  const actual =
+    await vi.importActual<typeof import('@thymian/core')>('@thymian/core');
+
+  return {
+    ...actual,
+    loadRules: vi.fn(),
+  };
+});
+
+import {
+  loadRules,
+  type Rule,
+  type RuleMeta,
+  SEVERITY_SYMBOLS,
+} from '@thymian/core';
+
+import ExplainRule from '../../../src/commands/explain/rule.js';
+
+const mockedLoadRules = vi.mocked(loadRules);
+
+function makeRule(meta: Partial<RuleMeta> & { name: string }): Rule {
+  return {
+    meta: {
+      type: ['static'],
+      severity: 'warn',
+      options: {} as RuleMeta['options'],
+      ...meta,
+    },
+  } as unknown as Rule;
+}
+
+const fullyPopulated = makeRule({
+  name: 'rfc9110/example-rule',
+  severity: 'error',
+  type: ['static'],
+  summary: 'A short one-liner.',
+  description: 'A longer description of what the rule checks.',
+  explanation: 'This matters because interoperability depends on it.',
+  recommendation: 'Do the recommended thing to fix it.',
+  appliesTo: ['origin server', 'client'],
+  url: 'https://www.rfc-editor.org/rfc/rfc9110.html#name-overview',
+});
+
+// ANSI escape (U+001B) — kept as a computed value so the source stays plain.
+const ANSI_ESCAPE = String.fromCharCode(27);
+
+// Error symbol sourced from core (single source of truth), not a literal.
+const ERROR_SYMBOL = SEVERITY_SYMBOLS.error;
+
+describe('explain rule command', () => {
+  beforeEach(() => {
+    mockedLoadRules.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders every field for a fully-populated rule', async () => {
+    mockedLoadRules.mockResolvedValue([fullyPopulated]);
+
+    const { stdout } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
+    });
+
+    expect(stdout).toContain('rfc9110/example-rule');
+    expect(stdout).toContain(
+      'This matters because interoperability depends on it.',
+    );
+    expect(stdout).toContain('RECOMMENDATION');
+    expect(stdout).toContain('Do the recommended thing to fix it.');
+    expect(stdout).toContain('SEVERITY');
+    expect(stdout).toContain('error');
+    expect(stdout).toContain('REFERENCE');
+    expect(stdout).toContain(
+      'https://www.rfc-editor.org/rfc/rfc9110.html#name-overview',
+    );
+  });
+
+  it('fails cleanly with a non-zero exit for an unknown rule', async () => {
+    mockedLoadRules.mockResolvedValue([fullyPopulated]);
+
+    const { error } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/does-not-exist', '--no-autoload']);
+    });
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('Unknown rule "rfc9110/does-not-exist"');
+    expect(error!.message).toContain('thymian rules list');
+    // oclif errors carry a non-zero exit code.
+    expect(
+      (error as { oclif?: { exit?: number } }).oclif?.exit,
+    ).toBeGreaterThan(0);
+  });
+
+  it('produces identical output on repeated invocations', async () => {
+    mockedLoadRules.mockResolvedValue([fullyPopulated]);
+
+    const first = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
+    });
+    const second = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
+    });
+
+    expect(first.stdout).toEqual(second.stdout);
+  });
+
+  it('emits plain, symbol-preserving output in non-TTY mode', async () => {
+    mockedLoadRules.mockResolvedValue([fullyPopulated]);
+
+    const { stdout } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
+    });
+
+    // Captured (non-TTY) output carries no ANSI color escapes...
+    expect(stdout).not.toContain(ANSI_ESCAPE);
+    // ...but the Unicode severity symbol is preserved.
+    expect(stdout).toContain(ERROR_SYMBOL);
+  });
+
+  it('loads rules threshold-independently — filter admits warn/hint/off', async () => {
+    mockedLoadRules.mockResolvedValue([fullyPopulated]);
+
+    await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
+    });
+
+    // The 2nd arg to loadRules is the rule filter. `explain` must NOT gate on
+    // the active severity threshold, so the filter has to admit non-error rules
+    // (incl. disabled `off` rules) — otherwise a real warn/hint rule the user
+    // names would be reported as "Unknown rule".
+    expect(mockedLoadRules).toHaveBeenCalledTimes(1);
+    const filter = mockedLoadRules.mock.calls[0]![1];
+    expect(filter(makeRule({ name: 'w', severity: 'warn' }))).toBe(true);
+    expect(filter(makeRule({ name: 'h', severity: 'hint' }))).toBe(true);
+    expect(filter(makeRule({ name: 'o', severity: 'off' }))).toBe(true);
+  });
+
+  it('omits the "Applies to" line for an empty appliesTo array', async () => {
+    mockedLoadRules.mockResolvedValue([
+      makeRule({
+        name: 'rfc9110/empty-applies-to',
+        severity: 'error',
+        description: 'Only a description is present.',
+        appliesTo: [],
+      }),
+    ]);
+
+    const { stdout } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/empty-applies-to', '--no-autoload']);
+    });
+
+    expect(stdout).not.toContain('Applies to:');
+  });
+});

--- a/packages/thymian/test/commands/explain/rule.test.ts
+++ b/packages/thymian/test/commands/explain/rule.test.ts
@@ -90,6 +90,21 @@ describe('explain rule command', () => {
     expect(stdout).toContain(
       'https://www.rfc-editor.org/rfc/rfc9110.html#name-overview',
     );
+
+    // Field order is a documented contract (UX Decision 11), not just presence.
+    const sectionOrder = [
+      'RULE',
+      'SUMMARY',
+      'DESCRIPTION',
+      'EXPLANATION',
+      'RECOMMENDATION',
+      'SEVERITY',
+      'APPLIES TO',
+      'REFERENCE',
+    ];
+    const positions = sectionOrder.map((heading) => stdout.indexOf(heading));
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 
   it('fails cleanly with a non-zero exit for an unknown rule', async () => {
@@ -121,17 +136,26 @@ describe('explain rule command', () => {
     expect(first.stdout).toEqual(second.stdout);
   });
 
-  it('emits plain, symbol-preserving output in non-TTY mode', async () => {
+  it('keeps content identical across color modes, preserving the severity symbol', async () => {
     mockedLoadRules.mockResolvedValue([fullyPopulated]);
 
-    const { stdout } = await captureOutput(async () => {
+    const run = async (): Promise<void> => {
       await ExplainRule.run(['rfc9110/example-rule', '--no-autoload']);
-    });
+    };
 
-    // Captured (non-TTY) output carries no ANSI color escapes...
-    expect(stdout).not.toContain(ANSI_ESCAPE);
-    // ...but the Unicode severity symbol is preserved.
-    expect(stdout).toContain(ERROR_SYMBOL);
+    // Default capture strips ANSI; the second keeps it (`stripAnsi: false`) so
+    // the comparison is non-vacuous — the helper's default would otherwise hide
+    // any escapes the command emitted.
+    const { stdout: stripped } = await captureOutput(run);
+    const { stdout: raw } = await captureOutput(run, { stripAnsi: false });
+
+    // Color is purely presentational (via `ux.colorize`): stripping ANSI from
+    // the raw render must reproduce the plain render exactly — AC5's "content
+    // identical across modes, only presentation changes".
+    const ansiPattern = new RegExp(`${ANSI_ESCAPE}\\[[0-9;]*m`, 'g');
+    expect(raw.replace(ansiPattern, '')).toEqual(stripped);
+    // The Unicode severity symbol is content, not color — it survives stripping.
+    expect(stripped).toContain(ERROR_SYMBOL);
   });
 
   it('loads rules threshold-independently — filter admits warn/hint/off', async () => {
@@ -146,7 +170,13 @@ describe('explain rule command', () => {
     // (incl. disabled `off` rules) — otherwise a real warn/hint rule the user
     // names would be reported as "Unknown rule".
     expect(mockedLoadRules).toHaveBeenCalledTimes(1);
-    const filter = mockedLoadRules.mock.calls[0]![1];
+    // `loadRules`' filter param is optional (defaults to `() => true`), so the
+    // captured arg is `RuleFilter | undefined`; assert + narrow before calling.
+    const filter = mockedLoadRules.mock.calls[0]?.[1];
+    expect(filter).toBeDefined();
+    if (!filter) {
+      return;
+    }
     expect(filter(makeRule({ name: 'w', severity: 'warn' }))).toBe(true);
     expect(filter(makeRule({ name: 'h', severity: 'hint' }))).toBe(true);
     expect(filter(makeRule({ name: 'o', severity: 'off' }))).toBe(true);
@@ -167,5 +197,39 @@ describe('explain rule command', () => {
     });
 
     expect(stdout).not.toContain('APPLIES TO');
+  });
+
+  it('renders an `off`-severity rule without a symbol or error', async () => {
+    mockedLoadRules.mockResolvedValue([
+      makeRule({
+        name: 'rfc9110/disabled-rule',
+        severity: 'off',
+        description: 'A disabled rule can still be explained.',
+      }),
+    ]);
+
+    const { stdout, error } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/disabled-rule', '--no-autoload']);
+    });
+
+    expect(error).toBeUndefined();
+    expect(stdout).toContain('SEVERITY');
+    expect(stdout).toContain('off');
+    // `off` has no report symbol; it must not borrow another severity's glyph.
+    expect(stdout).not.toContain(SEVERITY_SYMBOLS.error);
+  });
+
+  it('errors clearly when no rules are loaded', async () => {
+    mockedLoadRules.mockResolvedValue([]);
+
+    const { error } = await captureOutput(async () => {
+      await ExplainRule.run(['rfc9110/anything', '--no-autoload']);
+    });
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('No rules are loaded');
+    expect(
+      (error as { oclif?: { exit?: number } }).oclif?.exit,
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
This PR adds the `thymian explain rule <rule-name>` command.

For example running `thymian explain rule rfc9110/intermediary-must-parse-and-remove-connection-fields` prints

```txt

RULE
rfc9110/intermediary-must-parse-and-remove-connection-fields

SUMMARY
Intermediary MUST parse and remove Connection fields before forwarding.

DESCRIPTION
Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).

EXPLANATION
Before a proxy passes a message on, it must read the incoming Connection header, and for every field name listed there it must strip out that matching header or trailer, then drop the Connection header itself (or replace it with its own options for the next hop). Those listed fields are meant only for the current connection ("hop-by-hop"); if they leak downstream they can misconfigure or confuse the next recipient. Removing them keeps connection-specific control information from being blindly forwarded.

SEVERITY
✖ error

APPLIES TO
intermediary

REFERENCE
https://www.rfc-editor.org/rfc/rfc9110.html#name-connection
```

to the console.