### PR TITLE
Epic 11: Internal Social Media Hub extension (Stories 11.1–11.3)

### DIFF
--- a/.github/skills/create-social-content/SKILL.md
+++ b/.github/skills/create-social-content/SKILL.md
@@ -314,6 +314,11 @@ When creating the same message for multiple platforms:
 
 ## Validation Checklist
 
+This checklist covers hand-authored `astro-docs/src/content/social/**` MDX posts only —
+`/social/events-resources/**` is generated build-time from the `events`/`resources` collections and
+renders exactly one image per entry across all four platforms (AD-14), so its "one `SocialImage` per
+platform" / "`SocialImage` platform matches its parent `PlatformSection`" rules below do not apply there.
+
 When creating social content, verify:
 
 - [ ] Frontmatter has all required fields (`title`, `description`, `category`, `publishStatus`)

--- a/astro-docs/e2e/social-hub.spec.ts
+++ b/astro-docs/e2e/social-hub.spec.ts
@@ -1,0 +1,335 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page, test } from '@playwright/test';
+
+import {
+  PLATFORM_CHAR_LIMITS,
+  PROMO_PLATFORMS,
+  type PromoPlatform,
+} from '../src/lib/promo-platforms';
+import { forceDarkTheme } from './navigation/nav-shared';
+
+/**
+ * Rendered/a11y verification for Story 11.3's Events & Resources hub
+ * (thymian-internal#449, AC14). `PlatformSection`/`PostText`/`SocialImage`/
+ * `SocialLayout` are AD-8-frozen presentational components this spec never
+ * edits — it only verifies what this story's own markup (`.hub-*`) does
+ * with them.
+ *
+ * One event page (FrosCon — the only entry with a registered `LOGO_CREDITS`
+ * licence line, AC9) and one resource page (the inherited-logo Resource)
+ * cover "at least one event page, one resource page" per AC14.
+ */
+const EVENT_PATH = '/social/events-resources/events/froscon-community-booth/';
+const RESOURCE_PATH =
+  '/social/events-resources/resources/should-i-get-or-should-i-post-recording/';
+const LANDING_PATH = '/social/events-resources/';
+
+const HUB_ENTRY_PAGES = [
+  { path: EVENT_PATH, label: 'event' },
+  { path: RESOURCE_PATH, label: 'resource' },
+];
+
+// Mirrors promo-strip.spec.ts's module-load empty-set guard: fail loudly
+// rather than silently registering zero tests. (PROMO_PLATFORMS is a fixed
+// `as const` 4-tuple — its length is a compile-time literal, so a runtime
+// emptiness check on it is unreachable by construction and not guarded
+// here; HUB_ENTRY_PAGES below is the one genuinely runtime-derived list.)
+if (HUB_ENTRY_PAGES.length === 0) {
+  throw new Error(
+    'HUB_ENTRY_PAGES is empty - this would silently register zero social-hub tests instead of failing loudly.',
+  );
+}
+
+const REDDIT_INDEX = PROMO_PLATFORMS.indexOf('reddit');
+if (REDDIT_INDEX === -1) {
+  throw new Error(
+    'PROMO_PLATFORMS no longer contains "reddit" - the licence-chain test below assumes reddit is one of the four platforms.',
+  );
+}
+
+/** #447 AC7: reddit gets 2 blocks (title + body); every other platform 1. */
+function expectedBlockCount(platform: PromoPlatform): number {
+  return platform === 'reddit' ? 2 : 1;
+}
+
+const TOTAL_EXPECTED_BLOCKS = PROMO_PLATFORMS.reduce(
+  (sum, platform) => sum + expectedBlockCount(platform),
+  0,
+);
+
+/** The `.char-limit-hint` text `PlatformSection` renders for a platform with
+ *  a char limit, or `null` for reddit (no limit -> no hint rendered at
+ *  all). Derived from the imported `PLATFORM_CHAR_LIMITS`, never retyped, so
+ *  it doubles as an order-and-identity fingerprint per section without a
+ *  hand-authored platform label map. */
+function expectedCharLimitHint(platform: PromoPlatform): string | null {
+  const limit = PLATFORM_CHAR_LIMITS[platform];
+  return limit === null ? null : `max ${limit.toLocaleString()} chars`;
+}
+
+/**
+ * AC6/AC7 structural assertions, run against a `.hub-entry` page (event or
+ * resource): exactly one `noindex` meta tag, 4 `.platform-section`s in
+ * `PROMO_PLATFORMS` order (verified via each section's `.char-limit-hint`,
+ * never a hand-typed label map), 5 `.hub-post-editable` regions total with
+ * 5 distinct `aria-label`s, exactly 1 `.hub-promo-image`, and no literal
+ * "undefined" / empty `<dd>` in the header.
+ */
+async function expectHubEntryStructure(page: Page): Promise<void> {
+  await expect(
+    page.locator('meta[name="robots"][content="noindex, nofollow"]'),
+  ).toHaveCount(1);
+
+  const sections = page.locator('.hub-entry .platform-section');
+  await expect(sections).toHaveCount(PROMO_PLATFORMS.length);
+
+  const allEditable = page.locator('.hub-entry .hub-post-editable');
+  await expect(allEditable).toHaveCount(TOTAL_EXPECTED_BLOCKS);
+
+  for (const [index, platform] of PROMO_PLATFORMS.entries()) {
+    const section = sections.nth(index);
+    await expect(section.locator('.hub-post-editable')).toHaveCount(
+      expectedBlockCount(platform),
+    );
+
+    const hint = section.locator('.char-limit-hint');
+    const expectedHint = expectedCharLimitHint(platform);
+    if (expectedHint === null) {
+      await expect(hint).toHaveCount(0);
+    } else {
+      await expect(hint).toHaveText(expectedHint);
+    }
+  }
+
+  await expect(page.locator('.hub-entry .hub-promo-image')).toHaveCount(1);
+
+  const headerText = await page
+    .locator('.hub-entry .hub-entry-header')
+    .innerText();
+  expect(headerText).not.toContain('undefined');
+  expect(await page.locator('.hub-entry-header dd:empty').count()).toBe(0);
+
+  const labels = await allEditable.evaluateAll((els) =>
+    els.map((el) => el.getAttribute('aria-label') ?? ''),
+  );
+  expect(labels).toHaveLength(TOTAL_EXPECTED_BLOCKS);
+  expect(labels.every((label) => label.length > 0)).toBe(true);
+  expect(new Set(labels).size).toBe(TOTAL_EXPECTED_BLOCKS);
+
+  for (const region of await allEditable.all()) {
+    await expect(region).toHaveAttribute('contenteditable', 'true');
+  }
+}
+
+test.describe('hub entry page structure (AC1, AC3, AC6, AC7)', () => {
+  for (const { path, label } of HUB_ENTRY_PAGES) {
+    test(`${label} page: 1 image, ${PROMO_PLATFORMS.length} platform sections in order, ${TOTAL_EXPECTED_BLOCKS} editable regions, clean header`, async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await expectHubEntryStructure(page);
+    });
+  }
+});
+
+test.describe('editable regions: contenteditable, focusable, distinct names (AC7)', () => {
+  test('all editable regions on the event page are [contenteditable="true"], keyboard-focusable, with distinct aria-labels', async ({
+    page,
+  }) => {
+    await page.goto(EVENT_PATH);
+
+    const regions = page.locator('.hub-entry .hub-post-editable');
+    await expect(regions).toHaveCount(TOTAL_EXPECTED_BLOCKS);
+
+    const labels: string[] = [];
+    for (const region of await regions.all()) {
+      await expect(region).toHaveAttribute('contenteditable', 'true');
+      await region.focus();
+      await expect(region).toBeFocused();
+      labels.push((await region.getAttribute('aria-label')) ?? '');
+    }
+    expect(new Set(labels).size).toBe(TOTAL_EXPECTED_BLOCKS);
+  });
+});
+
+test.describe('copy-after-edit (AC7)', () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test("typing into a region, then pressing its platform's Copy text button, copies the EDITED text", async ({
+    page,
+  }) => {
+    await page.goto(EVENT_PATH);
+
+    const region = page.locator('.hub-entry .hub-post-editable').first();
+    const block = page.locator('.hub-entry .post-text-block').first();
+    const copyButton = block.locator('.copy-btn');
+
+    const originalText = await region.innerText();
+
+    await region.click();
+    await page.keyboard.type(' EDITED-BY-TEST');
+
+    await copyButton.click();
+    // PostText.astro's copy handler has no `.catch()` — assert the button
+    // shows "Copied!" first (a denied clipboard write rejects silently and
+    // never flips the label, which would otherwise fail as an opaque
+    // timeout on the readText() call below).
+    await expect(copyButton).toHaveText('Copied!');
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(clipboardText).not.toBe(originalText);
+    expect(clipboardText).toContain('EDITED-BY-TEST');
+  });
+});
+
+test.describe('discovery: /social/ -> /social/events-resources/ -> every entry (AC1, AC2, AC5)', () => {
+  test('/social/ links to the landing page, and the landing page links every entry with a resolving, fragment-free href', async ({
+    page,
+  }) => {
+    await page.goto('/social/');
+    await expect(
+      page.locator('a[href="/social/events-resources/"]').first(),
+    ).toBeVisible();
+
+    await page.goto(LANDING_PATH);
+    await expect(page.locator('.hub-index')).toBeVisible();
+
+    const links = page.locator(
+      '.hub-index a[href^="/social/events-resources/"]',
+    );
+    const hrefs = await links.evaluateAll((as) =>
+      as.map((a) => a.getAttribute('href') ?? ''),
+    );
+    expect(hrefs.length).toBeGreaterThanOrEqual(1);
+
+    for (const href of hrefs) {
+      expect(href).not.toContain('#');
+      const response = await page.goto(href);
+      expect(response?.status()).toBe(200);
+      await expect(page.locator('.hub-entry')).toBeVisible();
+    }
+  });
+});
+
+test.describe('FrosCon licence chain (AC9)', () => {
+  const FROSCON_IMAGE_CREDIT =
+    'FrosCon logo © FrOSCon e.V., licensed under CC BY-ND 3.0 DE (https://creativecommons.org/licenses/by-nd/3.0/de/).';
+
+  test("the complete 3-part notice appears once, as the final line of the final block of every platform section, and never in reddit's first block", async ({
+    page,
+  }) => {
+    await page.goto(EVENT_PATH);
+
+    const sections = page.locator('.hub-entry .platform-section');
+    await expect(sections).toHaveCount(PROMO_PLATFORMS.length);
+
+    for (const section of await sections.all()) {
+      const blocks = section.locator('.post-text-content');
+      const lastBlockText = await blocks.last().innerText();
+      expect(lastBlockText).toContain(FROSCON_IMAGE_CREDIT);
+    }
+
+    const redditFirstBlockText = await sections
+      .nth(REDDIT_INDEX)
+      .locator('.post-text-content')
+      .first()
+      .innerText();
+    expect(redditFirstBlockText).not.toContain(FROSCON_IMAGE_CREDIT);
+  });
+});
+
+/**
+ * Pre-existing color-contrast failures inside the hub subtree, owned by the
+ * AD-8-frozen presentational components. A violation is ACCEPTED only if it
+ * is `color-contrast` AND every one of its nodes is one of these classes.
+ * Anything else is NEW and fails.
+ */
+const CONTRAST_BASELINE_CLASSES = [
+  'char-counter',
+  'char-limit-hint',
+  'copy-btn',
+  'platform-label',
+] as const;
+
+function newViolations(results: {
+  violations: { id: string; nodes: { html: string }[] }[];
+}) {
+  return results.violations.filter(
+    (v) =>
+      v.id !== 'color-contrast' ||
+      v.nodes.some(
+        (n) =>
+          !CONTRAST_BASELINE_CLASSES.some((c) =>
+            new RegExp(`class="([^"]*\\s)?${c}(\\s[^"]*)?"`).test(n.html),
+          ),
+      ),
+  );
+}
+
+/**
+ * Assert the scan root is visible FIRST (a scoped scan against a
+ * non-matching selector silently reports zero violations — false green),
+ * then run the scoped WCAG 2 A/AA scan. `useBaseline` gates whether
+ * pre-existing baseline `color-contrast` findings are filtered out
+ * (`.hub-entry`) or not (`.hub-index`, which contains none of the 4 frozen
+ * components and must return zero violations unconditionally).
+ */
+async function expectHubSubtreeClean(
+  page: Page,
+  selector: string,
+  useBaseline: boolean,
+): Promise<void> {
+  await expect(page.locator(selector)).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .include(selector)
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+
+  const violations = useBaseline ? newViolations(results) : results.violations;
+  expect(violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+}
+
+test.describe('.hub-entry scoped a11y, both themes, against the enumerated baseline (AC14)', () => {
+  for (const { path, label } of HUB_ENTRY_PAGES) {
+    test(`${label} page light mode: no NEW WCAG AA violations`, async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      await expectHubSubtreeClean(page, '.hub-entry', true);
+    });
+
+    test(`${label} page dark mode: no NEW WCAG AA violations`, async ({
+      page,
+    }) => {
+      await forceDarkTheme(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+      await expectHubSubtreeClean(page, '.hub-entry', true);
+    });
+  }
+});
+
+test.describe('.hub-index scoped a11y, both themes, ZERO violations with no allowlist (AC14)', () => {
+  test('landing page light mode: zero violations', async ({ page }) => {
+    await page.goto(LANDING_PATH);
+    await page.waitForLoadState('networkidle');
+
+    await expectHubSubtreeClean(page, '.hub-index', false);
+  });
+
+  test('landing page dark mode: zero violations', async ({ page }) => {
+    await forceDarkTheme(page);
+    await page.goto(LANDING_PATH);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    await expectHubSubtreeClean(page, '.hub-index', false);
+  });
+});

--- a/astro-docs/src/components/social/HubEntry.astro
+++ b/astro-docs/src/components/social/HubEntry.astro
@@ -1,0 +1,193 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+import { urlForEntry } from '../../lib/cross-links';
+import type { PromoImageResult } from '../../lib/promo-image';
+import type { PromoFacts, PromoPost } from '../../lib/promo-post';
+import PlatformSection from './PlatformSection.astro';
+import PostText from './PostText.astro';
+import PromoImage from './PromoImage.astro';
+
+/**
+ * The Epic 11 hub's per-entry page BODY (Story 11.3, AC6/AC7/AC11/AC12).
+ * Prop-driven — no `getCollection` here, ever; the page shell
+ * (`src/pages/social/events-resources/[collection]/[entry].astro`) does all
+ * data fetching and passes the result in. `facts` (#447), `posts` (#447) and
+ * `image` (#448) are consumed exactly as their owning stories produce them —
+ * never re-derived, never re-branched, never forked.
+ *
+ * Render order (fixed, AC6): `.hub-entry-header` -> `.hub-promo-image` ->
+ * four `PlatformSection`s (one per `posts` entry, already in
+ * `PROMO_PLATFORMS` order) -> one `PostText` per `post.blocks` entry (five
+ * total: reddit 2, the other three 1 each). No `<h2>`s anywhere in this
+ * file — the entry title is already the page `<h1>` via Starlight, and the
+ * five `aria-label`s below carry the structure instead.
+ */
+
+interface Props {
+  entry: CollectionEntry<'events'> | CollectionEntry<'resources'>;
+  facts: PromoFacts;
+  /** Exactly 4, in `PROMO_PLATFORMS` order, 5 blocks total. NOT a
+   *  platform-keyed `Record`, NOT four plain strings. */
+  posts: PromoPost[];
+  image: PromoImageResult;
+}
+
+const { entry, facts, posts, image } = Astro.props;
+
+const publicLinkLabel =
+  entry.collection === 'events'
+    ? 'View the public Events page'
+    : 'View the public Resources page';
+---
+
+<div class="hub-entry">
+  <header class="hub-entry-header">
+    <dl>
+      <dt>Kind</dt>
+      <dd>{facts.kindLabel}</dd>
+      {
+        facts.modeLabel !== undefined && (
+          <>
+            <dt>Mode</dt>
+            <dd>{facts.modeLabel}</dd>
+          </>
+        )
+      }
+      {
+        facts.dateDisplay !== undefined && (
+          <>
+            <dt>Date</dt>
+            <dd>{facts.dateDisplay}</dd>
+          </>
+        )
+      }
+      {
+        facts.place !== undefined && (
+          <>
+            <dt>Place</dt>
+            <dd>{facts.place}</dd>
+          </>
+        )
+      }
+      {
+        facts.speakerNames.length > 0 && (
+          <>
+            <dt>Speakers</dt>
+            <dd>{facts.speakerNames.join(', ')}</dd>
+          </>
+        )
+      }
+      {
+        facts.guestCredit !== undefined && (
+          <>
+            <dt>Guest credit</dt>
+            <dd>{`Guest of ${facts.guestCredit.externalHost} on ${facts.guestCredit.platform}`}</dd>
+          </>
+        )
+      }
+    </dl>
+    <a class="hub-entry-public-link" href={urlForEntry(entry)}>
+      {publicLinkLabel}
+    </a>
+  </header>
+
+  <div class="hub-promo-image"><PromoImage image={image} entryId={entry.id} /></div>
+
+  {
+    posts.map((post) => (
+      <PlatformSection platform={post.platform}>
+        {post.blocks.map((block) => (
+          <PostText platform={post.platform} label={block.label}><div
+            class="hub-post-editable" contenteditable="true" role="textbox" aria-multiline="true"
+            aria-label={`${post.platform} — ${block.label ?? 'post text'}`} spellcheck="true">{block.text}</div></PostText>
+        ))}
+      </PlatformSection>
+    ))
+  }
+</div>
+
+<style>
+  .hub-entry {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    /* Self-seeded focus ring — mirrors PromoImage.astro's own workaround for
+       the token-scope trap: no --ev-*/--sl-color-accent read for anything
+       load-bearing in this story's own markup. */
+    --hub-focus-ring: #017b64;
+  }
+
+  :global(:root[data-theme='dark']) .hub-entry {
+    --hub-focus-ring: #74cfbf;
+  }
+
+  .hub-entry-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.75rem;
+  }
+
+  .hub-entry-header dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    margin: 0;
+  }
+
+  .hub-entry-header dt {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    /* Proven-safe pairing (AC14 baseline table): --sl-color-white on
+       gray-6 measures 14.98:1 dark / 15.31:1 light — dt/dd differ by weight
+       and case only, never by color, so neither can trip color-contrast. */
+    color: var(--sl-color-white);
+  }
+
+  .hub-entry-header dd {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--sl-color-white);
+  }
+
+  .hub-entry-public-link {
+    align-self: flex-start;
+  }
+
+  .hub-promo-image {
+    max-width: 40rem;
+  }
+
+  .hub-post-editable {
+    /* Deliberately redundant with .post-text-content's inherited
+       white-space: pre-wrap (Dev Notes) — the copy target is the slot
+       wrapper, not this div, but the visible wrapping must match. */
+    white-space: pre-wrap;
+  }
+
+  .hub-post-editable:focus-visible {
+    outline: 2px solid var(--hub-focus-ring);
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+
+  /* AC11's explicit link colour: never inherit Starlight's
+     accent-derived link colour (--sl-color-accent is forbidden here). */
+  .hub-entry a {
+    color: var(--sl-color-white);
+    text-decoration: underline;
+  }
+
+  .hub-entry a:focus-visible {
+    outline: 2px solid var(--hub-focus-ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+</style>

--- a/astro-docs/src/components/social/PromoImage.astro
+++ b/astro-docs/src/components/social/PromoImage.astro
@@ -1,0 +1,131 @@
+---
+import { Image } from 'astro:assets';
+
+import type { PromoImageResult } from '../../lib/promo-image';
+import SocialImage from './SocialImage.astro';
+
+/**
+ * The render primitive for `resolvePromoImage`'s two mutually-exclusive
+ * branches (`src/lib/promo-image.ts`, AD-14). Renders exactly the branch it
+ * is given — no re-branching downstream, no client JS of its own.
+ *
+ * `logo` → an unmodified `<Image>` on a white chip (`background: #ffffff`
+ * LITERALLY, in BOTH themes — never a theme-reactive token: FrosCon's
+ * dark-navy wordmark, CC BY-ND — used unmodified — must stay legible on a
+ * dark page too). This copies `EventLogo.astro`'s CHIP RULE, not the
+ * component itself (its fallback is the wrong one here, and it reads
+ * `--ev-*` tokens by inheritance from an `.events-root` ancestor this hub
+ * does not have). A licence-credit line renders when `image.credit` is set,
+ * in `EventsLayout.astro`'s exact markup shape (`rel="license"`, linked
+ * licence name) — the CC BY-ND attribution obligation. No download
+ * affordance: this branch is a preview only (the licence is NoDerivatives),
+ * and reusing `SocialImage`'s `.social-image-canvas` / `.download-btn` class
+ * names would silently attach ITS exporter to this markup, so neither is
+ * used here.
+ *
+ * `card` → the existing `SocialImage type="headline"` branded card, with NO
+ * `platform` prop (its default `'x'`/1200×628 is the single canonical size,
+ * AD-14) and an explicit, deterministic `id` (`promo-${entryId}`).
+ *
+ * Token-scope trap: no `.events-root`/`.resources-root` ancestor exists on
+ * the future hub page, so a bare `var(--ev-…)` would resolve to nothing.
+ * Starlight's own `--sl-color-gray-*` DO cascade globally (legitimate here
+ * for the credit line's text and the chip's border) — but the chip
+ * background is a literal `#ffffff`, never a variable, and `--sl-color-accent`
+ * is never read (`global.css` reseeds it to green under dark mode). The one
+ * custom property this component needs (a focus ring) is self-seeded on its
+ * own root for both themes.
+ */
+
+interface Props {
+  image: PromoImageResult;
+  entryId: string;
+}
+
+const { image, entryId } = Astro.props;
+---
+
+{
+  image.kind === 'logo' ? (
+    <div class="promo-image-logo">
+      <div class="promo-image-logo-chip">
+        <Image
+          src={image.image}
+          alt={image.alt}
+          class="promo-image-logo-img"
+        />
+      </div>
+      {image.credit && (
+        <p class="promo-image-credit">
+          {image.credit.text}, licensed under{' '}
+          <a
+            href={image.credit.licenseUrl}
+            rel="license noopener noreferrer"
+            target="_blank"
+          >
+            {image.credit.licenseName}
+          </a>
+          .
+        </p>
+      )}
+    </div>
+  ) : (
+    <SocialImage
+      type="headline"
+      headline={image.headline}
+      subheadline={image.subheadline}
+      id={`promo-${entryId}`}
+    />
+  )
+}
+
+<style>
+  .promo-image-logo {
+    /* Self-seeded — see the header comment's Token-scope-trap note. */
+    --promo-image-focus-ring: #017b64;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  :global(:root[data-theme='dark']) .promo-image-logo {
+    --promo-image-focus-ring: #74cfbf;
+  }
+
+  .promo-image-logo-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 160px;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.75rem;
+    /* AC9: literally #ffffff in BOTH themes — never a theme-reactive token. */
+    background: #ffffff;
+  }
+
+  .promo-image-logo-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .promo-image-credit {
+    margin: 0;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: var(--sl-color-gray-3);
+  }
+
+  .promo-image-credit a {
+    color: var(--sl-color-gray-2);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .promo-image-credit a:focus-visible {
+    outline: 2px solid var(--promo-image-focus-ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+</style>

--- a/astro-docs/src/components/social/SocialLayout.astro
+++ b/astro-docs/src/components/social/SocialLayout.astro
@@ -17,6 +17,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   'real-world-use-cases': 'Real-World Use Cases',
   educational: 'Educational',
   'thymian-hints': 'Thymian Hints',
+  'events-resources': 'Events & Resources',
 };
 ---
 

--- a/astro-docs/src/components/social/socialHubPaths.ts
+++ b/astro-docs/src/components/social/socialHubPaths.ts
@@ -1,0 +1,49 @@
+import type { CollectionEntry } from 'astro:content';
+
+/**
+ * The pure entry -> route mapping for the Epic 11 hub (Story 11.3, AC1/AC13).
+ *
+ * PURE by contract, in the words `src/lib/cross-links.ts` uses for itself:
+ * this module never calls `getCollection`/`getEntry`, never reads the clock,
+ * and never reads `Astro.*` — callers pass the already-loaded entry in, so
+ * it stays unit-testable with fake entries and no content fixtures.
+ *
+ * `cross-links.ts` declares its own `EventEntry`/`ResourceEntry` aliases
+ * module-locally and exports neither, so this module declares its own local
+ * aliases below rather than importing them. The union type is named
+ * `HubPathEntry`, not `HubEntry`, so it never collides with the sibling
+ * `HubEntry.astro` component.
+ */
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+/** Either collection this hub route serves. */
+export type HubPathEntry = EventEntry | ResourceEntry;
+
+/** The dynamic route params for one entry's per-entry hub page. */
+export interface HubParams {
+  collection: HubPathEntry['collection'];
+  entry: string;
+}
+
+/**
+ * The `[collection]`/`[entry]` route params for one entry — consumed both by
+ * `getStaticPaths` (`src/pages/social/events-resources/[collection]/[entry].astro`)
+ * and by {@link hubPathForEntry} below, so the two can never drift apart.
+ */
+export function hubParamsForEntry(entry: HubPathEntry): HubParams {
+  return { collection: entry.collection, entry: entry.id };
+}
+
+/**
+ * The absolute, trailing-slash path to one entry's per-entry hub page:
+ * `/social/events-resources/<collection>/<id>/`. The `collection` segment is
+ * required — entry ids are unique only *within* a collection (both content
+ * dirs are flat), so a flat `[entry]` scheme would be a latent collision.
+ * Never a `#` fragment.
+ */
+export function hubPathForEntry(entry: HubPathEntry): string {
+  const { collection, entry: id } = hubParamsForEntry(entry);
+  return `/social/events-resources/${collection}/${id}/`;
+}

--- a/astro-docs/src/lib/promo-image.ts
+++ b/astro-docs/src/lib/promo-image.ts
@@ -1,0 +1,160 @@
+import type { ImageMetadata } from 'astro'; // NOT from 'astro:assets' — that
+// module exports the `Image` component, not the type.
+import type { CollectionEntry } from 'astro:content';
+
+import {
+  type LogoCredit,
+  PARTICIPATION_TYPE_LABELS,
+  resolveEventBrand,
+  resolveLogoAlt,
+  resolveLogoCredits,
+} from '../components/events/eventMeta';
+import {
+  resolveGuestAttribution,
+  RESOURCE_TYPE_LABELS,
+} from '../components/resources/resourceMeta';
+import { type EventDate, formatDisplay } from '../schema/event-date';
+import { resolveOriginEvent } from './cross-links';
+
+/**
+ * The single module that resolves a promo post's branded image (AD-14): the
+ * Event's own logo when it has one — or, for a Resource, its Origin Event's
+ * logo when that Event has one — otherwise a generated `SocialImage` branded
+ * card. `PromoImage.astro` renders whichever branch this returns; no other
+ * surface may re-derive the choice — AD-14 exists precisely to stop the hub
+ * and the promo strip picking images differently.
+ *
+ * PURE by contract, in the words `src/lib/cross-links.ts` uses for itself:
+ * this module never calls `getCollection`/`getEntry` — callers pass the
+ * already-loaded entry and `eventsById` map in — so it stays unit-testable
+ * with fake entries and no content fixtures.
+ *
+ * `resolvePromoImage` takes exactly TWO parameters — no `platform`, not even
+ * an optional one "for later": AD-14 mandates ONE image reference per entry
+ * across all four platforms, never per-platform sizing.
+ *
+ * The only license-cleared launch logo (FrosCon's) is CC BY-ND 3.0 DE —
+ * NoDerivatives. The `logo` branch therefore hands back the `ImageMetadata`
+ * completely unmodified — never composited into the card, recolored,
+ * cropped, or filtered. The two branches are mutually exclusive: a logo is
+ * used INSTEAD OF the card, never inside it.
+ */
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+export type PromoImageResult =
+  | {
+      kind: 'logo';
+      image: ImageMetadata;
+      brand: string;
+      alt: string;
+      credit: LogoCredit | undefined;
+    }
+  | { kind: 'card'; headline: string; subheadline: string };
+
+/** Join non-empty (trimmed) fragments with `' · '`, filtering BEFORE joining
+ * so an omitted/blank fragment can never leave a doubled or trailing
+ * separator (AC5). */
+function joinFragments(fragments: (string | undefined)[]): string {
+  return fragments
+    .filter((f): f is string => f !== undefined && f.trim().length > 0)
+    .join(' · ');
+}
+
+/**
+ * The card branch's subheadline for an Event: participation label, display
+ * date, and place — every derivation delegated (`PARTICIPATION_TYPE_LABELS`,
+ * `formatDisplay`), nothing re-derived here but the place fragment (a fourth
+ * inlined copy of the same physical-XOR-online formatter as `EventCard.astro`
+ * / `PromoStrip.astro` / `promo-post.ts`).
+ */
+function eventSubheadline(event: EventEntry): string {
+  const { participation, date, online, location } = event.data;
+  // `location` is typed `string | undefined` even though the schema `.refine`
+  // guarantees physical-XOR-online at runtime — narrow explicitly, or `astro
+  // check` fails under strict TS on the `online === true` branch.
+  const place = online === true ? 'Online' : (location ?? '');
+  return joinFragments([
+    PARTICIPATION_TYPE_LABELS[participation],
+    formatDisplay(date as EventDate),
+    place,
+  ]);
+}
+
+/**
+ * The card branch's subheadline for a Resource: type label plus an omitted-
+ * unless-present guest credit, mirroring `ResourceAttribution.astro`'s
+ * rendered "Guest of … on …" wording (never inventing new copy).
+ */
+function resourceSubheadline(resource: ResourceEntry): string {
+  const { resourceType, attribution } = resource.data;
+  const guest = resolveGuestAttribution(attribution);
+  const guestCredit = guest
+    ? `Guest of ${guest.externalHost} on ${guest.platform}`
+    : undefined;
+  return joinFragments([RESOURCE_TYPE_LABELS[resourceType], guestCredit]);
+}
+
+/**
+ * The `logo` branch result for a resolved logo-bearing Event. `logoEvent` is
+ * the Event that actually supplies the asset — for an inherited Resource
+ * logo, that is its Origin Event, never the Resource itself, so the licence
+ * lookup (AC7) always keys off the right entry id.
+ */
+function logoResult(
+  logoEvent: EventEntry,
+  image: ImageMetadata,
+): PromoImageResult {
+  const brand = resolveEventBrand({
+    title: logoEvent.data.title,
+    attribution: logoEvent.data.attribution,
+  });
+  return {
+    kind: 'logo',
+    image,
+    brand,
+    alt: resolveLogoAlt(brand),
+    credit: resolveLogoCredits([logoEvent])[0],
+  };
+}
+
+/**
+ * Resolve the branded image for one Event or Resource entry (AD-14).
+ *
+ * - An Event with `data.logo` set → `kind: 'logo'` for its own logo.
+ * - A Resource resolves through its Origin Event via `resolveOriginEvent`
+ *   (`src/lib/cross-links.ts`) — the SAME AD-6 dangling-reference guard #447
+ *   uses. That call is never wrapped in try/catch, never pre-filtered, and
+ *   never reimplemented with `eventsById.get(...)` directly: Astro 7.1.3's
+ *   `reference()` is warn-only, so this throw is the only thing that fails
+ *   the build on a dangling `originEvent`.
+ * - Anything else (no logo reachable) → `kind: 'card'`.
+ */
+export function resolvePromoImage(
+  entry: CollectionEntry<'events'> | CollectionEntry<'resources'>,
+  eventsById: Map<string, CollectionEntry<'events'>>,
+): PromoImageResult {
+  if (entry.collection === 'events') {
+    const { logo } = entry.data;
+    if (logo !== undefined) {
+      return logoResult(entry, logo);
+    }
+    return {
+      kind: 'card',
+      headline: entry.data.title,
+      subheadline: eventSubheadline(entry),
+    };
+  }
+
+  const originEvent = resolveOriginEvent(entry, eventsById);
+  const inheritedLogo = originEvent?.data.logo;
+  if (originEvent !== undefined && inheritedLogo !== undefined) {
+    return logoResult(originEvent, inheritedLogo);
+  }
+  return {
+    kind: 'card',
+    headline: entry.data.title,
+    subheadline: resourceSubheadline(entry),
+  };
+}

--- a/astro-docs/src/lib/promo-platforms.ts
+++ b/astro-docs/src/lib/promo-platforms.ts
@@ -1,0 +1,43 @@
+/**
+ * Zero-dependency platform/limit constants for the Epic 11 promo-post module
+ * (Story 11.1, AC1).
+ *
+ * NO IMPORTS AT ALL — deliberately, for the reason `promoStripLimit.ts` states
+ * for itself: `promo-post.ts` (like `promoStripMeta.ts`) pulls in
+ * `src/schema/event-date.ts`, which imports `z` from `astro:content` as a
+ * runtime value that Playwright's plain Node ESM loader cannot resolve. This
+ * module has no such import, so both `promo-post.ts` and a future Story 11.3
+ * e2e suite can share one source of truth for the platform order and char
+ * limits without either side re-declaring them.
+ *
+ * These values duplicate `PostText.astro`'s `CHAR_LIMITS` and
+ * `PlatformSection.astro`'s `PLATFORM_CONFIG` (AD-8 forbids touching either
+ * component). `PLATFORM_CONFIG.reddit` has no `charLimit` key at all, while
+ * `CHAR_LIMITS.reddit` is `null` — `PLATFORM_CHAR_LIMITS.reddit: null` matches
+ * both. The site-wide dedup of this now-five-file/nine-site duplication is a
+ * deliberately deferred follow-up (see Story 11.1 Dev Notes), not this
+ * story's job.
+ */
+
+/** The four supported promo platforms, in canonical/emission order. */
+export const PROMO_PLATFORMS = ['reddit', 'x', 'linkedin', 'discord'] as const;
+
+export type PromoPlatform = (typeof PROMO_PLATFORMS)[number];
+
+/**
+ * Platform-level character limits for the composed post BODY. reddit's body
+ * has no hard limit (`null`); reddit's TITLE uses {@link REDDIT_TITLE_LIMIT}
+ * instead.
+ */
+export const PLATFORM_CHAR_LIMITS = {
+  reddit: null,
+  x: 280,
+  linkedin: 3000,
+  discord: 2000,
+} satisfies Record<PromoPlatform, number | null>;
+
+/**
+ * Reddit's title guideline (SKILL.md:131) is doc-only and enforced nowhere in
+ * code today; this constant makes it a real, checkable limit.
+ */
+export const REDDIT_TITLE_LIMIT = 300;

--- a/astro-docs/src/lib/promo-post.ts
+++ b/astro-docs/src/lib/promo-post.ts
@@ -288,13 +288,22 @@ type EventLedeFn = (context: EventLedeContext) => string;
 type EventLedeKey = `${ParticipationType}:${ParticipationMode}`;
 
 /** Grammatical for all 12 `ParticipationType × ParticipationMode`
- *  combinations, so adding a new type/mode can never crash the composer. */
+ *  combinations, so adding a new type/mode can never crash the composer.
+ *  "Attending" reads naturally without "at" ("attending this podcast"),
+ *  while "presenting" (and any future mode) keeps it ("presenting at this
+ *  podcast") — a bare template would render "attending at this podcast" for
+ *  every attending-mode default, which is stilted rather than incorrect. */
 const DEFAULT_EVENT_LEDE: EventLedeFn = ({
   speakerNames,
   kindLabel,
   modeLabel,
-}) =>
-  `${who(speakerNames)} is ${modeLabel.toLowerCase()} at this ${kindLabel.toLowerCase()}.`;
+}) => {
+  const kind = kindLabel.toLowerCase();
+  const mode = modeLabel.toLowerCase();
+  return mode === 'attending'
+    ? `${who(speakerNames)} is attending this ${kind}.`
+    : `${who(speakerNames)} is ${mode} at this ${kind}.`;
+};
 
 /** The four combinations reachable from seed content each get their own,
  *  more natural phrasing; the other 8 of 12 fall to {@link DEFAULT_EVENT_LEDE}. */
@@ -375,8 +384,9 @@ function composeLede(facts: PromoFacts): string {
     : resourceLede(facts);
 }
 
-/** 3-5 `#tag` tokens on one line (LinkedIn only), derived from facts —
- *  never a hand-typed hashtag list, so it tracks the entry's own kind. */
+/** 3-4 `#tag` tokens on one line (LinkedIn only; AC7's gate accepts 3-5),
+ *  derived from facts — never a hand-typed hashtag list, so it tracks the
+ *  entry's own kind. */
 function buildHashtags(facts: PromoFacts): string {
   const kindTag = facts.kindLabel.replace(/[^A-Za-z0-9]/g, '');
   const tags = ['Thymian', 'API', 'HTTP', kindTag].filter(

--- a/astro-docs/src/lib/promo-post.ts
+++ b/astro-docs/src/lib/promo-post.ts
@@ -1,0 +1,693 @@
+import type { CollectionEntry } from 'astro:content';
+
+import {
+  PARTICIPATION_MODE_LABELS,
+  PARTICIPATION_TYPE_LABELS,
+  resolveEventLinks,
+  resolveGuestAttribution,
+  resolvePlatformLabel,
+} from '../components/events/eventMeta';
+import { RESOURCE_TYPE_LABELS } from '../components/resources/resourceMeta';
+import { blogAuthors } from '../data/team';
+import type { Attribution } from '../schema/attribution';
+import { classify, type EventDate, formatDisplay } from '../schema/event-date';
+import type { ParticipationMode, ParticipationType } from '../schema/events';
+import type { ResourceType } from '../schema/resources';
+import { resolveOriginEvent, urlForEntry } from './cross-links';
+import {
+  PLATFORM_CHAR_LIMITS,
+  PROMO_PLATFORMS,
+  type PromoPlatform,
+  REDDIT_TITLE_LIMIT,
+} from './promo-platforms';
+
+/**
+ * The Epic 11 hub's single field→per-platform-text composition module (AD-8).
+ *
+ * PURE by contract, in the words `src/lib/cross-links.ts` uses for itself:
+ * this module never calls `getCollection`/`getEntry` — callers pass the
+ * already-loaded entry/entries in — so it stays unit-testable with fake
+ * entries and no content fixtures. It additionally never reads the clock
+ * (`buildDate` is an explicit parameter) and never reads `Astro.site` /
+ * `import.meta.env` (`siteUrl` is an explicit parameter).
+ *
+ * Every derivation is delegated to an existing helper (see the AC4 reuse
+ * table in Story 11.1) — this module adds no new date parsing, comparators,
+ * host matching, or attribution branching. The two genuinely new pieces are
+ * the place formatter (a fourth inlined copy — see `EventCard.astro:47`,
+ * `PromoStrip.astro:76`, and `promo-image.ts`'s parallel copy, #448 AC5) and
+ * the platform text templates themselves.
+ */
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+// ---------------------------------------------------------------------------
+// Public types (AC2, AC3) — the single canonical contract.
+// ---------------------------------------------------------------------------
+
+export type PromoSubject =
+  | { kind: 'event'; entry: EventEntry }
+  | { kind: 'resource'; entry: ResourceEntry };
+
+export interface PromoPostBlock {
+  /** Feeds `PostText`'s `label` prop. Optional — `x`, `linkedin` and
+   *  `discord` omit it and inherit `PostText`'s own `'Post text'` default. */
+  label?: string;
+  /** Ready-to-copy text. Never empty, never whitespace-only. */
+  text: string;
+  /** The limit this block was composed against; `null` = no limit. Only the
+   *  terminal-arbitration arm of {@link fitWithinLimit} may return a `text`
+   *  longer than this. */
+  charLimit: number | null;
+}
+
+export interface PromoPost {
+  platform: PromoPlatform;
+  /** >=1 block. `reddit` has exactly 2 (title + body); every other platform
+   *  has 1. */
+  blocks: PromoPostBlock[];
+}
+
+/** The injected, platform-agnostic inputs. */
+export interface PromoInput {
+  subject: PromoSubject;
+  eventsById: Map<string, EventEntry>;
+  siteUrl: URL;
+  buildDate: Date;
+}
+
+/**
+ * One flat, tense-aware fact set — an Event OR a Resource normalised to the
+ * same shape, so all four platform templates read only from this and never
+ * re-derive a field per platform.
+ */
+export interface PromoFacts {
+  title: string;
+  dateDisplay: string | undefined;
+  timeframe: 'upcoming' | 'past';
+  primaryUrl: string;
+  siteEntryUrl: string;
+  speakerNames: string[];
+  kindLabel: string;
+  modeLabel: string | undefined;
+  place: string | undefined;
+  /** Both fields non-empty by construction (AD-13, AC10). `undefined` for a
+   *  `host` or absent attribution. */
+  guestCredit: { externalHost: string; platform: string } | undefined;
+  participation: ParticipationType | undefined;
+  mode: ParticipationMode | undefined;
+  resourceType: ResourceType | undefined;
+  mediaVerb: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Facts layer (AC3, AC4, AC5, AC6, AC10, AC12, AC13).
+// ---------------------------------------------------------------------------
+
+/** Mirrors private `GENERIC_LINK_LABEL` (`resourceMeta.ts`) verbatim — never
+ *  import it (it is module-private and stays that way, AC16). */
+const RESOURCE_MEDIA_VERB = {
+  'recorded talk': 'Watch the recording',
+  webinar: 'Watch the recording',
+  'podcast episode': 'Listen to the episode',
+  paper: 'Read the paper',
+} satisfies Record<ResourceType, string>;
+
+/** Reproduces private `resolveResourceLinkLabel(type, url)` exactly. */
+function resolveMediaVerb(resourceType: ResourceType, url: string): string {
+  if (resourceType === 'paper') {
+    return RESOURCE_MEDIA_VERB.paper;
+  }
+  return resolvePlatformLabel(url) ?? RESOURCE_MEDIA_VERB[resourceType];
+}
+
+/**
+ * AC10's local re-check narrowing: `resolveGuestAttribution` returns
+ * `Attribution | null`, but `Attribution` still TYPES `externalHost` /
+ * `platform` as optional even though its `.refine` guarantees both non-empty
+ * at runtime for a `guest`. Narrow here, explicitly, with no `!`.
+ */
+function toGuestCredit(
+  attribution: Attribution | null,
+): { externalHost: string; platform: string } | undefined {
+  if (attribution === null) {
+    return undefined;
+  }
+  const { externalHost, platform } = attribution;
+  if (externalHost === undefined || platform === undefined) {
+    return undefined;
+  }
+  return { externalHost, platform };
+}
+
+function resolveEventFacts(
+  entry: EventEntry,
+  siteUrl: URL,
+  buildDate: Date,
+): PromoFacts {
+  const { data } = entry;
+  const date = data.date as EventDate;
+  const timeframe = classify(date, buildDate);
+  const dateDisplay = formatDisplay(date);
+  const siteEntryUrl = new URL(urlForEntry(entry), siteUrl).href;
+
+  const links = resolveEventLinks({
+    timeframe,
+    registerUrl: data.registerUrl,
+    resourceUrl: data.resourceUrl,
+  });
+  const guestAttribution = resolveGuestAttribution(data.attribution);
+  const primaryUrl =
+    links[0]?.url ?? guestAttribution?.externalUrl ?? siteEntryUrl;
+
+  const speakerNames = data.speakers.map(
+    (key) => blogAuthors[key]?.name ?? key,
+  );
+  // The fourth inlined copy of `EventCard.astro:47`'s
+  // `const place = online ? 'Online' : location;` — see this module's header
+  // docstring and Story 11.1 Dev Notes ("No place formatter"). Do not
+  // refactor the existing callers to share this (out of scope).
+  const place = data.online ? 'Online' : data.location;
+
+  return {
+    title: data.title,
+    dateDisplay,
+    timeframe,
+    primaryUrl,
+    siteEntryUrl,
+    speakerNames,
+    kindLabel: PARTICIPATION_TYPE_LABELS[data.participation],
+    modeLabel: PARTICIPATION_MODE_LABELS[data.mode],
+    place,
+    guestCredit: toGuestCredit(guestAttribution),
+    participation: data.participation,
+    mode: data.mode,
+    resourceType: undefined,
+    mediaVerb: undefined,
+  };
+}
+
+function resolveResourceFacts(
+  entry: ResourceEntry,
+  eventsById: Map<string, EventEntry>,
+  siteUrl: URL,
+  buildDate: Date,
+): PromoFacts {
+  const { data } = entry;
+  // Throws (AD-6, AC13) on a set-but-dangling `originEvent`; returns
+  // `undefined` (no throw) when `originEvent` is simply unset.
+  const originEvent = resolveOriginEvent(entry, eventsById);
+
+  const timeframe: 'upcoming' | 'past' =
+    originEvent !== undefined
+      ? classify(originEvent.data.date as EventDate, buildDate)
+      : 'past';
+  const dateDisplay =
+    originEvent !== undefined
+      ? formatDisplay(originEvent.data.date as EventDate)
+      : undefined;
+  const siteEntryUrl = new URL(urlForEntry(entry), siteUrl).href;
+  const speakerNames =
+    originEvent !== undefined
+      ? originEvent.data.speakers.map((key) => blogAuthors[key]?.name ?? key)
+      : [];
+
+  const guestAttribution = resolveGuestAttribution(data.attribution);
+
+  return {
+    title: data.title,
+    dateDisplay,
+    timeframe,
+    // A Resource's `url` is schema-required and absolute (AC5) — always
+    // present, no fallback chain needed.
+    primaryUrl: data.url,
+    siteEntryUrl,
+    speakerNames,
+    kindLabel: RESOURCE_TYPE_LABELS[data.resourceType],
+    modeLabel: undefined,
+    place: undefined,
+    guestCredit: toGuestCredit(guestAttribution),
+    participation: undefined,
+    mode: undefined,
+    resourceType: data.resourceType,
+    mediaVerb: resolveMediaVerb(data.resourceType, data.url),
+  };
+}
+
+/**
+ * Turn an Event or a Resource into one flat, tense-aware fact set. Every
+ * derivation delegates to an existing helper (AC4) — see this module's
+ * header docstring.
+ */
+export function resolvePromoFacts(input: PromoInput): PromoFacts {
+  const { subject, eventsById, siteUrl, buildDate } = input;
+  if (subject.kind === 'event') {
+    return resolveEventFacts(subject.entry, siteUrl, buildDate);
+  }
+  return resolveResourceFacts(subject.entry, eventsById, siteUrl, buildDate);
+}
+
+// ---------------------------------------------------------------------------
+// Phrasing tables (AC8).
+// ---------------------------------------------------------------------------
+
+/** Oxford-comma join, e.g. `['A']` → `'A'`, `['A','B']` → `'A and B'`,
+ *  `['A','B','C']` → `'A, B, and C'`. Never called with `[]` (call sites
+ *  guard on `speakerNames.length > 0` first). */
+function joinNames(names: string[]): string {
+  if (names.length === 0) {
+    return '';
+  }
+  if (names.length === 1) {
+    return names[0] as string;
+  }
+  if (names.length === 2) {
+    return `${names[0] as string} and ${names[1] as string}`;
+  }
+  const last = names[names.length - 1] as string;
+  const head = names.slice(0, -1).join(', ');
+  return `${head}, and ${last}`;
+}
+
+function who(speakerNames: string[]): string {
+  return speakerNames.length > 0 ? joinNames(speakerNames) : 'Thymian';
+}
+
+interface EventLedeContext {
+  speakerNames: string[];
+  kindLabel: string;
+  modeLabel: string;
+}
+
+type EventLedeFn = (context: EventLedeContext) => string;
+
+/** Key space built from the imported `ParticipationType`/`ParticipationMode`
+ *  — themselves `(typeof PARTICIPATION_TYPES)[number]` /
+ *  `(typeof PARTICIPATION_MODES)[number]` — never a hand-typed union. */
+type EventLedeKey = `${ParticipationType}:${ParticipationMode}`;
+
+/** Grammatical for all 12 `ParticipationType × ParticipationMode`
+ *  combinations, so adding a new type/mode can never crash the composer. */
+const DEFAULT_EVENT_LEDE: EventLedeFn = ({
+  speakerNames,
+  kindLabel,
+  modeLabel,
+}) =>
+  `${who(speakerNames)} is ${modeLabel.toLowerCase()} at this ${kindLabel.toLowerCase()}.`;
+
+/** The four combinations reachable from seed content each get their own,
+ *  more natural phrasing; the other 8 of 12 fall to {@link DEFAULT_EVENT_LEDE}. */
+const EVENT_LEDES: Partial<Record<EventLedeKey, EventLedeFn>> = {
+  'talk:presenting': ({ speakerNames }) =>
+    `${who(speakerNames)} is giving this talk.`,
+  'booth:attending': ({ speakerNames }) =>
+    `${who(speakerNames)} will be at this booth — stop by and say hello.`,
+  'livestream:presenting': ({ speakerNames }) =>
+    `${who(speakerNames)} is going live for this livestream.`,
+  'paper:presenting': ({ speakerNames }) =>
+    `${who(speakerNames)} is presenting this paper.`,
+};
+
+function eventLede(facts: PromoFacts): string {
+  const context: EventLedeContext = {
+    speakerNames: facts.speakerNames,
+    kindLabel: facts.kindLabel,
+    modeLabel: facts.modeLabel ?? '',
+  };
+  const { participation, mode } = facts;
+  if (participation === undefined || mode === undefined) {
+    // Unreachable for an event subject — resolveEventFacts always sets both.
+    // Kept total (never throws) rather than assuming the invariant.
+    return DEFAULT_EVENT_LEDE(context);
+  }
+  const key: EventLedeKey = `${participation}:${mode}`;
+  const fn = EVENT_LEDES[key];
+  return (fn ?? DEFAULT_EVENT_LEDE)(context);
+}
+
+interface ResourceLedeContext {
+  speakerNames: string[];
+  mediaVerb: string;
+}
+
+type ResourceLedeFn = (context: ResourceLedeContext) => string;
+
+/** A `RESOURCE_TYPES`-keyed table (via the imported `ResourceType`), full
+ *  (not `Partial`) — all 4 resource types are named content, no default arm
+ *  needed. Folds `PromoFacts.mediaVerb` into the sentence so the fact is
+ *  never computed and then left out of the generated text. */
+const RESOURCE_LEDES = {
+  'recorded talk': ({ speakerNames, mediaVerb }) =>
+    speakerNames.length > 0
+      ? `${mediaVerb} — featuring ${joinNames(speakerNames)}.`
+      : `${mediaVerb}.`,
+  webinar: ({ speakerNames, mediaVerb }) =>
+    speakerNames.length > 0
+      ? `${mediaVerb} — featuring ${joinNames(speakerNames)}.`
+      : `${mediaVerb}.`,
+  'podcast episode': ({ speakerNames, mediaVerb }) =>
+    speakerNames.length > 0
+      ? `${mediaVerb} — with ${joinNames(speakerNames)}.`
+      : `${mediaVerb}.`,
+  paper: ({ speakerNames, mediaVerb }) =>
+    speakerNames.length > 0
+      ? `${mediaVerb}, authored by ${joinNames(speakerNames)}.`
+      : `${mediaVerb}.`,
+} satisfies Record<ResourceType, ResourceLedeFn>;
+
+function resourceLede(facts: PromoFacts): string {
+  const { resourceType, mediaVerb, speakerNames } = facts;
+  if (resourceType === undefined || mediaVerb === undefined) {
+    // Unreachable for a resource subject — resolveResourceFacts always sets
+    // both. Kept total (never throws) rather than assuming the invariant.
+    return mediaVerb ?? 'Watch the recording.';
+  }
+  return RESOURCE_LEDES[resourceType]({ speakerNames, mediaVerb });
+}
+
+/** AC8's sentence, dispatched on which half of {@link PromoFacts} is
+ *  populated — `participation` is set only for an event subject. Never
+ *  restates `facts.title` (that is clause 1, kept separate). */
+function composeLede(facts: PromoFacts): string {
+  return facts.participation !== undefined
+    ? eventLede(facts)
+    : resourceLede(facts);
+}
+
+/** 3-5 `#tag` tokens on one line (LinkedIn only), derived from facts —
+ *  never a hand-typed hashtag list, so it tracks the entry's own kind. */
+function buildHashtags(facts: PromoFacts): string {
+  const kindTag = facts.kindLabel.replace(/[^A-Za-z0-9]/g, '');
+  const tags = ['Thymian', 'API', 'HTTP', kindTag].filter(
+    (tag) => tag.length > 0,
+  );
+  return [...new Set(tags)].map((tag) => `#${tag}`).join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Clause layout, the drop plan, and `fitWithinLimit` (AC9, AC11).
+// ---------------------------------------------------------------------------
+
+type ClauseRole =
+  | 'title'
+  | 'lede'
+  | 'kind'
+  | 'mode'
+  | 'date'
+  | 'place'
+  | 'guestCredit'
+  | 'primaryUrl'
+  | 'siteEntryUrl'
+  | 'hashtags'
+  | 'imageCredit';
+
+/** One atom of a composed block, in canonical emission order. Exported so
+ *  {@link fitWithinLimit} can be driven directly with synthetic lists. */
+export interface PromoClause {
+  role: ClauseRole;
+  text: string;
+}
+
+/** Clauses 3-6 (`kind`/`mode`/`date`/`place`) render as one middot-joined
+ *  line — separable atoms, not one fused sentence, so the drop plan can
+ *  remove `place`/`mode`/`date` independently without breaking grammar.
+ *  Every other clause is its own line. */
+function renderClauses(clauses: PromoClause[]): string {
+  const lines: string[] = [];
+  let factsLine: string[] = [];
+
+  const flushFactsLine = () => {
+    if (factsLine.length > 0) {
+      lines.push(factsLine.join(' · '));
+      factsLine = [];
+    }
+  };
+
+  for (const clause of clauses) {
+    if (
+      clause.role === 'kind' ||
+      clause.role === 'mode' ||
+      clause.role === 'date' ||
+      clause.role === 'place'
+    ) {
+      factsLine.push(clause.text);
+      continue;
+    }
+    flushFactsLine();
+    lines.push(clause.text);
+  }
+  flushFactsLine();
+
+  return lines.join('\n');
+}
+
+/** Never below this many characters (including the trailing ellipsis). */
+const TITLE_FLOOR = 40;
+
+/** Truncate `text` to at most `maxLen` characters, on a word boundary, with
+ *  a trailing `…` (U+2026) — but never produce a result shorter than
+ *  {@link TITLE_FLOOR}. A no-op when `text` already fits. */
+function truncateAtWordBoundary(text: string, maxLen: number): string {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  const effectiveMax = Math.max(maxLen, TITLE_FLOOR);
+  const budget = effectiveMax - 1; // room for the ellipsis
+  let cut = text.slice(0, budget);
+  const lastSpace = cut.lastIndexOf(' ');
+  if (lastSpace >= TITLE_FLOOR - 1) {
+    cut = cut.slice(0, lastSpace);
+  }
+  return `${cut}…`;
+}
+
+/**
+ * Step 4 of the drop plan: shrink the `title` clause to the smallest length
+ * (word-boundary, `…`-suffixed) that makes the whole block fit `limit`,
+ * without ever going below {@link TITLE_FLOOR}. A no-op when there is no
+ * `title` clause (e.g. the reddit body).
+ */
+function truncateTitleClause(
+  clauses: PromoClause[],
+  limit: number,
+): PromoClause[] {
+  const titleClause = clauses.find((c) => c.role === 'title');
+  if (titleClause === undefined) {
+    return clauses;
+  }
+
+  const withTitle = (text: string): PromoClause[] =>
+    clauses.map((c) => (c.role === 'title' ? { ...c, text } : c));
+
+  for (let len = titleClause.text.length - 1; len >= TITLE_FLOOR; len -= 1) {
+    const candidate = withTitle(truncateAtWordBoundary(titleClause.text, len));
+    if (renderClauses(candidate).length <= limit) {
+      return candidate;
+    }
+  }
+
+  return withTitle(truncateAtWordBoundary(titleClause.text, TITLE_FLOOR));
+}
+
+/** Steps 1-3 and 5-6 of AC9's drop plan (step 4 is {@link truncateTitleClause},
+ *  step 7 is "no more steps — return what's left"). Never targets
+ *  `guestCredit`, `primaryUrl` or `imageCredit`. */
+const PROSE_ROLES: readonly ClauseRole[] = [
+  'lede',
+  'kind',
+  'siteEntryUrl',
+  'hashtags',
+];
+
+const DROP_STEPS: ((clauses: PromoClause[], limit: number) => PromoClause[])[] =
+  [
+    (clauses) => clauses.filter((c) => c.role !== 'place'),
+    (clauses) => clauses.filter((c) => c.role !== 'mode'),
+    (clauses) => clauses.filter((c) => c.role !== 'date'),
+    (clauses, limit) => truncateTitleClause(clauses, limit),
+    (clauses) => clauses.filter((c) => !PROSE_ROLES.includes(c.role)),
+    (clauses) => clauses.filter((c) => c.role !== 'title'),
+  ];
+
+/**
+ * Apply AC9's ordered drop plan, re-measuring after each step and stopping
+ * as soon as the rendered text fits `limit`. `limit === null` (the reddit
+ * body) never runs a step. `guestCredit`, `primaryUrl` and `imageCredit`
+ * clauses are never targeted by any step — if the block still exceeds
+ * `limit` once every step has run (terminal arbitration), the limit loses:
+ * the over-limit text is returned as-is rather than ever cutting one of
+ * those three. `limit` itself is unaffected — callers still record it as
+ * the block's `charLimit`.
+ */
+export function fitWithinLimit(
+  clauses: PromoClause[],
+  limit: number | null,
+): { text: string; clauses: PromoClause[] } {
+  if (limit === null) {
+    return { text: renderClauses(clauses), clauses };
+  }
+
+  let current = clauses;
+  let text = renderClauses(current);
+
+  for (const step of DROP_STEPS) {
+    if (text.length <= limit) {
+      return { text, clauses: current };
+    }
+    current = step(current, limit);
+    text = renderClauses(current);
+  }
+
+  return { text, clauses: current };
+}
+
+// ---------------------------------------------------------------------------
+// Per-platform clause assembly and the composition entrypoint (AC2, AC7).
+// ---------------------------------------------------------------------------
+
+function buildClauses(input: {
+  facts: PromoFacts;
+  lede: string;
+  platform: PromoPlatform;
+  includeTitle: boolean;
+  includeHashtags: boolean;
+  /** The complete, already-composed licence notice, or `undefined` when
+   *  none was supplied / it was blank. Appended verbatim (AC11) — never
+   *  parsed, split, or reconstructed. */
+  creditClauseText: string | undefined;
+}): PromoClause[] {
+  const {
+    facts,
+    lede,
+    platform,
+    includeTitle,
+    includeHashtags,
+    creditClauseText,
+  } = input;
+  const clauses: PromoClause[] = [];
+
+  if (includeTitle) {
+    // Discord gets a Markdown construct on the title (AC7's per-platform
+    // gate) — every other platform renders it plain.
+    clauses.push({
+      role: 'title',
+      text: platform === 'discord' ? `**${facts.title}**` : facts.title,
+    });
+  }
+
+  clauses.push({ role: 'lede', text: lede });
+  clauses.push({ role: 'kind', text: facts.kindLabel });
+
+  if (facts.modeLabel !== undefined) {
+    clauses.push({ role: 'mode', text: facts.modeLabel });
+  }
+  if (facts.dateDisplay !== undefined) {
+    clauses.push({ role: 'date', text: facts.dateDisplay });
+  }
+  if (facts.place !== undefined) {
+    clauses.push({ role: 'place', text: facts.place });
+  }
+  if (facts.guestCredit !== undefined) {
+    clauses.push({
+      role: 'guestCredit',
+      text: `Guest of ${facts.guestCredit.externalHost} on ${facts.guestCredit.platform}`,
+    });
+  }
+
+  clauses.push({ role: 'primaryUrl', text: facts.primaryUrl });
+
+  // siteEntryUrl: own line on reddit body / linkedin / discord when it
+  // differs from primaryUrl; x never gets a second URL (AC5).
+  if (platform !== 'x' && facts.siteEntryUrl !== facts.primaryUrl) {
+    clauses.push({ role: 'siteEntryUrl', text: facts.siteEntryUrl });
+  }
+
+  if (includeHashtags) {
+    clauses.push({ role: 'hashtags', text: buildHashtags(facts) });
+  }
+
+  if (creditClauseText !== undefined) {
+    clauses.push({ role: 'imageCredit', text: creditClauseText });
+  }
+
+  return clauses;
+}
+
+function buildBlocksForPlatform(
+  platform: PromoPlatform,
+  facts: PromoFacts,
+  lede: string,
+  creditClauseText: string | undefined,
+): PromoPostBlock[] {
+  if (platform === 'reddit') {
+    // Block 1: the title clause ONLY, plain text, no URL.
+    const titleResult = fitWithinLimit(
+      [{ role: 'title', text: facts.title }],
+      REDDIT_TITLE_LIMIT,
+    );
+    // Block 2: full Markdown, every remaining clause — never the title.
+    const bodyClauses = buildClauses({
+      facts,
+      lede,
+      platform,
+      includeTitle: false,
+      includeHashtags: false,
+      creditClauseText,
+    });
+    const bodyResult = fitWithinLimit(bodyClauses, PLATFORM_CHAR_LIMITS.reddit);
+
+    return [
+      {
+        label: 'Title',
+        text: titleResult.text,
+        charLimit: REDDIT_TITLE_LIMIT,
+      },
+      {
+        label: 'Post body',
+        text: bodyResult.text,
+        charLimit: PLATFORM_CHAR_LIMITS.reddit,
+      },
+    ];
+  }
+
+  const clauses = buildClauses({
+    facts,
+    lede,
+    platform,
+    includeTitle: true,
+    includeHashtags: platform === 'linkedin',
+    creditClauseText,
+  });
+  const limit = PLATFORM_CHAR_LIMITS[platform];
+  const result = fitWithinLimit(clauses, limit);
+
+  return [{ text: result.text, charLimit: limit }];
+}
+
+/**
+ * Compose all 4 platform-tailored posts (5 text blocks) for one subject.
+ * Deterministic and side-effect-free: identical input always yields
+ * byte-identical output.
+ */
+export function composePromoPosts(
+  input: PromoInput & {
+    /** The complete, ready-to-publish licence notice as plain text (AC11),
+     *  composed by the caller. Appended verbatim; never parsed, split,
+     *  re-wrapped or reconstructed. */
+    imageCredit?: string;
+  },
+): PromoPost[] {
+  const { imageCredit, ...promoInput } = input;
+  const facts = resolvePromoFacts(promoInput);
+  const lede = composeLede(facts);
+  const creditClauseText =
+    imageCredit !== undefined && imageCredit.trim().length > 0
+      ? imageCredit
+      : undefined;
+
+  return PROMO_PLATFORMS.map((platform) => ({
+    platform,
+    blocks: buildBlocksForPlatform(platform, facts, lede, creditClauseText),
+  }));
+}

--- a/astro-docs/src/pages/social/events-resources/[collection]/[entry].astro
+++ b/astro-docs/src/pages/social/events-resources/[collection]/[entry].astro
@@ -1,0 +1,99 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+
+import HubEntry from '../../../../components/social/HubEntry.astro';
+import SocialLayout from '../../../../components/social/SocialLayout.astro';
+import {
+  assertOriginEventsResolve,
+  indexEventsById,
+} from '../../../../lib/cross-links';
+import { resolvePromoImage } from '../../../../lib/promo-image';
+import {
+  composePromoPosts,
+  resolvePromoFacts,
+  type PromoInput,
+  type PromoSubject,
+} from '../../../../lib/promo-post';
+
+/**
+ * The Epic 11 hub's per-entry route (Story 11.3, AC1/AC3/AC8/AC9/AC10/AC12).
+ * A thin data shell only: `getStaticPaths` + `getCollection` + the AD-6
+ * guard + the three module calls (11.1/11.2) + one `<HubEntry>`. Nothing
+ * else — the rendering itself lives in `HubEntry.astro`.
+ */
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+export async function getStaticPaths() {
+  const [allEvents, allResources] = await Promise.all([
+    getCollection('events'),
+    getCollection('resources'),
+  ]);
+  const entries: (EventEntry | ResourceEntry)[] = [
+    ...allEvents,
+    ...allResources,
+  ];
+  return entries.map((entry) => ({
+    params: { collection: entry.collection, entry: entry.id },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: EventEntry | ResourceEntry;
+}
+
+const { entry } = Astro.props;
+
+// 1. Both collections, freshly loaded in the page frontmatter (a `Map` isn't
+//    serialisable through `getStaticPaths`, and this page needs `eventsById`
+//    for `resolvePromoImage` and both 11.1 calls below).
+const allEvents = await getCollection('events');
+const allResources = await getCollection('resources');
+
+// 2. The AD-6 build-time guard, over the FULL resource set, on this render
+//    path too — Astro 7.1.3 `reference()` is warn-only.
+const eventsById = indexEventsById(allEvents);
+assertOriginEventsResolve(allResources, eventsById);
+
+// 3. Narrow Astro.site (URL | undefined) — never assert.
+const siteUrl = Astro.site;
+if (!siteUrl) {
+  throw new Error(
+    'astro.config.ts must set `site` — promo posts need absolute URLs (#447 AC5).',
+  );
+}
+
+// 4. Build the subject from the resolved entry.
+const subject: PromoSubject =
+  entry.collection === 'events'
+    ? { kind: 'event', entry }
+    : { kind: 'resource', entry };
+
+const buildDate = new Date();
+
+// 5. resolvePromoImage FIRST (11.2) — its `credit` feeds `imageCredit` below.
+const promoImage = resolvePromoImage(entry, eventsById);
+
+// 6. Compose the complete, 3-part licence notice (#448 AC9 / #447 AC11) —
+//    never reach into LOGO_CREDITS / resolveLogoCredits directly.
+const imageCredit =
+  promoImage.kind === 'logo' && promoImage.credit
+    ? `${promoImage.credit.text}, licensed under ${promoImage.credit.licenseName} (${promoImage.credit.licenseUrl}).`
+    : undefined;
+
+// 7-8. One PromoInput, built once, passed to both 11.1 calls.
+const promoInput: PromoInput = { subject, eventsById, siteUrl, buildDate };
+const facts = resolvePromoFacts(promoInput);
+const posts = composePromoPosts({ ...promoInput, imageCredit });
+---
+
+<SocialLayout
+  title={entry.data.title}
+  category="events-resources"
+  slug={entry.id}
+>
+  <HubEntry entry={entry} facts={facts} posts={posts} image={promoImage} />
+</SocialLayout>

--- a/astro-docs/src/pages/social/events-resources/index.astro
+++ b/astro-docs/src/pages/social/events-resources/index.astro
@@ -1,0 +1,153 @@
+---
+import { getCollection } from 'astro:content';
+
+import {
+  compareUpcomingEvents,
+  comparePastEvents,
+} from '../../../components/events/eventMeta';
+import SocialLayout from '../../../components/social/SocialLayout.astro';
+import { hubPathForEntry } from '../../../components/social/socialHubPaths';
+import {
+  assertOriginEventsResolve,
+  indexEventsById,
+  sortResourcesByEffectiveDate,
+} from '../../../lib/cross-links';
+import { classify, type EventDate } from '../../../schema/event-date';
+
+/**
+ * The Epic 11 hub's landing route (Story 11.3, AC2/AC3/AC10) — the "Events &
+ * Resources category" UJ-3 refers to. Lists every event and resource, each
+ * linking to its per-entry hub page via `hubPathForEntry` (AC13).
+ * Grouping/order is delegated, never re-derived.
+ */
+
+const allEvents = await getCollection('events');
+const allResources = await getCollection('resources');
+
+const eventsById = indexEventsById(allEvents);
+// The AD-6 build-time guard, over the FULL resource set, on this render path
+// too — Astro 7.1.3 `reference()` is warn-only.
+assertOriginEventsResolve(allResources, eventsById);
+
+const buildDate = new Date();
+
+const upcomingEvents = allEvents.filter(
+  (event) => classify(event.data.date as EventDate, buildDate) === 'upcoming',
+);
+const pastEvents = allEvents.filter(
+  (event) => classify(event.data.date as EventDate, buildDate) === 'past',
+);
+
+upcomingEvents.sort((a, b) =>
+  compareUpcomingEvents(
+    { date: a.data.date as EventDate, title: a.data.title },
+    { date: b.data.date as EventDate, title: b.data.title },
+  ),
+);
+pastEvents.sort((a, b) =>
+  comparePastEvents(
+    { date: a.data.date as EventDate, title: a.data.title },
+    { date: b.data.date as EventDate, title: b.data.title },
+  ),
+);
+
+const sortedResources = sortResourcesByEffectiveDate(allResources, eventsById);
+---
+
+<SocialLayout
+  title="Events & Resources"
+  description="Branded posts, ready to copy, for every Event and Resource."
+  category="events-resources"
+>
+  <div class="hub-index">
+    <section aria-labelledby="hub-upcoming-heading">
+      <h2 id="hub-upcoming-heading">Upcoming events</h2>
+      {
+        upcomingEvents.length > 0 ? (
+          <ul>
+            {upcomingEvents.map((event) => (
+              <li>
+                <a href={hubPathForEntry(event)}>{event.data.title}</a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="hub-index-empty">No upcoming events.</p>
+        )
+      }
+    </section>
+
+    <section aria-labelledby="hub-past-heading">
+      <h2 id="hub-past-heading">Past events</h2>
+      {
+        pastEvents.length > 0 ? (
+          <ul>
+            {pastEvents.map((event) => (
+              <li>
+                <a href={hubPathForEntry(event)}>{event.data.title}</a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="hub-index-empty">No past events.</p>
+        )
+      }
+    </section>
+
+    <section aria-labelledby="hub-resources-heading">
+      <h2 id="hub-resources-heading">Resources</h2>
+      {
+        sortedResources.length > 0 ? (
+          <ul>
+            {sortedResources.map((resource) => (
+              <li>
+                <a href={hubPathForEntry(resource)}>{resource.data.title}</a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="hub-index-empty">No resources yet.</p>
+        )
+      }
+    </section>
+  </div>
+</SocialLayout>
+
+<style>
+  .hub-index {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .hub-index ul {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .hub-index-empty {
+    margin: 0;
+    color: var(--sl-color-white);
+  }
+
+  /* Same explicit link colour rule as HubEntry.astro: never inherit
+     Starlight's accent-derived link colour. */
+  .hub-index a {
+    color: var(--sl-color-white);
+    text-decoration: underline;
+  }
+
+  .hub-index a:focus-visible {
+    outline: 2px solid #017b64;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  :global(:root[data-theme='dark']) .hub-index a:focus-visible {
+    outline-color: #74cfbf;
+  }
+</style>

--- a/astro-docs/src/pages/social/index.astro
+++ b/astro-docs/src/pages/social/index.astro
@@ -7,5 +7,36 @@ const allPosts = await getCollection('social');
 ---
 
 <SocialLayout title="Social Media Hub">
+  <div class="hub-link-block">
+    <a href="/social/events-resources/">
+      Events &amp; Resources — branded, ready-to-copy posts for every Event
+      and Resource
+    </a>
+  </div>
   <SocialPostList allPosts={allPosts} posts={allPosts} />
 </SocialLayout>
+
+<style>
+  .hub-link-block {
+    margin-bottom: 1.5rem;
+    padding: 0.625rem 1rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+  }
+
+  .hub-link-block a {
+    color: var(--sl-color-white);
+    text-decoration: underline;
+  }
+
+  .hub-link-block a:focus-visible {
+    outline: 2px solid #017b64;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  :global(:root[data-theme='dark']) .hub-link-block a:focus-visible {
+    outline-color: #74cfbf;
+  }
+</style>

--- a/astro-docs/test/promo-image.test.ts
+++ b/astro-docs/test/promo-image.test.ts
@@ -1,0 +1,356 @@
+import type { ImageMetadata } from 'astro';
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it } from 'vitest';
+
+import { indexEventsById } from '../src/lib/cross-links';
+import {
+  type PromoImageResult,
+  resolvePromoImage,
+} from '../src/lib/promo-image';
+import type { Attribution } from '../src/schema/attribution';
+import type { EventDate } from '../src/schema/event-date';
+import type {
+  ParticipationMode,
+  ParticipationType,
+} from '../src/schema/events';
+import type { ResourceType } from '../src/schema/resources';
+
+// Fake entries — mirror the `test/cross-links.test.ts` idiom (minimal object
+// literals cast `as unknown as CollectionEntry<...>`), extended with the
+// fields this resolver actually reads (`logo`, `participation`, `mode`,
+// `location`/`online`, `attribution` for events; `resourceType`,
+// `attribution` for resources). No content fixtures.
+
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+/** A resolved-logo fake, never a real imported asset (per Dev Notes). */
+function fakeLogo(src = '/logo.png'): ImageMetadata {
+  return {
+    src,
+    width: 200,
+    height: 100,
+    format: 'png',
+  } as unknown as ImageMetadata;
+}
+
+interface EventOverrides {
+  title?: string;
+  date?: EventDate;
+  participation?: ParticipationType;
+  mode?: ParticipationMode;
+  location?: string;
+  online?: boolean;
+  attribution?: Attribution;
+  logo?: ImageMetadata;
+}
+
+function event(id: string, overrides: EventOverrides = {}): EventEntry {
+  const {
+    title = id,
+    date = { precision: 'exact', date: new Date('2026-07-08') },
+    participation = 'talk',
+    mode = 'presenting',
+    location,
+    online,
+    attribution,
+    logo,
+  } = overrides;
+  return {
+    id,
+    collection: 'events',
+    data: {
+      title,
+      date,
+      participation,
+      mode,
+      location,
+      online,
+      attribution,
+      logo,
+    },
+  } as unknown as EventEntry;
+}
+
+interface ResourceOverrides {
+  title?: string;
+  resourceType?: ResourceType;
+  attribution?: Attribution;
+  originEventId?: string;
+}
+
+function resource(
+  id: string,
+  overrides: ResourceOverrides = {},
+): ResourceEntry {
+  const {
+    title = id,
+    resourceType = 'recorded talk',
+    attribution,
+    originEventId,
+  } = overrides;
+  return {
+    id,
+    collection: 'resources',
+    data: {
+      title,
+      resourceType,
+      attribution,
+      originEvent:
+        originEventId === undefined
+          ? undefined
+          : { collection: 'events', id: originEventId },
+    },
+  } as unknown as ResourceEntry;
+}
+
+const guestAttribution: Attribution = {
+  hostGuest: 'guest',
+  externalHost: 'My Coding Zone',
+  platform: 'YouTube',
+};
+
+const hostAttribution: Attribution = { hostGuest: 'host' };
+
+/** Narrow a `PromoImageResult` to its `logo` branch or fail the test loudly. */
+function asLogo(
+  result: PromoImageResult,
+): Extract<PromoImageResult, { kind: 'logo' }> {
+  if (result.kind !== 'logo') {
+    throw new Error(`expected kind: 'logo', got kind: '${result.kind}'`);
+  }
+  return result;
+}
+
+describe('resolvePromoImage — contract (AC1/AC6)', () => {
+  it('takes exactly two parameters — no platform, not even optional', () => {
+    expect(resolvePromoImage).toHaveLength(2);
+  });
+});
+
+describe('resolvePromoImage — Event logo branch (AC2)', () => {
+  it('returns kind: logo with the unmodified image and "<title> logo" alt', () => {
+    const logo = fakeLogo();
+    const ev = event('apidays', { title: 'apidays Munich', logo });
+    const result = asLogo(resolvePromoImage(ev, indexEventsById([ev])));
+    // Reference-identical, not deep-equal (AC6/AC8) — `toBe`, never `toEqual`.
+    expect(result.image).toBe(logo);
+    expect(result.brand).toBe('apidays Munich');
+    expect(result.alt).toBe('apidays Munich logo');
+  });
+
+  it('a Guest event derives brand/alt from externalHost, not title', () => {
+    const logo = fakeLogo();
+    const ev = event('mcz', {
+      title: 'Should I GET or Should I POST',
+      attribution: guestAttribution,
+      online: true,
+      logo,
+    });
+    const result = asLogo(resolvePromoImage(ev, indexEventsById([ev])));
+    expect(result.brand).toBe('My Coding Zone');
+    expect(result.alt).toBe('My Coding Zone logo');
+  });
+});
+
+describe('resolvePromoImage — Event card branch (AC5)', () => {
+  it('returns kind: card with headline = title and the exact subheadline', () => {
+    const ev = event('apidays', {
+      title: 'apidays Munich',
+      location: 'Munich',
+      date: { precision: 'exact', date: new Date('2026-07-08') },
+    });
+    const result = resolvePromoImage(ev, indexEventsById([ev]));
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'apidays Munich',
+      subheadline: 'Talk · July 8, 2026 · Munich',
+    });
+  });
+
+  it('an online event with no location resolves place to "Online"', () => {
+    const ev = event('mcz', {
+      title: 'Livestream',
+      participation: 'livestream',
+      online: true,
+      date: { precision: 'exact', date: new Date('2026-07-10') },
+    });
+    const result = resolvePromoImage(ev, indexEventsById([ev]));
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'Livestream',
+      subheadline: 'Livestream · July 10, 2026 · Online',
+    });
+  });
+
+  it('a TBA-date event yields "Date TBA" verbatim, filtered like any other fragment', () => {
+    const ev = event('future', {
+      title: 'Future Talk',
+      location: 'Berlin',
+      date: { precision: 'tba' },
+    });
+    const result = resolvePromoImage(ev, indexEventsById([ev]));
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'Future Talk',
+      subheadline: 'Talk · Date TBA · Berlin',
+    });
+  });
+
+  it('filters an empty place fragment without a doubled or trailing separator', () => {
+    // Not a schema-valid combination (the `.refine` requires physical XOR
+    // online) — but the resolver reads through `astro:content` types, not
+    // the runtime validator, so it must stay defensive under strict TS
+    // regardless of whether the content author violated the refine.
+    const ev = event('placeless', {
+      title: 'Placeless',
+      date: { precision: 'exact', date: new Date('2026-09-15') },
+    });
+    const result = resolvePromoImage(ev, indexEventsById([ev]));
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'Placeless',
+      subheadline: 'Talk · September 15, 2026',
+    });
+  });
+});
+
+describe('resolvePromoImage — Resource logo inheritance (AC3)', () => {
+  it('a Resource whose Origin Event has a logo inherits kind: logo', () => {
+    const logo = fakeLogo();
+    const originEvent = event('mcz', {
+      title: 'MCZ Livestream',
+      attribution: guestAttribution,
+      logo,
+    });
+    const eventsById = indexEventsById([originEvent]);
+    const res = resource('recording', { originEventId: 'mcz' });
+    const result = asLogo(resolvePromoImage(res, eventsById));
+    // Reference-identical to the ORIGIN EVENT's logo, never re-derived.
+    expect(result.image).toBe(logo);
+    expect(result.brand).toBe('My Coding Zone');
+  });
+});
+
+describe('resolvePromoImage — Resource card branch (AC3/AC5)', () => {
+  it('Origin Event has no logo → card, guest subheadline mirrors ResourceAttribution wording', () => {
+    const originEvent = event('mcz', {
+      title: 'MCZ Livestream',
+      attribution: guestAttribution,
+    });
+    const eventsById = indexEventsById([originEvent]);
+    const res = resource('recording', {
+      title: 'Should I GET or Should I POST',
+      resourceType: 'recorded talk',
+      attribution: guestAttribution,
+      originEventId: 'mcz',
+    });
+    const result = resolvePromoImage(res, eventsById);
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'Should I GET or Should I POST',
+      subheadline: 'Recorded Talk · Guest of My Coding Zone on YouTube',
+    });
+  });
+
+  it('a Host resource omits the guest fragment entirely — no separator, no trailer', () => {
+    const originEvent = event('conf', {
+      title: 'Conf',
+      attribution: hostAttribution,
+    });
+    const eventsById = indexEventsById([originEvent]);
+    const res = resource('paper', {
+      title: 'The Paper',
+      resourceType: 'paper',
+      attribution: hostAttribution,
+      originEventId: 'conf',
+    });
+    const result = resolvePromoImage(res, eventsById);
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'The Paper',
+      subheadline: 'Paper',
+    });
+  });
+
+  it('a Resource with no originEvent at all resolves to card (FR-17 fallback)', () => {
+    const res = resource('standalone', {
+      title: 'Standalone Paper',
+      resourceType: 'paper',
+      attribution: hostAttribution,
+    });
+    const result = resolvePromoImage(res, indexEventsById([]));
+    expect(result).toEqual({
+      kind: 'card',
+      headline: 'Standalone Paper',
+      subheadline: 'Paper',
+    });
+  });
+});
+
+describe('resolvePromoImage — AD-6 dangling originEvent (AC4)', () => {
+  it('throws, with AD-6 in the message, and never falls back to a card', () => {
+    const res = resource('ghost-resource', {
+      title: 'Ghost',
+      originEventId: 'no-such-event',
+    });
+    expect(() => resolvePromoImage(res, indexEventsById([]))).toThrow(/AD-6/);
+  });
+});
+
+describe('resolvePromoImage — licence credit (AC7)', () => {
+  it('the FrosCon event with a logo carries the CC BY-ND credit', () => {
+    const logo = fakeLogo();
+    const froscon = event('froscon-community-booth', {
+      title: 'FrosCon: Community Booth',
+      participation: 'booth',
+      mode: 'attending',
+      location: 'Sankt Augustin',
+      logo,
+    });
+    const result = asLogo(
+      resolvePromoImage(froscon, indexEventsById([froscon])),
+    );
+    expect(result.credit?.licenseName).toBe('CC BY-ND 3.0 DE');
+  });
+
+  it('the same FrosCon entry WITHOUT a logo carries no credit (text fallback obliges nothing)', () => {
+    const froscon = event('froscon-community-booth', {
+      title: 'FrosCon: Community Booth',
+      participation: 'booth',
+      mode: 'attending',
+      location: 'Sankt Augustin',
+    });
+    const result = resolvePromoImage(froscon, indexEventsById([froscon]));
+    expect(result.kind).toBe('card');
+    expect((result as { credit?: unknown }).credit).toBeUndefined();
+  });
+
+  it('an unregistered event with a logo carries credit === undefined, never []', () => {
+    const logo = fakeLogo();
+    const ev = event('frankenjs-spice-up-your-api', {
+      title: 'FrankenJS',
+      logo,
+    });
+    const result = asLogo(resolvePromoImage(ev, indexEventsById([ev])));
+    expect(result.credit).toBeUndefined();
+  });
+
+  it('a Resource inheriting the FrosCon logo resolves credit off the Origin Event id, not the resource id', () => {
+    const logo = fakeLogo();
+    const froscon = event('froscon-community-booth', {
+      title: 'FrosCon: Community Booth',
+      participation: 'booth',
+      mode: 'attending',
+      location: 'Sankt Augustin',
+      logo,
+    });
+    const eventsById = indexEventsById([froscon]);
+    const res = resource('froscon-recap', {
+      title: 'FrosCon recap',
+      originEventId: 'froscon-community-booth',
+    });
+    const result = asLogo(resolvePromoImage(res, eventsById));
+    expect(result.credit?.licenseName).toBe('CC BY-ND 3.0 DE');
+  });
+});

--- a/astro-docs/test/promo-post.test.ts
+++ b/astro-docs/test/promo-post.test.ts
@@ -1,0 +1,1065 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it } from 'vitest';
+
+import { blogAuthors } from '../src/data/team';
+import { indexEventsById } from '../src/lib/cross-links';
+import {
+  PLATFORM_CHAR_LIMITS,
+  PROMO_PLATFORMS,
+  type PromoPlatform,
+  REDDIT_TITLE_LIMIT,
+} from '../src/lib/promo-platforms';
+import {
+  composePromoPosts,
+  fitWithinLimit,
+  type PromoClause,
+  type PromoInput,
+  type PromoPost,
+  type PromoPostBlock,
+  resolvePromoFacts,
+} from '../src/lib/promo-post';
+import type { Attribution } from '../src/schema/attribution';
+import type { EventDate } from '../src/schema/event-date';
+import {
+  PARTICIPATION_MODES,
+  PARTICIPATION_TYPES,
+  type ParticipationMode,
+  type ParticipationType,
+} from '../src/schema/events';
+import type { ResourceType } from '../src/schema/resources';
+import { TEAM_KEYS } from '../src/schema/team-keys';
+
+// Fake entries — mirror the `event()`/`resource()` idiom in
+// `test/cross-links.test.ts` / `test/promo-strip-meta.test.ts`: minimal
+// object literals cast `as unknown as EventEntry`/`ResourceEntry`. No
+// content fixtures. A fixed BUILD_DATE and siteUrl throughout — the module
+// must never read the real clock or `Astro.site`.
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+const BUILD_DATE = new Date('2026-08-01');
+const SITE_URL = new URL('https://thymian.dev');
+
+const exact = (iso: string): EventDate => ({
+  precision: 'exact',
+  date: new Date(iso),
+});
+const monthPrecision = (year: number, month: number): EventDate => ({
+  precision: 'month',
+  year,
+  month,
+});
+const tba: EventDate = { precision: 'tba' };
+
+interface EventOverrides {
+  title?: string;
+  participation?: ParticipationType;
+  mode?: ParticipationMode;
+  speakers?: string[];
+  location?: string;
+  online?: boolean;
+  date?: EventDate;
+  attribution?: Attribution;
+  registerUrl?: string;
+  resourceUrl?: string;
+}
+
+function event(id: string, overrides: EventOverrides = {}): EventEntry {
+  return {
+    id,
+    collection: 'events',
+    data: {
+      title: overrides.title ?? id,
+      participation: overrides.participation ?? 'talk',
+      mode: overrides.mode ?? 'presenting',
+      speakers: overrides.speakers ?? [],
+      location: overrides.location,
+      online: overrides.online,
+      date: overrides.date ?? exact('2026-07-08'),
+      attribution: overrides.attribution,
+      registerUrl: overrides.registerUrl,
+      resourceUrl: overrides.resourceUrl,
+    },
+  } as unknown as EventEntry;
+}
+
+interface ResourceOverrides {
+  title?: string;
+  resourceType?: ResourceType;
+  url?: string;
+  embeddable?: boolean;
+  attribution?: Attribution;
+  originEvent?: string;
+}
+
+function resource(
+  id: string,
+  overrides: ResourceOverrides = {},
+): ResourceEntry {
+  return {
+    id,
+    collection: 'resources',
+    data: {
+      title: overrides.title ?? id,
+      resourceType: overrides.resourceType ?? 'recorded talk',
+      url: overrides.url ?? 'https://example.com/resource',
+      embeddable: overrides.embeddable ?? true,
+      attribution: overrides.attribution ?? { hostGuest: 'host' },
+      originEvent:
+        overrides.originEvent === undefined
+          ? undefined
+          : { collection: 'events', id: overrides.originEvent },
+    },
+  } as unknown as ResourceEntry;
+}
+
+const TEAM_KEY = TEAM_KEYS[0] as string;
+const TEAM_NAME = blogAuthors[TEAM_KEY]?.name ?? TEAM_KEY;
+
+const GUEST_ATTRIBUTION: Attribution = {
+  hostGuest: 'guest',
+  externalHost: 'My Coding Zone',
+  platform: 'YouTube',
+  externalUrl: 'https://www.youtube.com/watch?v=1IvUSEnGkZ8',
+};
+
+// The 6 seed-shaped subjects (5 Events + 1 Resource), matching the content
+// reality table in the story's Dev Notes (verified 2026-08-11/12).
+function apidaysEvent(overrides: EventOverrides = {}): EventEntry {
+  return event('apidays-munich-should-i-get-or-should-i-post', {
+    title:
+      'apidays Munich: Should I GET or Should I POST — The Clash With HTTP Conformance',
+    participation: 'talk',
+    mode: 'presenting',
+    speakers: [TEAM_KEY],
+    location: 'Munich',
+    date: exact('2026-07-08'),
+    ...overrides,
+  });
+}
+
+function frankenjsEvent(overrides: EventOverrides = {}): EventEntry {
+  return event('frankenjs-spice-up-your-api', {
+    title: 'FrankenJS: Spice Up Your API With Thymian',
+    participation: 'talk',
+    mode: 'presenting',
+    speakers: [TEAM_KEY],
+    location: 'Nuremberg',
+    date: exact('2024-10-23'),
+    ...overrides,
+  });
+}
+
+function frosconEvent(overrides: EventOverrides = {}): EventEntry {
+  return event('froscon-community-booth', {
+    title: 'FrosCon: Community Booth',
+    participation: 'booth',
+    mode: 'attending',
+    speakers: [],
+    location: 'Sankt Augustin',
+    date: exact('2026-08-15'),
+    ...overrides,
+  });
+}
+
+function mczEvent(overrides: EventOverrides = {}): EventEntry {
+  return event('my-coding-zone-should-i-get-or-should-i-post', {
+    title: 'Should I GET or Should I POST — The Clash With HTTP Conformance',
+    participation: 'livestream',
+    mode: 'presenting',
+    speakers: [TEAM_KEY],
+    online: true,
+    date: exact('2026-07-10'),
+    attribution: GUEST_ATTRIBUTION,
+    resourceUrl: 'https://www.youtube.com/watch?v=1IvUSEnGkZ8',
+    ...overrides,
+  });
+}
+
+function webistEvent(overrides: EventOverrides = {}): EventEntry {
+  return event('webist-research-paper', {
+    title: 'WEBIST: Research Paper',
+    participation: 'paper',
+    mode: 'presenting',
+    speakers: [],
+    location: 'Angers, France',
+    date: exact('2026-10-27'),
+    ...overrides,
+  });
+}
+
+function mczResource(overrides: ResourceOverrides = {}): ResourceEntry {
+  return resource('should-i-get-or-should-i-post-recording', {
+    title: 'Should I GET or Should I POST — The Clash With HTTP Conformance',
+    resourceType: 'recorded talk',
+    url: 'https://www.youtube.com/watch?v=1IvUSEnGkZ8',
+    attribution: GUEST_ATTRIBUTION,
+    originEvent: 'my-coding-zone-should-i-get-or-should-i-post',
+    ...overrides,
+  });
+}
+
+function eventInput(
+  entry: EventEntry,
+  eventsById: Map<string, EventEntry> = new Map(),
+): PromoInput {
+  return {
+    subject: { kind: 'event', entry },
+    eventsById,
+    siteUrl: SITE_URL,
+    buildDate: BUILD_DATE,
+  };
+}
+
+function resourceInput(
+  entry: ResourceEntry,
+  eventsById: Map<string, EventEntry>,
+): PromoInput {
+  return {
+    subject: { kind: 'resource', entry },
+    eventsById,
+    siteUrl: SITE_URL,
+    buildDate: BUILD_DATE,
+  };
+}
+
+function findPost(posts: PromoPost[], platform: PromoPlatform): PromoPost {
+  const post = posts.find((p) => p.platform === platform);
+  if (post === undefined) {
+    throw new Error(`no post for platform "${platform}"`);
+  }
+  return post;
+}
+
+function firstBlock(post: PromoPost): PromoPostBlock {
+  const block = post.blocks[0];
+  if (block === undefined) {
+    throw new Error(`post for platform "${post.platform}" has no blocks`);
+  }
+  return block;
+}
+
+function lastBlock(post: PromoPost): PromoPostBlock {
+  const block = post.blocks[post.blocks.length - 1];
+  if (block === undefined) {
+    throw new Error(`post for platform "${post.platform}" has no blocks`);
+  }
+  return block;
+}
+
+// ---------------------------------------------------------------------------
+// Module shape and purity (AC1)
+// ---------------------------------------------------------------------------
+
+describe('promo-platforms.ts — module shape (AC1)', () => {
+  it('exports all four symbols with the pinned values', () => {
+    expect(PROMO_PLATFORMS).toEqual(['reddit', 'x', 'linkedin', 'discord']);
+    expect(PLATFORM_CHAR_LIMITS).toEqual({
+      reddit: null,
+      x: 280,
+      linkedin: 3000,
+      discord: 2000,
+    });
+    expect(Object.keys(PLATFORM_CHAR_LIMITS)).toEqual([...PROMO_PLATFORMS]);
+    expect(REDDIT_TITLE_LIMIT).toBe(300);
+  });
+});
+
+describe('composePromoPosts — determinism and purity (AC1)', () => {
+  it('is deterministic: two calls with identical input return identical output', () => {
+    const input = eventInput(apidaysEvent());
+    expect(composePromoPosts(input)).toEqual(composePromoPosts(input));
+  });
+
+  it('never reads the real clock: only the injected buildDate affects timeframe', () => {
+    const ev = event('flip', { date: exact('2026-06-15') });
+    const early = resolvePromoFacts({
+      ...eventInput(ev),
+      buildDate: new Date('2026-01-01'),
+    });
+    const late = resolvePromoFacts({
+      ...eventInput(ev),
+      buildDate: new Date('2026-12-01'),
+    });
+    expect(early.timeframe).toBe('upcoming');
+    expect(late.timeframe).toBe('past');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Return shape (AC2, AC7)
+// ---------------------------------------------------------------------------
+
+describe('composePromoPosts — return shape (AC2, AC7)', () => {
+  const posts = composePromoPosts(eventInput(apidaysEvent()));
+
+  it('returns exactly 4 posts, in PROMO_PLATFORMS order, with 5 blocks total (2,1,1,1)', () => {
+    expect(posts).toHaveLength(4);
+    expect(posts.map((p) => p.platform)).toEqual([...PROMO_PLATFORMS]);
+    expect(posts.map((p) => p.blocks.length)).toEqual([2, 1, 1, 1]);
+  });
+
+  it('every block text is non-empty and not whitespace-only', () => {
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        expect(block.text.length).toBeGreaterThan(0);
+        expect(block.text.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('pins charLimit per block: reddit [300,null], x 280, linkedin 3000, discord 2000', () => {
+    expect(posts.map((p) => p.blocks.map((b) => b.charLimit))).toEqual([
+      [REDDIT_TITLE_LIMIT, null],
+      [280],
+      [3000],
+      [2000],
+    ]);
+  });
+
+  it('pins the label tuple exactly', () => {
+    expect(posts.map((p) => p.blocks.map((b) => b.label))).toEqual([
+      ['Title', 'Post body'],
+      [undefined],
+      [undefined],
+      [undefined],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Facts layer (AC3, AC4)
+// ---------------------------------------------------------------------------
+
+describe('resolvePromoFacts — facts layer (AC3, AC4)', () => {
+  it('returns the exact apidays-shaped fact set', () => {
+    const facts = resolvePromoFacts(eventInput(apidaysEvent()));
+    expect(facts.dateDisplay).toBe('July 8, 2026');
+    expect(facts.kindLabel).toBe('Talk');
+    expect(facts.modeLabel).toBe('Presenting');
+    expect(facts.place).toBe('Munich');
+    expect(facts.guestCredit).toBeUndefined();
+    expect(facts.participation).toBe('talk');
+    expect(facts.mode).toBe('presenting');
+    expect(facts.resourceType).toBeUndefined();
+    expect(facts.mediaVerb).toBeUndefined();
+    expect(facts.speakerNames).toEqual([TEAM_NAME]);
+  });
+
+  it('renders month precision as "Month YYYY"', () => {
+    const facts = resolvePromoFacts(
+      eventInput(event('m', { date: monthPrecision(2026, 9) })),
+    );
+    expect(facts.dateDisplay).toBe('September 2026');
+  });
+
+  it('renders tba precision as "Date TBA"', () => {
+    const facts = resolvePromoFacts(eventInput(event('t', { date: tba })));
+    expect(facts.dateDisplay).toBe('Date TBA');
+  });
+
+  it('resolves online:true to place "Online"', () => {
+    const facts = resolvePromoFacts(
+      eventInput(event('o', { online: true, location: undefined })),
+    );
+    expect(facts.place).toBe('Online');
+  });
+
+  it('resolves a physical location to that exact string', () => {
+    const facts = resolvePromoFacts(
+      eventInput(event('l', { location: 'Berlin' })),
+    );
+    expect(facts.place).toBe('Berlin');
+  });
+
+  it('resolves a speaker key to its blogAuthors display name, falling back to the key for an unknown one', () => {
+    const known = resolvePromoFacts(
+      eventInput(event('k', { speakers: [TEAM_KEY] })),
+    );
+    expect(known.speakerNames).toEqual([TEAM_NAME]);
+
+    const unknown = resolvePromoFacts(
+      eventInput(event('u', { speakers: ['notARealKey'] })),
+    );
+    expect(unknown.speakerNames).toEqual(['notARealKey']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outward link (AC5)
+// ---------------------------------------------------------------------------
+
+describe('resolvePromoFacts — outward link precedence (AC5)', () => {
+  it('falls back to siteEntryUrl when no register/resource/external URL exists', () => {
+    const facts = resolvePromoFacts(
+      eventInput(event('none-links', { date: exact('2027-01-01') })),
+    );
+    expect(facts.primaryUrl).toBe('https://thymian.dev/events/');
+  });
+
+  it('an upcoming event with registerUrl uses that URL', () => {
+    const facts = resolvePromoFacts(
+      eventInput(
+        event('reg', {
+          date: exact('2027-01-01'),
+          registerUrl: 'https://example.com/signup',
+        }),
+      ),
+    );
+    expect(facts.primaryUrl).toBe('https://example.com/signup');
+  });
+
+  it('a past event with resourceUrl uses that URL', () => {
+    const facts = resolvePromoFacts(
+      eventInput(
+        event('res', {
+          date: exact('2020-01-01'),
+          resourceUrl: 'https://example.com/recording',
+        }),
+      ),
+    );
+    expect(facts.primaryUrl).toBe('https://example.com/recording');
+  });
+
+  it('an upcoming event with only resourceUrl falls through to siteEntryUrl (resolveEventLinks returns [])', () => {
+    const facts = resolvePromoFacts(
+      eventInput(
+        event('upcoming-resource-only', {
+          date: exact('2027-01-01'),
+          resourceUrl: 'https://example.com/recording',
+        }),
+      ),
+    );
+    expect(facts.primaryUrl).toBe('https://thymian.dev/events/');
+  });
+
+  it("a guest event with no register/resource URL uses the guest attribution's externalUrl", () => {
+    const facts = resolvePromoFacts(
+      eventInput(mczEvent({ resourceUrl: undefined })),
+    );
+    expect(facts.primaryUrl).toBe(GUEST_ATTRIBUTION.externalUrl);
+  });
+
+  it('a resource always uses its own entry.data.url', () => {
+    const eventsById = indexEventsById([mczEvent()]);
+    const facts = resolvePromoFacts(resourceInput(mczResource(), eventsById));
+    expect(facts.primaryUrl).toBe(
+      'https://www.youtube.com/watch?v=1IvUSEnGkZ8',
+    );
+  });
+
+  it('siteEntryUrl appears on reddit body / linkedin / discord when it differs from primaryUrl, never on x', () => {
+    const posts = composePromoPosts(
+      eventInput(
+        event('diff-url', {
+          date: exact('2027-01-01'),
+          registerUrl: 'https://example.com/signup',
+        }),
+      ),
+    );
+    const siteEntryLine = 'https://thymian.dev/events/';
+
+    expect(lastBlock(findPost(posts, 'reddit')).text).toContain(siteEntryLine);
+    expect(lastBlock(findPost(posts, 'linkedin')).text).toContain(
+      siteEntryLine,
+    );
+    expect(lastBlock(findPost(posts, 'discord')).text).toContain(siteEntryLine);
+    expect(lastBlock(findPost(posts, 'x')).text).not.toContain(siteEntryLine);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource timeframe and date (AC6)
+// ---------------------------------------------------------------------------
+
+describe('resolvePromoFacts — resource timeframe & date (AC6)', () => {
+  it('an origin event dated after buildDate yields timeframe "upcoming" with its display string', () => {
+    const eventsById = indexEventsById([
+      event('future', { date: exact('2027-05-01') }),
+    ]);
+    const facts = resolvePromoFacts(
+      resourceInput(
+        resource('r-future', { originEvent: 'future' }),
+        eventsById,
+      ),
+    );
+    expect(facts.timeframe).toBe('upcoming');
+    expect(facts.dateDisplay).toBe('May 1, 2027');
+  });
+
+  it('an origin event in the past yields timeframe "past"', () => {
+    const eventsById = indexEventsById([
+      event('bygone', { date: exact('2020-01-01') }),
+    ]);
+    const facts = resolvePromoFacts(
+      resourceInput(resource('r-past', { originEvent: 'bygone' }), eventsById),
+    );
+    expect(facts.timeframe).toBe('past');
+  });
+
+  it('no originEvent yields timeframe "past", dateDisplay undefined, and no date substring in any block', () => {
+    const facts = resolvePromoFacts(
+      resourceInput(resource('orphan'), new Map()),
+    );
+    expect(facts.timeframe).toBe('past');
+    expect(facts.dateDisplay).toBeUndefined();
+
+    const posts = composePromoPosts(
+      resourceInput(resource('orphan'), new Map()),
+    );
+    const monthNames =
+      /\b(January|February|March|April|May|June|July|August|September|October|November|December)\b/;
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        expect(block.text).not.toMatch(monthNames);
+      }
+    }
+  });
+
+  it("a resource's place, modeLabel, participation and mode are all undefined", () => {
+    const facts = resolvePromoFacts(
+      resourceInput(resource('r-shape'), new Map()),
+    );
+    expect(facts.place).toBeUndefined();
+    expect(facts.modeLabel).toBeUndefined();
+    expect(facts.participation).toBeUndefined();
+    expect(facts.mode).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-platform contract & falsifiable gates (AC7)
+// ---------------------------------------------------------------------------
+
+describe('composePromoPosts — per-platform contract & falsifiable gates (AC7)', () => {
+  const ev = apidaysEvent();
+  const posts = composePromoPosts(eventInput(ev));
+  const facts = resolvePromoFacts(eventInput(ev));
+
+  const redditPost = findPost(posts, 'reddit');
+  const redditTitleBlock = firstBlock(redditPost);
+  const redditBody = lastBlock(redditPost).text;
+  const xBody = firstBlock(findPost(posts, 'x')).text;
+  const linkedinBody = firstBlock(findPost(posts, 'linkedin')).text;
+  const discordBody = firstBlock(findPost(posts, 'discord')).text;
+
+  it('reddit block 1 is within REDDIT_TITLE_LIMIT and contains no "http"', () => {
+    expect(redditTitleBlock.text.length).toBeLessThanOrEqual(
+      REDDIT_TITLE_LIMIT,
+    );
+    expect(redditTitleBlock.text).not.toContain('http');
+  });
+
+  it('the four bodies (reddit body, x, linkedin, discord) are pairwise different', () => {
+    const bodies = [redditBody, xBody, linkedinBody, discordBody];
+    for (let i = 0; i < bodies.length; i += 1) {
+      for (let j = i + 1; j < bodies.length; j += 1) {
+        expect(bodies[i]).not.toBe(bodies[j]);
+      }
+    }
+  });
+
+  it("linkedin: body >280 chars (a richer subject actually uses LinkedIn's room), hashtag-only final line, no fence", () => {
+    // apidays alone renders a lean ~211-char body — genuinely native, not
+    // padded (Dev Notes: "a well-structured 400-character LinkedIn body
+    // beats a padded 2,900"). A richer real-shaped subject (longer title,
+    // longer location, a guest credit) legitimately fills more of LinkedIn's
+    // room, which is what this bullet is checking.
+    const richEvent = event('linkedin-rich', {
+      title:
+        'A Very Long And Fully Descriptive Conference Talk Title About HTTP Conformance Testing And Validation Strategies',
+      participation: 'talk',
+      mode: 'presenting',
+      speakers: [TEAM_KEY],
+      location:
+        'A City With A Very Long And Descriptive Name, Somewhere In Europe',
+      date: exact('2026-07-08'),
+      attribution: GUEST_ATTRIBUTION,
+    });
+    const richBody = firstBlock(
+      findPost(composePromoPosts(eventInput(richEvent)), 'linkedin'),
+    ).text;
+
+    expect(richBody.length).toBeGreaterThan(280);
+    const lines = richBody.split('\n').filter((l) => l.length > 0);
+    const lastLine = lines[lines.length - 1];
+    expect(lastLine).toMatch(/^#[A-Za-z0-9]+( #[A-Za-z0-9]+){2,4}$/);
+    expect(richBody).not.toContain('```');
+  });
+
+  it("linkedin: the apidays-shaped body's title lands within the first ~210-character fold", () => {
+    expect(linkedinBody.slice(0, 210)).toContain(ev.data.title);
+  });
+
+  it('x: body has no "#" and no "](", and its last content line is exactly primaryUrl', () => {
+    expect(xBody).not.toContain('#');
+    expect(xBody).not.toContain('](');
+    const lines = xBody.split('\n').filter((l) => l.length > 0);
+    expect(lines[lines.length - 1]).toBe(facts.primaryUrl);
+  });
+
+  it('discord: has >=1 Markdown construct and no hashtag-only line', () => {
+    const lines = discordBody.split('\n');
+    const hasMarkdown =
+      discordBody.includes('**') ||
+      lines.some((l) => l.startsWith('- ') || l.startsWith('> '));
+    expect(hasMarkdown).toBe(true);
+    expect(lines.some((l) => /^#[A-Za-z0-9]+(\s#[A-Za-z0-9]+)*$/.test(l))).toBe(
+      false,
+    );
+  });
+
+  it('neither the linkedin nor the discord body is a prefix of the other', () => {
+    expect(linkedinBody.startsWith(discordBody)).toBe(false);
+    expect(discordBody.startsWith(linkedinBody)).toBe(false);
+  });
+
+  it('golden-facts check: the linkedin body contains every apidays fact verbatim', () => {
+    expect(linkedinBody).toContain(ev.data.title);
+    expect(linkedinBody).toContain('Talk');
+    expect(linkedinBody).toContain('Presenting');
+    expect(linkedinBody).toContain('July 8, 2026');
+    expect(linkedinBody).toContain('Munich');
+    expect(linkedinBody).toContain(TEAM_NAME);
+    expect(linkedinBody).toContain('https://thymian.dev/events/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phrasing (AC8)
+// ---------------------------------------------------------------------------
+
+describe('composePromoPosts — phrasing (AC8)', () => {
+  it('booth/attending and talk/presenting yield different lede text for an otherwise identical entry', () => {
+    const talkPosts = composePromoPosts(
+      eventInput(
+        event('e-talk', {
+          participation: 'talk',
+          mode: 'presenting',
+          speakers: [],
+        }),
+      ),
+    );
+    const boothPosts = composePromoPosts(
+      eventInput(
+        event('e-booth', {
+          participation: 'booth',
+          mode: 'attending',
+          speakers: [],
+        }),
+      ),
+    );
+    const talkX = firstBlock(findPost(talkPosts, 'x')).text;
+    const boothX = firstBlock(findPost(boothPosts, 'x')).text;
+    expect(talkX).not.toBe(boothX);
+  });
+
+  it('all 12 ParticipationType x ParticipationMode combinations compose without throwing, non-empty text', () => {
+    for (const participation of PARTICIPATION_TYPES) {
+      for (const mode of PARTICIPATION_MODES) {
+        const posts = composePromoPosts(
+          eventInput(
+            event(`combo-${participation}-${mode}`, { participation, mode }),
+          ),
+        );
+        for (const post of posts) {
+          for (const block of post.blocks) {
+            expect(block.text.trim().length).toBeGreaterThan(0);
+          }
+        }
+      }
+    }
+  });
+
+  it('resource verbs: paper -> Read the paper; recognised/unrecognised hosts pick the right verb', () => {
+    expect(
+      resolvePromoFacts(
+        resourceInput(
+          resource('paper-r', {
+            resourceType: 'paper',
+            url: 'https://example.com/paper.pdf',
+          }),
+          new Map(),
+        ),
+      ).mediaVerb,
+    ).toBe('Read the paper');
+
+    expect(
+      resolvePromoFacts(
+        resourceInput(
+          resource('talk-yt', {
+            resourceType: 'recorded talk',
+            url: 'https://www.youtube.com/watch?v=abc',
+          }),
+          new Map(),
+        ),
+      ).mediaVerb,
+    ).toBe('Watch on YouTube');
+
+    expect(
+      resolvePromoFacts(
+        resourceInput(
+          resource('talk-unknown', {
+            resourceType: 'recorded talk',
+            url: 'https://example.com/video',
+          }),
+          new Map(),
+        ),
+      ).mediaVerb,
+    ).toBe('Watch the recording');
+
+    expect(
+      resolvePromoFacts(
+        resourceInput(
+          resource('pod-unknown', {
+            resourceType: 'podcast episode',
+            url: 'https://example.com/ep1',
+          }),
+          new Map(),
+        ),
+      ).mediaVerb,
+    ).toBe('Listen to the episode');
+  });
+
+  it('speakers: [] emits no speaker clause — no "undefined", no dangling "by "/"with " fragment', () => {
+    const posts = composePromoPosts(eventInput(frosconEvent()));
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        expect(block.text).not.toContain('undefined');
+        expect(block.text).not.toMatch(/\bby\s*$/m);
+        expect(block.text).not.toMatch(/\bwith\s*$/m);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Limits (AC9)
+// ---------------------------------------------------------------------------
+
+describe('fitWithinLimit — drop plan, driven directly with synthetic clause lists (AC9)', () => {
+  const clauses: PromoClause[] = [
+    {
+      role: 'title',
+      text: 'A Fairly Long And Descriptive Title For This Test Case',
+    },
+    { role: 'lede', text: 'A short lede sentence about the appearance.' },
+    { role: 'kind', text: 'Talk' },
+    { role: 'mode', text: 'Presenting' },
+    { role: 'date', text: 'July 8, 2026' },
+    { role: 'place', text: 'A Specific Named Venue' },
+    { role: 'guestCredit', text: 'Guest of My Coding Zone on YouTube' },
+    { role: 'primaryUrl', text: 'https://example.com/watch?v=abc123' },
+    {
+      role: 'imageCredit',
+      text: 'Credit line, licensed under CC BY-ND 3.0 DE (https://example.com/license).',
+    },
+  ];
+
+  it('drops place, then mode, then date, in that order, and never removes guestCredit/primaryUrl/imageCredit', () => {
+    const fullLen = fitWithinLimit(clauses, 100000).text.length;
+
+    // Step 1: drop `place`.
+    const afterPlace = fitWithinLimit(clauses, fullLen - 1);
+    expect(afterPlace.clauses.some((c) => c.role === 'place')).toBe(false);
+    expect(afterPlace.clauses.some((c) => c.role === 'mode')).toBe(true);
+    expect(afterPlace.clauses.some((c) => c.role === 'date')).toBe(true);
+
+    const noPlaceLen = fitWithinLimit(
+      clauses.filter((c) => c.role !== 'place'),
+      100000,
+    ).text.length;
+
+    // Step 2: drop `mode` too.
+    const afterMode = fitWithinLimit(clauses, noPlaceLen - 1);
+    expect(afterMode.clauses.some((c) => c.role === 'place')).toBe(false);
+    expect(afterMode.clauses.some((c) => c.role === 'mode')).toBe(false);
+    expect(afterMode.clauses.some((c) => c.role === 'date')).toBe(true);
+
+    const noPlaceOrModeLen = fitWithinLimit(
+      clauses.filter((c) => c.role !== 'place' && c.role !== 'mode'),
+      100000,
+    ).text.length;
+
+    // Step 3: drop `date` too — title survives untouched at this point.
+    const afterDate = fitWithinLimit(clauses, noPlaceOrModeLen - 1);
+    expect(afterDate.clauses.some((c) => c.role === 'date')).toBe(false);
+    expect(afterDate.clauses.some((c) => c.role === 'title')).toBe(true);
+
+    for (const result of [afterPlace, afterMode, afterDate]) {
+      expect(result.clauses.some((c) => c.role === 'guestCredit')).toBe(true);
+      expect(result.clauses.some((c) => c.role === 'primaryUrl')).toBe(true);
+      expect(result.clauses.some((c) => c.role === 'imageCredit')).toBe(true);
+    }
+  });
+
+  it('truncates the title on a word boundary with a trailing … and a 40-char floor, never below it', () => {
+    const titleClauses: PromoClause[] = [
+      { role: 'title', text: 'Word '.repeat(80).trim() },
+      { role: 'primaryUrl', text: 'https://example.com/x' },
+    ];
+    const result = fitWithinLimit(titleClauses, 90);
+    const titleClause = result.clauses.find((c) => c.role === 'title');
+    expect(titleClause).toBeDefined();
+    expect(titleClause?.text.endsWith('…')).toBe(true);
+    expect(titleClause?.text.length ?? 0).toBeGreaterThanOrEqual(40);
+    expect(result.text.length).toBeLessThanOrEqual(90);
+  });
+
+  it('limit === null (reddit body) never runs a drop step', () => {
+    const bodyClauses: PromoClause[] = [
+      { role: 'lede', text: 'Lede.' },
+      { role: 'kind', text: 'Talk' },
+      { role: 'mode', text: 'Presenting' },
+      { role: 'date', text: 'July 8, 2026' },
+      { role: 'place', text: 'Munich' },
+      { role: 'primaryUrl', text: 'https://example.com' },
+    ];
+    const result = fitWithinLimit(bodyClauses, null);
+    expect(result.clauses).toEqual(bodyClauses);
+    expect(result.text).toContain('Talk · Presenting · July 8, 2026 · Munich');
+  });
+
+  it('terminal arbitration: guestCredit + primaryUrl + a 400-char imageCredit together exceed the limit, and the limit loses', () => {
+    const imageCredit = 'C'.repeat(400);
+    const overloaded: PromoClause[] = [
+      { role: 'title', text: 'Short Title' },
+      { role: 'lede', text: 'A short lede.' },
+      { role: 'kind', text: 'Talk' },
+      { role: 'guestCredit', text: 'Guest of My Coding Zone on YouTube' },
+      { role: 'primaryUrl', text: 'https://example.com/x' },
+      { role: 'imageCredit', text: imageCredit },
+    ];
+    const result = fitWithinLimit(overloaded, 280);
+    expect(result.text.length).toBeGreaterThan(280);
+    expect(result.text).toContain('Guest of My Coding Zone on YouTube');
+    expect(result.text).toContain('https://example.com/x');
+    expect(result.text).toContain(imageCredit);
+  });
+});
+
+describe('composePromoPosts — limits end-to-end (AC9)', () => {
+  it('a 400-character title still yields an x block within 280, primaryUrl intact, title truncated (…, >=40 chars)', () => {
+    const longTitle = 'Should I GET or Should I POST '.repeat(20).slice(0, 400);
+    expect(longTitle.length).toBe(400);
+    const ev = apidaysEvent({ title: longTitle });
+    const facts = resolvePromoFacts(eventInput(ev));
+    const posts = composePromoPosts(eventInput(ev));
+    const xBlock = firstBlock(findPost(posts, 'x'));
+
+    expect(xBlock.text.length).toBeLessThanOrEqual(280);
+    expect(xBlock.text).toContain(facts.primaryUrl);
+    const firstLine = xBlock.text.split('\n')[0] ?? '';
+    expect(firstLine.endsWith('…')).toBe(true);
+    expect(firstLine.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('a synthetic 400-character imageCredit on x forces terminal arbitration: over 280, but URL/guest credit/credit intact', () => {
+    const imageCredit = 'X'.repeat(400);
+    const facts = resolvePromoFacts(eventInput(mczEvent()));
+    const posts = composePromoPosts({ ...eventInput(mczEvent()), imageCredit });
+    const xBlock = firstBlock(findPost(posts, 'x'));
+
+    expect(xBlock.text.length).toBeGreaterThan(280);
+    expect(xBlock.charLimit).toBe(280);
+    expect(xBlock.text).toContain(
+      `Guest of ${facts.guestCredit?.externalHost} on ${facts.guestCredit?.platform}`,
+    );
+    expect(xBlock.text).toContain(facts.primaryUrl);
+    expect(xBlock.text).toContain(imageCredit);
+  });
+
+  it('every block of every seed-shaped subject (5 Events + 1 Resource) is within its charLimit', () => {
+    const events = [
+      apidaysEvent(),
+      frankenjsEvent(),
+      frosconEvent(),
+      mczEvent(),
+      webistEvent(),
+    ];
+    const eventsById = indexEventsById(events);
+    const subjects: PromoInput[] = [
+      ...events.map((entry) => eventInput(entry, eventsById)),
+      resourceInput(mczResource(), eventsById),
+    ];
+
+    for (const input of subjects) {
+      const posts = composePromoPosts(input);
+      for (const post of posts) {
+        for (const block of post.blocks) {
+          if (block.charLimit !== null) {
+            expect(block.text.length).toBeLessThanOrEqual(block.charLimit);
+          }
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attribution (AC10)
+// ---------------------------------------------------------------------------
+
+describe('composePromoPosts / resolvePromoFacts — attribution (AC10)', () => {
+  it("guest: every body block contains 'Guest of My Coding Zone on YouTube' verbatim; reddit's title block never does", () => {
+    const posts = composePromoPosts(eventInput(mczEvent()));
+    const credit = 'Guest of My Coding Zone on YouTube';
+
+    expect(lastBlock(findPost(posts, 'reddit')).text).toContain(credit);
+    expect(firstBlock(findPost(posts, 'x')).text).toContain(credit);
+    expect(firstBlock(findPost(posts, 'linkedin')).text).toContain(credit);
+    expect(firstBlock(findPost(posts, 'discord')).text).toContain(credit);
+    expect(firstBlock(findPost(posts, 'reddit')).text).not.toContain(credit);
+  });
+
+  it('host and absent attribution: guestCredit is undefined and no block contains "Guest of"', () => {
+    const hostFacts = resolvePromoFacts(eventInput(apidaysEvent()));
+    expect(hostFacts.guestCredit).toBeUndefined();
+
+    const posts = composePromoPosts(eventInput(apidaysEvent()));
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        expect(block.text).not.toContain('Guest of');
+      }
+    }
+  });
+
+  it('a guest subject with a 400-character title on x still keeps both the guest credit and primaryUrl', () => {
+    const longTitle = 'Should I GET or Should I POST '.repeat(20).slice(0, 400);
+    const ev = mczEvent({ title: longTitle });
+    const facts = resolvePromoFacts(eventInput(ev));
+    const posts = composePromoPosts(eventInput(ev));
+    const xBlock = firstBlock(findPost(posts, 'x'));
+
+    expect(xBlock.text).toContain(
+      `Guest of ${facts.guestCredit?.externalHost} on ${facts.guestCredit?.platform}`,
+    );
+    expect(xBlock.text).toContain(facts.primaryUrl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Licence notice (AC11)
+// ---------------------------------------------------------------------------
+
+const FROSCON_IMAGE_CREDIT =
+  'FrosCon logo © FrOSCon e.V., licensed under CC BY-ND 3.0 DE (https://creativecommons.org/licenses/by-nd/3.0/de/).';
+
+function assertNoCreditArtifacts(posts: PromoPost[]): void {
+  for (const post of posts) {
+    for (const block of post.blocks) {
+      expect(block.text.endsWith('\n')).toBe(false);
+      expect(block.text.trimEnd()).toBe(block.text);
+      expect(block.text).not.toContain('undefined');
+    }
+  }
+}
+
+describe('composePromoPosts — imageCredit / licence notice (AC11)', () => {
+  it('appears verbatim exactly once as the final line of the final block of all four posts', () => {
+    const posts = composePromoPosts({
+      ...eventInput(frosconEvent()),
+      imageCredit: FROSCON_IMAGE_CREDIT,
+    });
+    for (const post of posts) {
+      const finalBlock = lastBlock(post);
+      const lines = finalBlock.text.split('\n');
+      expect(lines[lines.length - 1]).toBe(FROSCON_IMAGE_CREDIT);
+      expect(finalBlock.text.split(FROSCON_IMAGE_CREDIT).length - 1).toBe(1);
+    }
+    // Reddit's title block never carries it.
+    expect(firstBlock(findPost(posts, 'reddit')).text).not.toContain(
+      FROSCON_IMAGE_CREDIT,
+    );
+  });
+
+  it('the real 113-character FrosCon notice still leaves every block within its charLimit', () => {
+    expect(FROSCON_IMAGE_CREDIT.length).toBe(113);
+    const posts = composePromoPosts({
+      ...eventInput(frosconEvent()),
+      imageCredit: FROSCON_IMAGE_CREDIT,
+    });
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        if (block.charLimit !== null) {
+          expect(block.text.length).toBeLessThanOrEqual(block.charLimit);
+        }
+      }
+    }
+  });
+
+  it('omitted imageCredit adds no clause, no placeholder, no trailing blank line', () => {
+    assertNoCreditArtifacts(composePromoPosts(eventInput(frosconEvent())));
+  });
+
+  it('empty-string imageCredit behaves the same as omitted', () => {
+    assertNoCreditArtifacts(
+      composePromoPosts({ ...eventInput(frosconEvent()), imageCredit: '' }),
+    );
+  });
+
+  it('whitespace-only imageCredit behaves the same as omitted', () => {
+    assertNoCreditArtifacts(
+      composePromoPosts({ ...eventInput(frosconEvent()), imageCredit: '   ' }),
+    );
+  });
+
+  it('ordering: on x the credit follows primaryUrl; on linkedin it follows the hashtag line', () => {
+    const facts = resolvePromoFacts(eventInput(apidaysEvent()));
+    const posts = composePromoPosts({
+      ...eventInput(apidaysEvent()),
+      imageCredit: FROSCON_IMAGE_CREDIT,
+    });
+
+    const xLines = firstBlock(findPost(posts, 'x')).text.split('\n');
+    expect(xLines[xLines.length - 2]).toBe(facts.primaryUrl);
+    expect(xLines[xLines.length - 1]).toBe(FROSCON_IMAGE_CREDIT);
+
+    const linkedinLines = firstBlock(findPost(posts, 'linkedin')).text.split(
+      '\n',
+    );
+    expect(linkedinLines[linkedinLines.length - 1]).toBe(FROSCON_IMAGE_CREDIT);
+    expect(linkedinLines[linkedinLines.length - 2]).toMatch(
+      /^#[A-Za-z0-9]+( #[A-Za-z0-9]+){2,4}$/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases (AC12)
+// ---------------------------------------------------------------------------
+
+describe('composePromoPosts — an Event with no linked Resource (AC12)', () => {
+  it('composes fully with an empty eventsById Map; no resource lookup is attempted', () => {
+    const posts = composePromoPosts(eventInput(apidaysEvent(), new Map()));
+    expect(posts).toHaveLength(4);
+    for (const post of posts) {
+      for (const block of post.blocks) {
+        expect(block.text.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AD-6 guard (AC13)
+// ---------------------------------------------------------------------------
+
+describe('resolvePromoFacts / composePromoPosts — AD-6 guard (AC13)', () => {
+  it('throws with AD-6 in the message for a set-but-dangling originEvent', () => {
+    expect(() =>
+      composePromoPosts(
+        resourceInput(
+          resource('ghost', { originEvent: 'nonexistent' }),
+          new Map(),
+        ),
+      ),
+    ).toThrow(/AD-6/);
+  });
+
+  it('does not throw when originEvent is unset', () => {
+    expect(() =>
+      composePromoPosts(resourceInput(resource('no-origin'), new Map())),
+    ).not.toThrow();
+  });
+});

--- a/astro-docs/test/promo-post.test.ts
+++ b/astro-docs/test/promo-post.test.ts
@@ -731,6 +731,50 @@ describe('composePromoPosts — phrasing (AC8)', () => {
       }
     }
   });
+
+  it('joinNames: two speakers join with "and", three+ join with an Oxford comma', () => {
+    const [keyA, keyB, keyC] = TEAM_KEYS;
+    const nameA = blogAuthors[keyA as string]?.name ?? (keyA as string);
+    const nameB = blogAuthors[keyB as string]?.name ?? (keyB as string);
+    const nameC = blogAuthors[keyC as string]?.name ?? (keyC as string);
+
+    const twoPosts = composePromoPosts(
+      eventInput(
+        event('e-two-speakers', { speakers: [keyA as string, keyB as string] }),
+      ),
+    );
+    const twoLede = firstBlock(findPost(twoPosts, 'x')).text;
+    expect(twoLede).toContain(`${nameA} and ${nameB}`);
+
+    const threePosts = composePromoPosts(
+      eventInput(
+        event('e-three-speakers', {
+          speakers: [keyA as string, keyB as string, keyC as string],
+        }),
+      ),
+    );
+    const threeLede = firstBlock(findPost(threePosts, 'x')).text;
+    expect(threeLede).toContain(`${nameA}, ${nameB}, and ${nameC}`);
+  });
+
+  it('resource ledes: a paper resource with a speaking origin event credits the speaker(s) ("authored by")', () => {
+    const originEvent = event('paper-origin-event', {
+      participation: 'paper',
+      mode: 'presenting',
+      speakers: [TEAM_KEY],
+    });
+    const posts = composePromoPosts(
+      resourceInput(
+        resource('paper-with-authors', {
+          resourceType: 'paper',
+          originEvent: 'paper-origin-event',
+        }),
+        indexEventsById([originEvent]),
+      ),
+    );
+    const x = firstBlock(findPost(posts, 'x')).text;
+    expect(x).toContain(`authored by ${TEAM_NAME}`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/astro-docs/test/social-hub-paths.test.ts
+++ b/astro-docs/test/social-hub-paths.test.ts
@@ -1,0 +1,91 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it } from 'vitest';
+
+import {
+  hubParamsForEntry,
+  hubPathForEntry,
+} from '../src/components/social/socialHubPaths';
+
+// Fake entries — mirror the `test/cross-links.test.ts` idiom (minimal object
+// literals cast `as unknown as CollectionEntry<...>`). No content fixtures,
+// no clock reads.
+type EventEntry = CollectionEntry<'events'>;
+type ResourceEntry = CollectionEntry<'resources'>;
+
+function event(id: string): EventEntry {
+  return {
+    id,
+    collection: 'events',
+    data: { title: id },
+  } as unknown as EventEntry;
+}
+
+function resource(id: string): ResourceEntry {
+  return {
+    id,
+    collection: 'resources',
+    data: { title: id },
+  } as unknown as ResourceEntry;
+}
+
+describe('hubParamsForEntry', () => {
+  it('returns { collection: "events", entry: id } for an event', () => {
+    expect(hubParamsForEntry(event('froscon-community-booth'))).toEqual({
+      collection: 'events',
+      entry: 'froscon-community-booth',
+    });
+  });
+
+  it('returns { collection: "resources", entry: id } for a resource', () => {
+    expect(
+      hubParamsForEntry(resource('should-i-get-or-should-i-post-recording')),
+    ).toEqual({
+      collection: 'resources',
+      entry: 'should-i-get-or-should-i-post-recording',
+    });
+  });
+});
+
+describe('hubPathForEntry', () => {
+  it('builds the events path with a trailing slash', () => {
+    expect(hubPathForEntry(event('froscon-community-booth'))).toBe(
+      '/social/events-resources/events/froscon-community-booth/',
+    );
+  });
+
+  it('builds the resources path with a trailing slash', () => {
+    expect(
+      hubPathForEntry(resource('should-i-get-or-should-i-post-recording')),
+    ).toBe(
+      '/social/events-resources/resources/should-i-get-or-should-i-post-recording/',
+    );
+  });
+
+  it('never emits a "#" fragment', () => {
+    expect(hubPathForEntry(event('e'))).not.toContain('#');
+    expect(hubPathForEntry(resource('r'))).not.toContain('#');
+  });
+
+  it('disambiguates the same id across both collections via the collection segment', () => {
+    const sameId = 'shared-slug';
+    const eventPath = hubPathForEntry(event(sameId));
+    const resourcePath = hubPathForEntry(resource(sameId));
+
+    expect(eventPath).toBe('/social/events-resources/events/shared-slug/');
+    expect(resourcePath).toBe(
+      '/social/events-resources/resources/shared-slug/',
+    );
+    expect(eventPath).not.toBe(resourcePath);
+  });
+});
+
+describe('module purity', () => {
+  it('is deterministic across repeat calls — no clock, no getCollection, no Astro.* read', () => {
+    const e = event('same');
+    const r = resource('same');
+    expect(hubParamsForEntry(e)).toEqual(hubParamsForEntry(e));
+    expect(hubPathForEntry(e)).toBe(hubPathForEntry(e));
+    expect(hubParamsForEntry(r)).toEqual(hubParamsForEntry(r));
+    expect(hubPathForEntry(r)).toBe(hubPathForEntry(r));
+  });
+});


### PR DESCRIPTION
## Summary

Adds the internal, `noindex` Events & Resources hub: for any Event or Resource, one branded image plus
four platform-tailored (five text-block) ready-to-copy posts, editable before copying. Closes out Epic
11 (milestone #18) in one bundled PR, matching the playbook used for Epic 10 (#353) and Epic 13 (#341).

- **Story 11.1** (#447) — `src/lib/promo-post.ts` + `promo-platforms.ts`: pure per-platform post-text
  composition (`resolvePromoFacts`, `composePromoPosts`), with a deterministic character-limit drop plan
  that never drops the outward URL, guest attribution, or an injected image-licence notice.
- **Story 11.2** (#448) — `src/lib/promo-image.ts` + `PromoImage.astro`: resolves one branded image per
  entry (an Event's own logo, a Resource's inherited origin-event logo, or a generated branded-card
  fallback) and renders it, surfacing the CC BY-ND licence credit for the one logo that carries one.
- **Story 11.3** (#449) — the integration surface: `/social/events-resources/**` routes rendering both
  modules together via a new prop-driven `HubEntry.astro`, reachable from `/social/` by one bounded link,
  `noindex` solely via the existing `SocialLayout`. Owns this epic's rendered/a11y verification (e2e +
  axe, light/dark, against an enumerated pre-existing contrast baseline).

All three stories landed as one dev-auto run each, independently reviewed (adversarial + edge-case
passes) and verified before commit. 17 non-blocking review findings across the three stories were
triaged: several patched directly (grammar/docstring fixes, missing unit tests, a type-error fix),
the rest logged to `deferred-work.md` (pre-existing patterns, low-severity latent risks, or
explicitly-named follow-ups the stories themselves defer) or rejected as findings that turned out to
match explicit spec decisions on inspection.

## Test plan

- [x] `npx nx test astro` — 257/257 unit tests pass (11.1: 234, 11.2: +16, 11.3: +7)
- [x] `npx nx build astro` — succeeds, `starlight-links-validator` reports all internal links valid
- [x] `cd astro-docs && npx astro check` — 14 errors, unchanged from the pre-existing baseline (none in new files)
- [x] `npx nx run astro:e2e` — new `social-hub.spec.ts` (12 tests) passes: page structure, 5 distinct
      `aria-label`s, copy-after-edit via live clipboard read-back, discovery links, the FrosCon 3-part
      licence-notice chain, and axe light/dark scans (scoped, against the enumerated baseline, plus a
      zero-violation landing-page scan)
- [x] Mechanical scope checks: `git diff --stat` per story lists exactly the declared new/modified files;
      no AD-8-frozen presentational component (`PlatformSection`, `PostText`, `SocialImage`,
      `SocialLayout`'s core mechanism, `EventCard`, `ResourceCard`, `EventsLayout`, `ResourcesLayout`) was
      touched