### PR TITLE
feat(repo): shared HTTP-field foundation — @thymian/common-http-fields (Epic 588)

### DIFF
--- a/.license-checker.json
+++ b/.license-checker.json
@@ -13,6 +13,7 @@
   "excludePackages": [
     "thymian",
     "@thymian/common-cli",
+    "@thymian/common-http-fields",
     "@thymian/core",
     "@thymian/core-testing",
     "@thymian/plugin-http-analyzer",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ When making commits, use one of the following scopes to indicate the area of the
 | cli                              | Cross-cutting CLI concerns                                                             |
 | thymian                          | The `thymian` CLI product package                                                      |
 | common-cli                       | Shared CLI base library (`@thymian/common-cli`)                                        |
+| common-http-fields               | Shared HTTP field primitives for rule sets (`@thymian/common-http-fields`)             |
 | core                             | Core framework: workflows, contracts, rule system (`@thymian/core`)                    |
 | core-testing                     | Test utilities for core (`@thymian/core-testing`)                                      |
 | plugin-http-linter               | Static lint plugin                                                                     |
@@ -53,12 +54,12 @@ Refer to this list when contributing to ensure consistent commit messages.
 
 ### Dimension "scope"
 
-| Tag            | Allowed Dependencies                                     | Description                                                                                                         |
-| -------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `scope:cli`    | `scope:core`, `scope:cli`, `scope:plugin`, `scope:rules` | CLI packages (the `thymian` app aggregates plugins and rule sets)                                                   |
-| `scope:core`   | `scope:core`                                             | Core framework (contracts, rule system, Thymian format)                                                             |
-| `scope:plugin` | `scope:core`, `scope:cli`, `scope:plugin`                | Plugins (note: plugins may **not** depend on `scope:rules` — rules reach plugins via the core loader, per ADR-0009) |
-| `scope:rules`  | constrained via `type`/`npm` dimensions                  | Rule set packages; depend only on `@thymian/core` in practice                                                       |
+| Tag            | Allowed Dependencies                                     | Description                                                                                                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `scope:cli`    | `scope:core`, `scope:cli`, `scope:plugin`, `scope:rules` | CLI packages (the `thymian` app aggregates plugins and rule sets)                                                                                                                                                                                            |
+| `scope:core`   | `scope:core`                                             | Core framework (contracts, rule system, Thymian format)                                                                                                                                                                                                      |
+| `scope:plugin` | `scope:core`, `scope:cli`, `scope:plugin`                | Plugins (note: plugins may **not** depend on `scope:rules` — rules reach plugins via the core loader, per ADR-0009)                                                                                                                                          |
+| `scope:rules`  | `scope:core`                                             | Rule set packages. The qualifying property is the `scope:core` **tag**, not a name prefix — so `@thymian/core` and `@thymian/common-http-fields` are reachable, but `@thymian/common-cli` is not (it is `scope:cli`). Never a plugin, never another rule set |
 
 ### Dimension "type"
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,6 +10,7 @@ export default {
         'deps',
         'cli',
         'common-cli',
+        'common-http-fields',
         'core',
         'core-testing',
         'plugin-http-analyzer',

--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -140,11 +140,12 @@ C4Container
 
 Additional non-diagram packages:
 
-| Package                    | Purpose                                                            |
-| -------------------------- | ------------------------------------------------------------------ |
-| `packages/common-cli`      | Shared CLI base classes and helpers                                |
-| `packages/core-testing`    | Test utilities for the core package                                |
-| `packages/plugin-spectral` | Converts Spectral JSON reports into Thymian lint reports (Epic 14) |
+| Package                       | Purpose                                                                                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/common-cli`         | Shared CLI base classes and helpers                                                                                                                 |
+| `packages/common-http-fields` | Shared HTTP field primitives read by the `rules-*` packages: the normalized header view and the natively-Structured-Fields registry/guard (Epic 15) |
+| `packages/core-testing`       | Test utilities for the core package                                                                                                                 |
+| `packages/plugin-spectral`    | Converts Spectral JSON reports into Thymian lint reports (Epic 14)                                                                                  |
 
 ### Key Architectural Changes from Epic 1
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,12 @@ const depConstraintsProduction = [
   // scope:cli can only access core, cli, plugin, and rules (thymian CLI app aggregates plugins)
   {
     sourceTag: 'scope:cli',
-    onlyDependOnLibsWithTags: ['scope:core', 'scope:cli', 'scope:plugin', 'scope:rules'],
+    onlyDependOnLibsWithTags: [
+      'scope:core',
+      'scope:cli',
+      'scope:plugin',
+      'scope:rules',
+    ],
   },
   // scope:core can only access scope:core
   {
@@ -17,6 +22,21 @@ const depConstraintsProduction = [
   {
     sourceTag: 'scope:plugin',
     onlyDependOnLibsWithTags: ['scope:core', 'scope:cli', 'scope:plugin'],
+  },
+  // scope:rules can access ONLY core-scoped libraries — never a plugin, never another rules-*.
+  //
+  // Until now `scope:rules` appeared solely as a permitted TARGET of scope:cli, so rule packages
+  // had no enforced source constraint at all and "rules-* depend only on @thymian/core" was
+  // documentation rather than lint. This entry makes it real.
+  //
+  // Shared rule-support libraries (`@thymian/common-http-fields`) are tagged `scope:core` rather
+  // than getting a new `scope:common` dimension value: `core-testing` is already `scope:core`, and
+  // `common-cli` is `scope:cli` — i.e. `common-*` packages are tagged by DOMAIN, not by a "common"
+  // scope. That keeps this a one-entry change instead of three, and scope:core's own
+  // core-only constraint already stops a support library reaching sideways.
+  {
+    sourceTag: 'scope:rules',
+    onlyDependOnLibsWithTags: ['scope:core'],
   },
 
   // Dimension: type

--- a/package-lock.json
+++ b/package-lock.json
@@ -9212,6 +9212,10 @@
       "resolved": "packages/common-cli",
       "link": true
     },
+    "node_modules/@thymian/common-http-fields": {
+      "resolved": "packages/common-http-fields",
+      "link": true
+    },
     "node_modules/@thymian/core": {
       "resolved": "packages/core",
       "link": true
@@ -31809,6 +31813,18 @@
         "wrap-ansi": "^7.0.0",
         "yaml": "^2.8.3"
       },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/common-http-fields": {
+      "name": "@thymian/common-http-fields",
+      "version": "0.0.0-PLACEHOLDER",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "devDependencies": {},
       "engines": {
         "node": ">=22"
       }

--- a/packages/common-http-fields/eslint.config.mjs
+++ b/packages/common-http-fields/eslint.config.mjs
@@ -1,0 +1,20 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs}'],
+          ignoredDependencies: ['vitest'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/common-http-fields/package.json
+++ b/packages/common-http-fields/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@thymian/common-http-fields",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "Shared HTTP field primitives for Thymian rule sets: natively-Structured-Fields registry, non-SF guard, and the normalized header view",
+  "license": "AGPL-3.0-only",
+  "bugs": {
+    "url": "https://github.com/thymianofficial/thymian/issues"
+  },
+  "homepage": "https://thymian.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thymianofficial/thymian.git",
+    "directory": "packages/common-http-fields"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "thymian",
+    "api-governance",
+    "http",
+    "http-fields",
+    "http-headers",
+    "structured-fields",
+    "rfc-9651"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {}
+}

--- a/packages/common-http-fields/project.json
+++ b/packages/common-http-fields/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "common-http-fields",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/common-http-fields/src",
+  "projectType": "library",
+  "tags": ["scope:core", "type:lib", "npm:public"],
+  "// targets": "to see all targets run: nx show project common-http-fields --web",
+  "targets": {}
+}

--- a/packages/common-http-fields/src/index.ts
+++ b/packages/common-http-fields/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * `@thymian/common-http-fields` — shared HTTP field primitives for Thymian rule sets.
+ *
+ * Scope of this package is deliberately narrow: it holds **pure logic** that more than one
+ * `rules-*` package reads through, and nothing else.
+ *
+ * - The normalized header view every rule reads through, so `lint`, `test` and `analyze` agree on
+ *   case-folding and on same-name multiplicity.
+ * - The natively-Structured-Fields header registry, and the guard that **refuses** RFC 9651 parsing
+ *   for fields that never opted into the mechanism (`Content-Security-Policy`, `Set-Cookie`, …).
+ *
+ * Single-consumer reference data is **not** a shared utility and does not live here: the Public
+ * Suffix List snapshot stays vendored in `@thymian/rules-cookies`, the OWASP Secure Headers Project
+ * JSON in `@thymian/rules-secure-headers`. Promotion to this package is triggered by a second
+ * consumer, never by anticipation.
+ *
+ * This module is intentionally empty at scaffold time; the view lands with the normalized-header
+ * story and the registry/guard with the Structured-Fields story.
+ */
+
+export {};

--- a/packages/common-http-fields/tsconfig.json
+++ b/packages/common-http-fields/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
+}

--- a/packages/common-http-fields/tsconfig.lib.json
+++ b/packages/common-http-fields/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "moduleResolution": "nodenext",
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": []
+}

--- a/packages/common-http-fields/vitest.config.ts
+++ b/packages/common-http-fields/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Library convention is `test/**/*.test.ts`. `src/**` is collected too, deliberately: the
+    // adjacent `rules-*` packages colocate tests in `src/`, and `tsconfig.lib.json` excludes
+    // `src/**/*.test.ts` from the build — so a colocated test would otherwise be built by nothing
+    // and collected by nothing, and `passWithNoTests` would still report the target green.
+    include: ['test/**/*.test.ts', 'src/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,9 @@
       "path": "./packages/common-cli"
     },
     {
+      "path": "./packages/common-http-fields"
+    },
+    {
       "path": "./packages/plugin-har"
     }
   ]


### PR DESCRIPTION
> **Draft — epic-bundled PR.** This branch carries **Epic 588** (`thymian-internal#588`,
> "Shared HTTP-field foundation"). Story 588.1 is complete below; **588.2** (normalized header
> view) and **588.3** (Structured-Fields registry + non-SF guard) will land as further commits on
> this same branch. Ready for review when the epic is done.

## Story 588.1 — establish the `common-*` dependency boundary and scaffold the package

Refs `thymian-internal#593`. Two commits:

| Commit | Scope |
|---|---|
| `feat(repo): create the scope:rules module boundary` | boundary constraint + workspace registration + doc sync |
| `feat(common-http-fields): scaffold the shared HTTP-field package` | the new package + lockfile |

### The constraint had to be **created**, not relaxed

Before this PR, `scope:rules` appeared *only* as a permitted **target** of `scope:cli`. There was
no source constraint on rule packages at all — so "`rules-*` depend only on `@thymian/core`" was
documentation, never lint. The pre-change `depConstraintsProduction` had source entries for
`scope:cli`, `scope:core` and `scope:plugin`, and none for `scope:rules`.

### Scope-tag decision (AC 4): `scope:core`

`common-http-fields` is tagged `scope:core` rather than introducing a new `scope:common` dimension
value. `core-testing` is already `scope:core` and `common-cli` is `scope:cli` — i.e. the existing
convention tags `common-*` packages by **domain**, not by a "common" scope. That made this a
one-entry change instead of three (`scope:rules` source, `scope:common` source, plus admission to
`scope:cli`'s allow-list), and `scope:core`'s own core-only constraint already stops a support
library reaching sideways. The rationale is also recorded inline above the constraint in
`eslint.config.mjs`, so it survives independently of this description.

Consequence worth stating plainly: because the tag is shared, `scope:cli`, `scope:plugin` and
`type:app` sources may also import this package. That is the accepted trade-off of Option A.

### AC 5 evidence — the constraint actually fires

Negative probe, a `rules-*` file importing a `plugin-*` package:

```
packages/rules-rfc-9110/src/__boundary-probe.ts
  2:1  error  A project tagged with "scope:rules" can only depend on libs tagged with "scope:core"  @nx/enforce-module-boundaries

✖ 4 problems (2 errors, 2 warnings)
```

Positive probe, the same file importing `@thymian/common-http-fields` — **zero**
`enforce-module-boundaries` errors, so the constraint admits the intended edge:

```
✖ 3 problems (1 error, 2 warnings)
```

(The one remaining error is `@nx/dependency-checks` for the undeclared dependency, which is
expected — a real consumer declares it. Both probes were reverted; the tree is clean.)

### Two CI blockers found in review and fixed here

- **`package-lock.json` had no entry for the new package.** npm records `packages/*` workspace
  entries in the lockfile, so `npm ci` aborted with
  `Missing: @thymian/common-http-fields@0.0.0-PLACEHOLDER from lock file` *before any step* in all
  eight CI, e2e, release and deploy-docs jobs. Nx lint/build read the manifests off disk and need
  no node resolution, so a fully green `nx run-many` cannot detect this. Same class as `7a9a6496`.
- **`.license-checker.json` did not exclude the new package.** Its `AGPL-3.0-only` license is in
  `bannedLicenses`, and the root `postinstall` runs `check:licenses` — so *every* `npm install`
  exited non-zero, plus the dedicated CI license job. This had to be fixed before the `npm install`
  that regenerates the lockfile, or that install failed too.

### Scaffold notes

- `src/index.ts` is `export {}` by design. No SF registry, no non-SF guard, no normalized header
  view, no `structured-headers` dependency — those are 588.2 / 588.3. No vendored reference data
  ever (PSL and OSHP JSON stay with their sole consumers per AD-7). No docs-generation targets: the
  package ships no commands.
- **`@thymian/core` is deliberately not yet a declared dependency.** With an empty entrypoint
  `@nx/dependency-checks` correctly rejects the unused declaration, and suppressing it would be the
  weaken-the-lint-rule anti-pattern. **588.2 must restore both** the dependency and the
  `../core/tsconfig.lib.json` project reference when it first imports core types.
- `vitest` collects `src/**/*.test.ts` in addition to the `test/**` library convention. The
  adjacent `rules-rfc-9110` colocates its tests in `src/`, which `tsconfig.lib.json` excludes from
  the build — a colocated test here would otherwise be built by nothing and collected by nothing,
  while `passWithNoTests` still reported green.

### Doc sync

The `scope:rules` row in `CONTRIBUTING.md` claimed "constrained via `type`/`npm` dimensions …
depend only on `@thymian/core` in practice" — wrong in both halves now. It and the commit-scope
table (which the file itself asks to be kept in sync) and the arc42 package inventory cited by
ADR-0008 are all updated.

Both tables now key on the **`scope:core` tag, not a name prefix**: `@thymian/common-cli` is
`scope:cli` and is therefore *not* reachable from a rule set even though it is a `common-*`
package. The matching amendment in `thymian-internal/docs/project-context.md` is committed there
separately, per AD-8.

### ⚠️ Release gate — AC 10 is open

`npm run bootstrap-npm-packages` has **not** been run for `@thymian/common-http-fields` (deferred
by decision, batched across all four new `@thymian/*` packages in `#572`). This blocks
**publishing, not merging** — but `nx.json`'s `release.projects: ["packages/*"]` picks the package
up with no opt-in, so the first release after merge fails without it. No `NPM_TOKEN` /
`NODE_AUTH_TOKEN` is introduced; publishing stays on OIDC trusted publishing.

### Verification

`npm ci --dry-run` ✅ · `node scripts/check-licenses.js` ✅ · `nx lint` ✅ (`common-http-fields`,
both `rules-*`, `thymian`) · `nx test common-http-fields` ✅ · `prettier --check` ✅ on every
changed and new file.
