### PR TITLE
feat(core): add shared loadUserModule loader with extension dispatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31824,6 +31824,7 @@
         "ajv-formats": "^3.0.1",
         "chalk": "^5.4.1",
         "graphology": "^0.26.0",
+        "jiti": "^2.6.1",
         "path-to-regexp": "^8.4.0",
         "rxjs": "^7.8.2",
         "safe-stable-stringify": "^2.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "ajv-formats": "^3.0.1",
     "chalk": "^5.4.1",
     "graphology": "^0.26.0",
+    "jiti": "^2.6.1",
     "path-to-regexp": "^8.4.0",
     "rxjs": "^7.8.2",
     "safe-stable-stringify": "^2.5.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './http-status-codes/http-status-code-ranges.js';
 export * from './http-status-codes/index.js';
 export * from './http-testing/index.js';
+export * from './load-user-module.js';
 export * from './logger/log-level.js';
 export * from './logger/logger.js';
 export * from './logger/noop.logger.js';

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -372,11 +372,14 @@ export interface ResolveUserModuleOptions {
  * `{ ok: false }`, carrying a `reason` when the seam knows something the caller could not work
  * out for itself. On success, `path` is an absolute filesystem path, never a `file://` URL.
  *
- * Resolution order stops at the first hit: `require.resolve`, then a `.mjs`/`.cjs` extension
- * guess ({@link resolveThroughGuessing}), then jiti's `esmResolve` — with the `<cwd>/<specifier>`
- * fallback for bare names slotted in before that last step. `require.resolve` already handles
- * TypeScript with an explicit extension, so the jiti fallback is reached for *resolution* only by
- * extensionless and NodeNext `.js`→`.ts` specifiers.
+ * Resolution stops at the first hit and runs the same three-resolver chain
+ * ({@link resolveLocation}) over at most two candidates: the specifier itself, and — for a bare
+ * name nothing is installed under — `<cwd>/<specifier>`. Within a candidate the order is
+ * `require.resolve`, then a `.mjs`/`.cjs` extension guess ({@link resolveThroughGuessing}), then
+ * jiti's `esmResolve`. `require.resolve` already handles TypeScript with an explicit extension, so
+ * the jiti step is reached for *resolution* only by extensionless and NodeNext `.js`→`.ts`
+ * specifiers. The candidates are exhausted in that order, not the resolvers: a bare name that only
+ * jiti can resolve inside `node_modules` still beats a same-named local file.
  *
  * @param specifier The user's rule, rule-set or plugin specifier.
  * @param cwd Directory that path-like specifiers resolve against, that anchors the jiti fallback,
@@ -403,11 +406,17 @@ export async function resolveUserModule(
     // unambiguously a path.
     resolved = await resolveLocation(path.resolve(cwd, specifier), cwd);
   } else {
-    // Installed packages FIRST — through all three resolvers, not just the first two. jiti is
-    // what resolves an installed package whose entry point is TypeScript, which `require.resolve`
-    // cannot; running it here rather than after the cwd fallback is what keeps the documented
-    // order honest. Preferring `<cwd>/<specifier>` up front is what let a same-named local file
-    // or directory shadow — and silently execute in place of — an installed package.
+    // Installed packages FIRST — through all three resolvers, not just the first two. The third
+    // one earns its place: a bare SUBPATH whose target is TypeScript (`my-pkg/rules`, or its
+    // NodeNext `my-pkg/rules.js` spelling, against a `node_modules/my-pkg/rules.ts`) is refused
+    // by `require.resolve` and answered by jiti — measured, both spellings. A package whose
+    // `main` is TypeScript needs no help here; `require.resolve` already returns it.
+    //
+    // So this step has to run before the cwd fallback, not after it: otherwise a local
+    // `<cwd>/my-pkg/rules.ts` would shadow the installed `my-pkg/rules.ts`, which is the one
+    // thing the installed-first order exists to prevent. Preferring `<cwd>/<specifier>` up front
+    // is what let a same-named local file or directory shadow — and silently execute in place
+    // of — an installed package.
     resolved =
       resolveThroughRequire(specifier, cwd) ??
       resolveThroughGuessing(specifier) ??

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -15,7 +15,7 @@
  * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
  *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
  *
- * Two limitations are deliberate and measured against jiti 2.6.1, not oversights:
+ * Three limitations are deliberate and measured against jiti 2.6.1, not oversights:
  *
  * - **TypeScript sources must use `export default`.** `module.exports = …` in a `.ts`/`.cts` file
  *   produces a namespace with no `default` key, and jiti's interop makes that shape *identical*
@@ -30,7 +30,8 @@
  *   under `paths: { "@lib/*": [...] }` resolves and then fails at load with a raw
  *   `MODULE_NOT_FOUND`. Nested *package* imports from the user's own `node_modules` DO work; it is
  *   specifically the alias case. Probably the first limitation a real user writing TypeScript
- *   rules meets, so it wants a decision rather than silence.
+ *   rules meets. Recorded as deliberately unsupported in story 34.5's documentation criteria.
+ *
  * Bare specifiers resolve installed packages first — the user's project, then core's own install
  * directory — and only fall back to `<cwd>/<specifier>` when nothing is installed under that name.
  * Two reasons for that order: a package the user named in their config is theirs, so a globally
@@ -54,19 +55,6 @@ import { isRecord } from './utils.js';
 const require = createRequire(import.meta.url);
 
 /**
- * Resolves through Node's own resolver, trying the **user's project before core's install
- * directory**.
- *
- * Anchoring only at core's directory (the single `require` above) meant a package present only in
- * the user's `node_modules` was invisible to it and fell through to the jiti fallback — so a
- * plain-JavaScript rule package paid for jiti, breaking contract item 4 (confirmed with
- * `JITI_DEBUG=1`). It also meant a name the user installed lost to a Thymian dependency of the
- * same name, which for a globally installed CLI is the wrong answer twice over.
- *
- * Only **bare** specifiers are affected: a relative one is already an absolute path by the time it
- * gets here, and both anchors resolve an absolute path identically.
- */
-/**
  * Cwd-anchored resolvers, memoised. `resolveThroughRequire` runs for every specifier — including
  * every built-in rule on every invocation, the path the file header singles out as needing to stay
  * cheap — and `cwd` is stable within a run, so building the anchor each time was pure waste.
@@ -84,6 +72,19 @@ function requireFrom(cwd: string): NodeJS.Require {
   return anchored;
 }
 
+/**
+ * Resolves through Node's own resolver, trying the **user's project before core's install
+ * directory**.
+ *
+ * Anchoring only at core's directory (the bare `require` above) meant a package present only in
+ * the user's `node_modules` was invisible to it and fell through to the jiti fallback — so a
+ * plain-JavaScript rule package paid for jiti, breaking contract item 4 (confirmed with
+ * `JITI_DEBUG=1`). It also meant a name the user installed lost to a Thymian dependency of the
+ * same name, which for a globally installed CLI is the wrong answer twice over.
+ *
+ * Only **bare** specifiers are affected: a relative one is already an absolute path by the time it
+ * gets here, and both anchors resolve an absolute path identically.
+ */
 function resolveThroughRequire(
   location: string,
   cwd: string,

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -15,7 +15,9 @@
  *    everything else through a plain dynamic `import()`.
  * 3. **Never import-then-retry, and never evaluate twice.** A module's top-level side effects
  *    must run exactly once — across BOTH dispatch branches, across every spelling of its path,
- *    and under concurrency. A cycle is reported rather than deadlocked.
+ *    and under concurrency. A cycle is reported rather than deadlocked — including a cycle formed
+ *    by two concurrent roots waiting on each other, which needs the wait-for graph
+ *    ({@link blockedOn}) and not just the evaluation chain.
  * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
  *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
  *
@@ -494,6 +496,11 @@ function canonicalise(resolvedPath: string): string {
  * its own return can settle, and the process hangs silently — Node exits 13, "Detected unsettled
  * top-level await". `AsyncLocalStorage` carries the chain into module top-level code on both
  * branches (verified), so re-entry is detectable and can be reported instead of hung.
+ *
+ * It catches re-entry on ONE path and nothing more, which is all a per-path structure can do. Two
+ * roots entering concurrently and waiting on each other is the same defect through a door no chain
+ * can see; {@link blockedOn} is what closes that one, and the two work together rather than either
+ * replacing the other.
  */
 const evaluationChain = new AsyncLocalStorage<readonly string[]>();
 
@@ -502,11 +509,124 @@ const evaluationChain = new AsyncLocalStorage<readonly string[]>();
  * load *completes*, so without this two concurrent loads of one file evaluate it twice and return
  * two distinct namespaces — the double-evaluation contract item 3 forbids. Node's own loader
  * de-duplicates in flight, so the native branch needs no equivalent.
+ *
+ * De-duplication ONLY. Whether a wait is safe to join is {@link blockedOn}'s question, and the two
+ * are deliberately not the same lookup — see there for what conflating them cost.
  */
 const inFlightTypeScriptLoads = new Map<
   string,
   Promise<Record<string, unknown>>
 >();
+
+/**
+ * Which in-flight evaluation is blocked on which — the wait-for graph.
+ *
+ * Separate state from {@link inFlightTypeScriptLoads} on purpose. That map answers "is this file
+ * already loading", and the evaluation chain answers "am I already inside this file"; NEITHER can
+ * answer "would waiting for this file close a ring", and making one lookup serve both is what
+ * deadlocked two concurrent roots. `loadRules` fans out with `Promise.all`, so:
+ *
+ * - root A starts `a` with chain `[a]`; root B starts `b` with chain `[b]`
+ * - `a`'s top level asks for `b`: chain `[a]` does not contain `b`, so the in-flight entry is
+ *   awaited and the chain is never extended
+ * - `b`'s top level does the mirror image, and the two promises await each other
+ *
+ * The missing information is *dynamic*, which is why no per-path chain can supply it: at the moment
+ * B decides, the fact that matters is that `a`'s evaluation is ALREADY waiting on `b`. Threading
+ * the chain as an explicit parameter instead of through `AsyncLocalStorage` carries exactly the
+ * same per-path information and misses this identically.
+ *
+ * Keyed by the canonical path of the module doing the waiting, holding every path it currently
+ * awaits — a top level may await several at once. Entries live only for the duration of a wait.
+ */
+const blockedOn = new Map<string, Set<string>>();
+
+/**
+ * The chain of waits leading from `start` to `target`, or `undefined` when `start` is not waiting
+ * on `target` however indirectly. Returns the path rather than a boolean so the error can name the
+ * real ring (`b -> a -> b`) instead of the two modules that happened to notice it.
+ *
+ * Depth is bounded by the number of modules evaluating concurrently, so a plain guarded DFS is the
+ * right size of machinery here. `seen` makes it safe against the rings it is looking for.
+ */
+function waitPathTo(
+  start: string,
+  target: string,
+  seen: Set<string> = new Set(),
+): readonly string[] | undefined {
+  if (seen.has(start)) {
+    return undefined;
+  }
+
+  seen.add(start);
+
+  for (const next of blockedOn.get(start) ?? []) {
+    if (next === target) {
+      return [start, target];
+    }
+
+    const rest = waitPathTo(next, target, seen);
+
+    if (rest !== undefined) {
+      return [start, ...rest];
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Awaits another evaluation's in-flight load with the wait recorded, so that a third evaluation
+ * arriving mid-wait can see this one and report the ring instead of joining the pile-up.
+ *
+ * The edge is removed in `finally` rather than on success: a rejected load frees the waiter just as
+ * a resolved one does, and a stale edge would make the next unrelated wait look like a cycle.
+ */
+async function awaitRecorded(
+  waiter: string,
+  awaited: string,
+  pending: Promise<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  let edges = blockedOn.get(waiter);
+
+  if (edges === undefined) {
+    edges = new Set();
+    blockedOn.set(waiter, edges);
+  }
+
+  edges.add(awaited);
+
+  try {
+    return await pending;
+  } finally {
+    edges.delete(awaited);
+
+    if (edges.size === 0) {
+      blockedOn.delete(waiter);
+    }
+  }
+}
+
+/**
+ * One sentence for both ways a cycle is found — self re-entry on one path, and two paths waiting on
+ * each other — because to a user they are the same defect and want the same fix. `ring` is rendered
+ * as given, so each caller passes a closed loop.
+ */
+function cycleError(
+  canonical: string,
+  ring: readonly string[],
+): ThymianBaseError {
+  return new ThymianBaseError(
+    `Cannot load user module ${canonical}: it is already being evaluated, so the import cycle ` +
+      `${ring.join(' -> ')} can never complete.`,
+    {
+      name: 'UserModuleLoadError',
+      suggestions: [
+        'Break the cycle by importing the shared module directly instead of loading it through Thymian.',
+      ],
+    },
+  );
+}
 
 async function importNatively(
   resolvedPath: string,
@@ -578,16 +698,7 @@ export async function loadUserModule(
   const chain = evaluationChain.getStore() ?? [];
 
   if (chain.includes(canonical)) {
-    throw new ThymianBaseError(
-      `Cannot load user module ${canonical}: it is already being evaluated, so the import cycle ` +
-        `${[...chain, canonical].join(' -> ')} can never complete.`,
-      {
-        name: 'UserModuleLoadError',
-        suggestions: [
-          'Break the cycle by importing the shared module directly instead of loading it through Thymian.',
-        ],
-      },
-    );
+    throw cycleError(canonical, [...chain, canonical]);
   }
 
   const nested = [...chain, canonical];
@@ -599,7 +710,25 @@ export async function loadUserModule(
   const pending = inFlightTypeScriptLoads.get(canonical);
 
   if (pending !== undefined) {
-    return await pending;
+    // Another evaluation owns this load. Waiting for it is not just allowed but required — it is
+    // what makes "exactly once" hold under concurrency — with one exception: when that evaluation
+    // is itself waiting, directly or transitively, on the module being evaluated right here. Then
+    // the waits close a ring that no return can break.
+    const waiter = chain.at(-1);
+
+    if (waiter === undefined) {
+      // A root call. Nothing is being evaluated on this path, so joining a wait cannot close a
+      // ring — at worst this caller waits for a cycle someone else is about to report.
+      return await pending;
+    }
+
+    const ring = waitPathTo(canonical, waiter);
+
+    if (ring !== undefined) {
+      throw cycleError(canonical, [waiter, ...ring]);
+    }
+
+    return await awaitRecorded(waiter, canonical, pending);
   }
 
   const load = evaluationChain.run(nested, () => importThroughJiti(canonical));

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -42,7 +42,7 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -96,6 +96,61 @@ function resolveThroughRequire(
       return anchor.resolve(location);
     } catch {
       // Not resolvable from this anchor — fall through to the next, then to jiti.
+    }
+  }
+
+  return undefined;
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    // Missing, or a path whose parent is not a directory — either way, not a module.
+    return false;
+  }
+}
+
+/**
+ * The extensions this seam has to guess for itself, in the order unnarrowed jiti guessed them.
+ *
+ * Narrowing jiti's `extensions` (see {@link getJiti}) narrows what it *guesses* with too, and
+ * Node's CJS resolver inside `require.resolve` only ever tried `.js`, `.json` and `.node` — so
+ * without this step an extensionless `./my-rule` no longer finds a `my-rule.mjs` on disk.
+ */
+const GUESSED_EXTENSION = ['.mjs', '.cjs'];
+
+/**
+ * Completes extensionless resolution for the two extensions that fall between the resolvers.
+ *
+ * Ordering is what keeps this a gap-filler rather than a preference: {@link resolveThroughRequire}
+ * runs BEFORE it, so a sibling `.js` still wins, and {@link resolveThroughJiti} runs AFTER it, so
+ * `.mjs`/`.cjs` still win over a sibling `.ts`. That reproduces jiti's own default order
+ * (`.js`, `.mjs`, `.cjs`, `.ts`, …) exactly, which is the point — the narrowing is meant to change
+ * which registry a module lands in, not which file a specifier names.
+ *
+ * Only absolute locations, because guessing is a filesystem question: a bare specifier is a
+ * package name until the caller has turned it into a path.
+ */
+function resolveThroughGuessing(location: string): string | undefined {
+  if (!path.isAbsolute(location)) {
+    return undefined;
+  }
+
+  for (const extension of GUESSED_EXTENSION) {
+    const candidate = `${location}${extension}`;
+
+    if (isFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Then the directory forms, the same file-before-directory order Node applies to `.js`.
+  for (const extension of GUESSED_EXTENSION) {
+    const candidate = path.join(location, `index${extension}`);
+
+    if (isFile(candidate)) {
+      return candidate;
     }
   }
 
@@ -180,9 +235,16 @@ function getJiti(): Promise<Jiti> {
       // of registering it itself. With the default list, a `.js` module imported by both a
       // natively-loaded JS rule and a jiti-loaded TS rule lands in two registries and evaluates
       // TWICE, handing the two rules non-identical objects — measured, and the thing contract
-      // item 3 forbids. Narrowing unifies them: one evaluation, `===` identical. Resolution is
-      // unaffected (the list governs extension *guessing*, and every case here was measured
-      // identical), because explicit paths and `.js`→`.ts` NodeNext mapping still work.
+      // item 3 forbids. Narrowing unifies them: one evaluation, `===` identical.
+      //
+      // It is NOT resolution-neutral, though. jiti derives its guessing list (`additionalExts`)
+      // from `extensions` by dropping only `.js`, so narrowing takes `.mjs`, `.cjs` and the JSX
+      // family out of extension GUESSING as well as out of the registry — measured on 2.6.1:
+      // an extensionless `./my-rule` against a `my-rule.mjs` went from resolved to `undefined`.
+      // The JSX family is declined by {@link LOADABLE_EXTENSION} either way, and `.mjs`/`.cjs`
+      // are guessed back by {@link resolveThroughGuessing}, so the narrowing costs the registry
+      // its `.js` entry and costs resolution nothing. Explicit paths and `.js`→`.ts` NodeNext
+      // mapping are unaffected.
       createJiti(import.meta.url, {
         extensions: ['.ts', '.mts', '.cts'],
       }),
@@ -252,10 +314,11 @@ export interface ResolveUserModuleOptions {
  * Resolves a user-supplied module specifier to an absolute filesystem path, or `undefined` when
  * the specifier does not name a loadable user module. Never throws.
  *
- * Resolution order stops at the first hit: `existsSync` on `<cwd>/<specifier>`, then
- * `require.resolve`, then jiti's `esmResolve`. `require.resolve` already handles TypeScript with
- * an explicit extension, so the jiti fallback is reached for *resolution* only by extensionless
- * and NodeNext `.js`→`.ts` specifiers.
+ * Resolution order stops at the first hit: `require.resolve`, then a `.mjs`/`.cjs` extension
+ * guess ({@link resolveThroughGuessing}), then jiti's `esmResolve` — with the `<cwd>/<specifier>`
+ * fallback for bare names slotted in before that last step. `require.resolve` already handles
+ * TypeScript with an explicit extension, so the jiti fallback is reached for *resolution* only by
+ * extensionless and NodeNext `.js`→`.ts` specifiers.
  *
  * @param specifier The user's rule, rule-set or plugin specifier.
  * @param cwd Directory that path-like specifiers resolve against, that anchors the jiti fallback,
@@ -283,11 +346,14 @@ export async function resolveUserModule(
 
     resolved =
       resolveThroughRequire(location, cwd) ??
+      resolveThroughGuessing(location) ??
       (await resolveThroughJiti(location, cwd));
   } else {
     // Installed packages FIRST. Preferring `<cwd>/<specifier>` up front is what let a same-named
     // file or directory shadow — and silently execute in place of — an installed package.
-    resolved = resolveThroughRequire(specifier, cwd);
+    resolved =
+      resolveThroughRequire(specifier, cwd) ??
+      resolveThroughGuessing(specifier);
 
     if (
       resolved === undefined &&
@@ -301,7 +367,9 @@ export async function resolveUserModule(
       const fileLocation = path.resolve(cwd, specifier);
 
       if (existsSync(fileLocation)) {
-        resolved = resolveThroughRequire(fileLocation, cwd);
+        resolved =
+          resolveThroughRequire(fileLocation, cwd) ??
+          resolveThroughGuessing(fileLocation);
       }
     }
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -9,59 +9,121 @@
  *    `undefined` and lets the caller phrase the error.
  * 2. **Dispatch on the *resolved* extension, before any import.** TypeScript goes through jiti,
  *    everything else through a plain dynamic `import()`.
- * 3. **Never import-then-retry.** A retry would run a module's top-level side effects twice.
+ * 3. **Never import-then-retry, and never evaluate twice.** A module's top-level side effects
+ *    must run exactly once, so concurrent loads of one file share a single in-flight import.
  * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
  *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
+ *
+ * Three limitations are deliberate and measured against jiti 2.6.1, not oversights:
+ *
+ * - **TypeScript sources must use `export default`.** `module.exports = …` in a `.ts`/`.cts` file
+ *   produces a namespace with no `default` key, and jiti's interop makes that shape *identical*
+ *   to a module with only named exports (`interopDefault: false` does not separate them either).
+ *   Synthesising a default would let a named-only module masquerade as a rule, so this seam
+ *   reports it as "no default export" rather than guessing. Tracked as epic follow-up work.
+ * - **`.tsx`/`.mtsx`/`.ctsx` are declined at resolution.** jiti's `jsx` option is off by default,
+ *   so dispatching them to jiti yields a bare `ParseError` with no file or line. Declining lets
+ *   the caller say "cannot resolve", which is the more useful message.
+ * - **A *bare* specifier that resolves only from the user's project still instantiates jiti**,
+ *   even when it is plain JavaScript. `require` is anchored to core's install directory, so a
+ *   package present only in the user's `node_modules` misses it and reaches the jiti fallback
+ *   (measured with `JITI_DEBUG=1`). Contract item 4 therefore holds for Thymian's own bundled
+ *   rules — the ones loaded on every invocation — but not for every JavaScript module. Closing
+ *   it means re-anchoring `require` at `cwd`, which changes bare-specifier resolution for a
+ *   globally installed CLI; deliberately not done here.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Jiti } from 'jiti';
 
+import { isRecord } from './utils.js';
+
 const require = createRequire(import.meta.url);
 
-/** Extensions jiti must handle. `.tsx` rides along on the same branch. */
-const TYPESCRIPT_EXTENSION = /\.[cm]?tsx?$/;
+/** Extensions jiti handles. `.tsx` is excluded on purpose — see the file header. */
+const TYPESCRIPT_EXTENSION = /\.[cm]?ts$/;
 
-/** Declaration files are never loadable — checked first, since `.d.ts` also matches above. */
-const DECLARATION_FILE = /\.d\.[cm]?ts$/;
+/**
+ * Extensions the dispatch has no working branch for. Declined at resolution so the caller phrases
+ * the error, rather than surfacing a jiti `ParseError` or a Node `ERR_UNKNOWN_FILE_EXTENSION`.
+ */
+const UNSUPPORTED_EXTENSION = /\.[cm]?tsx$/i;
+
+/**
+ * Declaration files are never loadable. Case-insensitive: on Windows and default macOS volumes a
+ * `Decl.D.TS` resolves fine, and a case-sensitive guard would wave through exactly the file it
+ * exists to stop. Checked before {@link TYPESCRIPT_EXTENSION}, which `.d.ts` also matches.
+ */
+const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
+
+/** `./x`, `../x`, `.` or `..` — specifiers Node resolves against the importer, not `node_modules`. */
+const RELATIVE_SPECIFIER = /^\.\.?(?:[/\\]|$)/;
 
 /**
  * Memoised as the *promise*, not the resolved instance: `loadRules` resolves rule sources
  * concurrently, and memoising the instance would let several concurrent TypeScript loads each
- * kick off their own `import('jiti')`. The promise makes "imported lazily, once" hold under
- * concurrency too.
+ * kick off their own `import('jiti')`. Cleared on rejection, so one transient failure (a partial
+ * install, EMFILE) does not poison every later TypeScript load in the process.
  */
 let jitiInstance: Promise<Jiti> | undefined;
 
 function getJiti(): Promise<Jiti> {
   // A type-only import of `Jiti` emits nothing under `verbatimModuleSyntax`, so this dynamic
   // import is the only `jiti` reference in the built output — that is what keeps it lazy.
-  jitiInstance ??= import('jiti').then(({ createJiti }) =>
-    // Defaults only. `interopDefault` already defaults to `true`, and `fsCache` degrades
-    // gracefully rather than throwing when its directory is unwritable (measured against
-    // 2.6.1) — so a read-only or containerised CI needs no Thymian-specific cache option.
-    // `JITI_FS_CACHE=false` is the existing escape hatch if one is ever wanted.
-    createJiti(import.meta.url),
-  );
+  jitiInstance ??= import('jiti')
+    .then(({ createJiti }) =>
+      // Defaults only. `interopDefault` already defaults to `true`, and `fsCache` degrades
+      // gracefully rather than throwing when its directory is unwritable (measured against
+      // 2.6.1) — so a read-only or containerised CI needs no Thymian-specific cache option.
+      // `JITI_FS_CACHE=false` is the existing escape hatch if one is ever wanted.
+      createJiti(import.meta.url),
+    )
+    .catch((error: unknown) => {
+      jitiInstance = undefined;
+
+      throw error;
+    });
 
   return jitiInstance;
+}
+
+/** True for specifiers Node resolves against the importer rather than the `node_modules` chain. */
+function isPathLike(specifier: string): boolean {
+  return RELATIVE_SPECIFIER.test(specifier) || path.isAbsolute(specifier);
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
 }
 
 async function resolveThroughJiti(
   location: string,
   cwd: string,
 ): Promise<string | undefined> {
-  const jiti = await getJiti();
+  let jiti: Jiti;
+
+  try {
+    jiti = await getJiti();
+  } catch {
+    // Resolution never throws (contract item 1). A broken jiti install means "unresolved", and
+    // the caller keeps ownership of the message the user actually sees.
+    return undefined;
+  }
 
   // `try: true` makes jiti answer `undefined` instead of throwing. The declared overload
   // widens `try` to `boolean`, which would hide that case, so the annotation restores it.
   const resolvedUrl: string | undefined = jiti.esmResolve(location, {
     try: true,
-    // Resolve relative and bare specifiers from the user's project, not from core's `dist/`.
+    // A hint only — jiti abandons it when the path misses, which is why relative specifiers are
+    // anchored at `cwd` before they ever get here.
     parentURL: pathToFileURL(path.join(cwd, '_')),
   });
 
@@ -84,7 +146,13 @@ async function resolveThroughJiti(
 }
 
 export interface ResolveUserModuleOptions {
-  /** Try `<cwd>/<specifier>` on disk before `require.resolve`. Default `true`. */
+  /**
+   * Try `<cwd>/<specifier>` on disk before `require.resolve`. Default `true`.
+   *
+   * Governs **bare** specifiers only, and applies to them only when they name a *file*, so a
+   * same-named directory in `cwd` can no longer shadow an installed package. Relative specifiers
+   * are always anchored at `cwd` regardless of this flag — they are unambiguously paths.
+   */
   preferCwdRelative?: boolean;
 }
 
@@ -98,20 +166,39 @@ export interface ResolveUserModuleOptions {
  * and NodeNext `.js`→`.ts` specifiers.
  *
  * @param specifier The user's rule, rule-set or plugin specifier.
- * @param cwd Directory that cwd-relative and bare specifiers resolve against.
+ * @param cwd Directory that path-like specifiers resolve against, and that anchors the jiti
+ *   fallback. **Bare** specifiers are resolved through `require.resolve`, which is anchored to
+ *   core's own install directory and walks its `node_modules` ancestor chain — `cwd` does not
+ *   move that base.
  * @param options See {@link ResolveUserModuleOptions}.
  */
 export async function resolveUserModule(
   specifier: string,
   cwd: string = process.cwd(),
-  { preferCwdRelative = true }: ResolveUserModuleOptions = {},
+  options: ResolveUserModuleOptions = {},
 ): Promise<string | undefined> {
+  const { preferCwdRelative = true } = options;
+
   let location = specifier;
 
-  if (preferCwdRelative) {
+  if (RELATIVE_SPECIFIER.test(specifier)) {
+    // A relative specifier is relative to the USER's cwd, never to core's install directory —
+    // but `require` is anchored to the latter and jiti's `parentURL` is only a hint it abandons
+    // when the path misses. Both would hand back Thymian's *own* modules as the user's rule
+    // (`./index.js` resolves core's barrel), so anchor it here instead of delegating.
+    // Unconditional: `preferCwdRelative` governs bare names, and a relative specifier is
+    // unambiguously a path.
+    location = path.resolve(cwd, specifier);
+  } else if (preferCwdRelative) {
     const fileLocation = path.resolve(cwd, specifier);
 
-    if (existsSync(fileLocation)) {
+    // A bare specifier is only preferred when it names a file. A same-named directory in `cwd`
+    // would otherwise win and then either fail to resolve or — worse — load a decoy package's
+    // code under the name of an installed one.
+    if (
+      existsSync(fileLocation) &&
+      (isPathLike(specifier) || isFile(fileLocation))
+    ) {
       location = fileLocation;
     }
   }
@@ -124,7 +211,7 @@ export async function resolveUserModule(
     resolved = await resolveThroughJiti(location, cwd);
   }
 
-  if (resolved === undefined || DECLARATION_FILE.test(resolved)) {
+  if (resolved === undefined) {
     return undefined;
   }
 
@@ -135,7 +222,47 @@ export async function resolveUserModule(
     return undefined;
   }
 
-  return resolved;
+  let normalised: string;
+
+  try {
+    // `native` reports the *on-disk* casing. Both resolvers echo the caller's spelling, so on a
+    // case-insensitive volume `./Rule.TS` would otherwise reach a dispatch that matches neither
+    // branch. Symlinks are unaffected: both resolvers already return realpaths.
+    normalised = realpathSync.native(resolved);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    DECLARATION_FILE.test(normalised) ||
+    UNSUPPORTED_EXTENSION.test(normalised)
+  ) {
+    return undefined;
+  }
+
+  return normalised;
+}
+
+/**
+ * In-flight TypeScript loads, keyed by resolved path. jiti only populates its module cache once a
+ * load *completes*, so without this two concurrent loads of one file evaluate it twice and return
+ * two distinct namespaces — the double-evaluation contract item 3 forbids. Node's own loader
+ * de-duplicates in flight, so the native branch needs no equivalent.
+ */
+const inFlightTypeScriptLoads = new Map<
+  string,
+  Promise<Record<string, unknown>>
+>();
+
+async function importThroughJiti(
+  resolvedPath: string,
+): Promise<Record<string, unknown>> {
+  const jiti = await getJiti();
+  const module = await jiti.import<unknown>(resolvedPath);
+
+  // `export = <primitive>` yields the bare value, so `'default' in module` would throw a
+  // `TypeError`. A non-object export can only ever have been a default.
+  return isRecord(module) ? module : { default: module };
 }
 
 /**
@@ -147,15 +274,25 @@ export async function resolveUserModule(
 export async function loadUserModule(
   resolvedPath: string,
 ): Promise<Record<string, unknown>> {
-  if (TYPESCRIPT_EXTENSION.test(resolvedPath)) {
-    const jiti = await getJiti();
+  if (!TYPESCRIPT_EXTENSION.test(resolvedPath)) {
+    const module: unknown = await import(pathToFileURL(resolvedPath).href);
 
-    return await jiti.import<Record<string, unknown>>(resolvedPath);
+    return isRecord(module) ? module : { default: module };
   }
 
-  const module: Record<string, unknown> = await import(
-    pathToFileURL(resolvedPath).href
-  );
+  const pending = inFlightTypeScriptLoads.get(resolvedPath);
 
-  return module;
+  if (pending !== undefined) {
+    return await pending;
+  }
+
+  const load = importThroughJiti(resolvedPath);
+
+  inFlightTypeScriptLoads.set(resolvedPath, load);
+
+  try {
+    return await load;
+  } finally {
+    inFlightTypeScriptLoads.delete(resolvedPath);
+  }
 }

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -5,8 +5,12 @@
  * 1. **Resolve first, load second.** The two steps are separate and separately inspectable:
  *    callers need the resolved path in its own right (`loadRuleSet` uses it as a glob base) and
  *    they need resolution failure to stay distinguishable from load failure, so each keeps its
- *    own user-facing error message. `resolveUserModule` therefore never throws — it answers
- *    `undefined` and lets the caller phrase the error.
+ *    own user-facing error message. `resolveUserModule` therefore never throws — it answers a
+ *    {@link ResolveUserModuleResult} and lets the caller phrase the error. That result is a
+ *    DISCRIMINATED UNION rather than `string | undefined` because "does not exist" and "exists
+ *    but is not loadable" need different sentences: the seam is the only place that knows which
+ *    it is, and every call site would otherwise re-derive it from the specifier it already
+ *    failed to resolve.
  * 2. **Dispatch on the *resolved* extension, before any import.** TypeScript goes through jiti,
  *    everything else through a plain dynamic `import()`.
  * 3. **Never import-then-retry, and never evaluate twice.** A module's top-level side effects
@@ -22,9 +26,10 @@
  *   to a module with only named exports (`interopDefault: false` does not separate them either).
  *   Synthesising a default would let a named-only module masquerade as a rule, so this seam
  *   reports it as "no default export" rather than guessing. Tracked as epic follow-up work.
- * - **Only JavaScript and TypeScript are loadable**, enforced as an allow-list at resolution so
- *   the caller phrases the error. See {@link LOADABLE_EXTENSION} for why each excluded extension
- *   is excluded — including `.node`, which is not importable on the `engines.node` floor at all.
+ * - **Only JavaScript and TypeScript are loadable**, enforced as an allow-list at resolution,
+ *   which hands the caller a `reason` to phrase the error with. See {@link LOADABLE_EXTENSION}
+ *   for why each excluded extension is excluded — including `.node`, which is not importable on
+ *   the `engines.node` floor at all.
  * - **tsconfig `paths` aliases are not honoured in a user TypeScript module.** jiti is given no
  *   `alias` option and does not read the user's `tsconfig.json`, so a rule importing `@lib/x.js`
  *   under `paths: { "@lib/*": [...] }` resolves and then fails at load with a raw
@@ -192,8 +197,10 @@ const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
 /**
  * Why a resolved path can never be loaded, or `undefined` when it can.
  *
- * Shared by both halves of the seam so they cannot drift: `resolveUserModule` turns a reason into
- * `undefined`, and `loadUserModule` turns it into a framed error. Without the second check a path
+ * Shared by both halves of the seam so they cannot drift: `resolveUserModule` passes a reason out
+ * as {@link ResolveUserModuleResult.reason}, and `loadUserModule` turns it into a framed error.
+ * One sentence, one source — the two halves can never disagree about WHY a path is unloadable.
+ * Without the second check a path
  * obtained some other way — a `loadRuleSet` glob, a config `path` — bypasses the guard entirely,
  * and a `.d.ts` then imports as an EMPTY module, so the caller reports "does not use default
  * export": the exact confusion the guard exists to prevent.
@@ -299,6 +306,56 @@ async function resolveThroughJiti(
   return existsSync(resolvedPath) ? resolvedPath : undefined;
 }
 
+/**
+ * Runs an absolute filesystem location through all three resolvers, in the one order that holds
+ * for a path: Node, then the extensions Node does not guess ({@link resolveThroughGuessing}),
+ * then jiti for the ones neither knows — `.ts` and NodeNext `.js`→`.ts`.
+ *
+ * Shared by the relative branch and the bare `<cwd>/<specifier>` fallback so the two cannot
+ * drift. They had: the fallback stopped after the guessing step and gated the whole block on
+ * `existsSync(<cwd>/<specifier>)`, so `rules: ['my-rule']` against a `<cwd>/my-rule.ts` resolved
+ * to nothing — the gate tested the EXTENSIONLESS spelling, which does not exist, and the jiti step
+ * it then fell through to was handed the BARE name, which searches `node_modules` only. The very
+ * same file resolved fine spelled `./my-rule`. Extensionless local TypeScript is the headline case
+ * for this seam, and it is the shape `rule-loader` accepts today, so both branches now run this.
+ *
+ * No existence gate: every resolver here is already existence-checked internally
+ * (`require.resolve` throws, {@link resolveThroughGuessing} calls `isFile`, and
+ * {@link resolveThroughJiti} ends on `existsSync`), so the gate only ever removed reachable
+ * answers.
+ */
+async function resolveLocation(
+  location: string,
+  cwd: string,
+): Promise<string | undefined> {
+  return (
+    resolveThroughRequire(location, cwd) ??
+    resolveThroughGuessing(location) ??
+    (await resolveThroughJiti(location, cwd))
+  );
+}
+
+/**
+ * The outcome of a resolution attempt.
+ *
+ * A discriminated union rather than `string | undefined` because the two failure modes are not
+ * interchangeable to a user: "there is no such file" and "the file is right there but Thymian
+ * cannot load it" want different sentences, and only this seam knows which one applies. Returning
+ * `undefined` for both meant the precise sentence {@link unloadableReason} had just produced was
+ * discarded one line later, and a `rules: ['./rules.yaml']` was reported as unresolvable.
+ *
+ * `reason` is optional, not `string | null`, because most failures genuinely have nothing to add
+ * beyond "not found" — a caller writes `result.reason ?? <its own default>` and is done. Callers
+ * own the *sentence*; this seam owns the *fact*, which is the same split the contract's item 1
+ * describes.
+ */
+export type ResolveUserModuleResult =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason?: string };
+
+/** Not resolvable, with no more to say about it than that. */
+const NOT_RESOLVED: ResolveUserModuleResult = { ok: false };
+
 export interface ResolveUserModuleOptions {
   /**
    * Fall back to `<cwd>/<specifier>` when nothing is installed under that name. Default `true`.
@@ -311,8 +368,9 @@ export interface ResolveUserModuleOptions {
 }
 
 /**
- * Resolves a user-supplied module specifier to an absolute filesystem path, or `undefined` when
- * the specifier does not name a loadable user module. Never throws.
+ * Resolves a user-supplied module specifier. Never throws — every failure comes back as
+ * `{ ok: false }`, carrying a `reason` when the seam knows something the caller could not work
+ * out for itself. On success, `path` is an absolute filesystem path, never a `file://` URL.
  *
  * Resolution order stops at the first hit: `require.resolve`, then a `.mjs`/`.cjs` extension
  * guess ({@link resolveThroughGuessing}), then jiti's `esmResolve` — with the `<cwd>/<specifier>`
@@ -325,12 +383,13 @@ export interface ResolveUserModuleOptions {
  *   and whose `node_modules` ancestor chain is searched for **bare** specifiers before core's own
  *   (see {@link resolveThroughRequire}).
  * @param options See {@link ResolveUserModuleOptions}.
+ * @returns See {@link ResolveUserModuleResult}.
  */
 export async function resolveUserModule(
   specifier: string,
   cwd: string = process.cwd(),
   options: ResolveUserModuleOptions = {},
-): Promise<string | undefined> {
+): Promise<ResolveUserModuleResult> {
   const { preferCwdRelative = true } = options;
 
   let resolved: string | undefined;
@@ -342,18 +401,17 @@ export async function resolveUserModule(
     // (`./index.js` resolves core's barrel), so anchor it here instead of delegating.
     // Unconditional: `preferCwdRelative` governs bare names, and a relative specifier is
     // unambiguously a path.
-    const location = path.resolve(cwd, specifier);
-
-    resolved =
-      resolveThroughRequire(location, cwd) ??
-      resolveThroughGuessing(location) ??
-      (await resolveThroughJiti(location, cwd));
+    resolved = await resolveLocation(path.resolve(cwd, specifier), cwd);
   } else {
-    // Installed packages FIRST. Preferring `<cwd>/<specifier>` up front is what let a same-named
-    // file or directory shadow — and silently execute in place of — an installed package.
+    // Installed packages FIRST — through all three resolvers, not just the first two. jiti is
+    // what resolves an installed package whose entry point is TypeScript, which `require.resolve`
+    // cannot; running it here rather than after the cwd fallback is what keeps the documented
+    // order honest. Preferring `<cwd>/<specifier>` up front is what let a same-named local file
+    // or directory shadow — and silently execute in place of — an installed package.
     resolved =
       resolveThroughRequire(specifier, cwd) ??
-      resolveThroughGuessing(specifier);
+      resolveThroughGuessing(specifier) ??
+      (await resolveThroughJiti(specifier, cwd));
 
     if (
       resolved === undefined &&
@@ -364,27 +422,19 @@ export async function resolveUserModule(
       // the user meant. Resolving the absolute path (rather than using it verbatim) keeps a
       // directory holding `index.js` or a `package.json` `main` working, which is the shape
       // today's `rule-loader` accepts for `rules: ['my-rules']`.
-      const fileLocation = path.resolve(cwd, specifier);
-
-      if (existsSync(fileLocation)) {
-        resolved =
-          resolveThroughRequire(fileLocation, cwd) ??
-          resolveThroughGuessing(fileLocation);
-      }
+      resolved = await resolveLocation(path.resolve(cwd, specifier), cwd);
     }
-
-    resolved ??= await resolveThroughJiti(specifier, cwd);
   }
 
   if (resolved === undefined) {
-    return undefined;
+    return NOT_RESOLVED;
   }
 
   if (!path.isAbsolute(resolved)) {
     // `require.resolve` answers a builtin specifier with the bare id (`fs`, `node:fs`). That is
     // not a loadable user module, and passing it on would turn into a nonsense
     // `file://<cwd>/node:fs` import rather than the caller's "cannot resolve" message.
-    return undefined;
+    return NOT_RESOLVED;
   }
 
   let normalised: string;
@@ -395,14 +445,20 @@ export async function resolveUserModule(
     // branch. Symlinks are unaffected: both resolvers already return realpaths.
     normalised = realpathSync.native(resolved);
   } catch {
-    return undefined;
+    return NOT_RESOLVED;
   }
 
-  if (unloadableReason(normalised) !== undefined) {
-    return undefined;
+  const reason = unloadableReason(normalised);
+
+  if (reason !== undefined) {
+    // The one failure the caller cannot work out for itself: the path EXISTS and resolved
+    // cleanly, and is refused only because of what it is. Reported as `{ ok: false }` with no
+    // reason, this became "cannot resolve <path>" — telling the user a file they are looking at
+    // cannot be found.
+    return { ok: false, reason };
   }
 
-  return normalised;
+  return { ok: true, path: normalised };
 }
 
 /**

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -14,7 +14,7 @@
  * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
  *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
  *
- * Three limitations are deliberate and measured against jiti 2.6.1, not oversights:
+ * Two limitations are deliberate and measured against jiti 2.6.1, not oversights:
  *
  * - **TypeScript sources must use `export default`.** `module.exports = …` in a `.ts`/`.cts` file
  *   produces a namespace with no `default` key, and jiti's interop makes that shape *identical*
@@ -28,13 +28,10 @@
  *   Declining lets the caller say "cannot resolve", which is the more useful message.
  *   `.node` and `.wasm` are deliberately NOT declined: Node genuinely imports both, so a valid
  *   addon or wasm module loads through the native branch (verified).
- * - **A *bare* specifier that resolves only from the user's project still instantiates jiti**,
- *   even when it is plain JavaScript. `require` is anchored to core's install directory, so a
- *   package present only in the user's `node_modules` misses it and reaches the jiti fallback
- *   (measured with `JITI_DEBUG=1`). Contract item 4 therefore holds for Thymian's own bundled
- *   rules — the ones loaded on every invocation — but not for every JavaScript module. Closing
- *   it means re-anchoring `require` at `cwd`, which changes bare-specifier resolution for a
- *   globally installed CLI; deliberately not done here.
+ * Bare specifiers are resolved from the **user's project first**, then from core's own install
+ * directory. A package the user named in their config is theirs, so a globally installed CLI must
+ * not answer with its own copy of a colliding name; core's anchor stays as a fallback so
+ * Thymian's bundled rule packages keep resolving when the user's project does not carry them.
  */
 
 import { existsSync, realpathSync, statSync } from 'node:fs';
@@ -47,6 +44,36 @@ import type { Jiti } from 'jiti';
 import { isRecord } from './utils.js';
 
 const require = createRequire(import.meta.url);
+
+/**
+ * Resolves through Node's own resolver, trying the **user's project before core's install
+ * directory**.
+ *
+ * Anchoring only at core's directory (the single `require` above) meant a package present only in
+ * the user's `node_modules` was invisible to it and fell through to the jiti fallback — so a
+ * plain-JavaScript rule package paid for jiti, breaking contract item 4 (confirmed with
+ * `JITI_DEBUG=1`). It also meant a name the user installed lost to a Thymian dependency of the
+ * same name, which for a globally installed CLI is the wrong answer twice over.
+ *
+ * Only **bare** specifiers are affected: a relative one is already an absolute path by the time it
+ * gets here, and both anchors resolve an absolute path identically.
+ */
+function resolveThroughRequire(
+  location: string,
+  cwd: string,
+): string | undefined {
+  const anchors = [createRequire(pathToFileURL(path.join(cwd, '_'))), require];
+
+  for (const anchor of anchors) {
+    try {
+      return anchor.resolve(location);
+    } catch {
+      // Not resolvable from this anchor — fall through to the next, then to jiti.
+    }
+  }
+
+  return undefined;
+}
 
 /** Extensions jiti handles. `.tsx` is excluded on purpose — see the file header. */
 const TYPESCRIPT_EXTENSION = /\.[cm]?ts$/;
@@ -174,10 +201,9 @@ export interface ResolveUserModuleOptions {
  * and NodeNext `.js`→`.ts` specifiers.
  *
  * @param specifier The user's rule, rule-set or plugin specifier.
- * @param cwd Directory that path-like specifiers resolve against, and that anchors the jiti
- *   fallback. **Bare** specifiers are resolved through `require.resolve`, which is anchored to
- *   core's own install directory and walks its `node_modules` ancestor chain — `cwd` does not
- *   move that base.
+ * @param cwd Directory that path-like specifiers resolve against, that anchors the jiti fallback,
+ *   and whose `node_modules` ancestor chain is searched for **bare** specifiers before core's own
+ *   (see {@link resolveThroughRequire}).
  * @param options See {@link ResolveUserModuleOptions}.
  */
 export async function resolveUserModule(
@@ -211,11 +237,9 @@ export async function resolveUserModule(
     }
   }
 
-  let resolved: string | undefined;
+  let resolved = resolveThroughRequire(location, cwd);
 
-  try {
-    resolved = require.resolve(location);
-  } catch {
+  if (resolved === undefined) {
     resolved = await resolveThroughJiti(location, cwd);
   }
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -1,0 +1,161 @@
+/**
+ * The single seam through which Thymian loads a *user-supplied* module — a rule, a rule set or a
+ * plugin. Its contract, in order:
+ *
+ * 1. **Resolve first, load second.** The two steps are separate and separately inspectable:
+ *    callers need the resolved path in its own right (`loadRuleSet` uses it as a glob base) and
+ *    they need resolution failure to stay distinguishable from load failure, so each keeps its
+ *    own user-facing error message. `resolveUserModule` therefore never throws — it answers
+ *    `undefined` and lets the caller phrase the error.
+ * 2. **Dispatch on the *resolved* extension, before any import.** TypeScript goes through jiti,
+ *    everything else through a plain dynamic `import()`.
+ * 3. **Never import-then-retry.** A retry would run a module's top-level side effects twice.
+ * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
+ *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
+ */
+
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { Jiti } from 'jiti';
+
+const require = createRequire(import.meta.url);
+
+/** Extensions jiti must handle. `.tsx` rides along on the same branch. */
+const TYPESCRIPT_EXTENSION = /\.[cm]?tsx?$/;
+
+/** Declaration files are never loadable — checked first, since `.d.ts` also matches above. */
+const DECLARATION_FILE = /\.d\.[cm]?ts$/;
+
+/**
+ * Memoised as the *promise*, not the resolved instance: `loadRules` resolves rule sources
+ * concurrently, and memoising the instance would let several concurrent TypeScript loads each
+ * kick off their own `import('jiti')`. The promise makes "imported lazily, once" hold under
+ * concurrency too.
+ */
+let jitiInstance: Promise<Jiti> | undefined;
+
+function getJiti(): Promise<Jiti> {
+  // A type-only import of `Jiti` emits nothing under `verbatimModuleSyntax`, so this dynamic
+  // import is the only `jiti` reference in the built output — that is what keeps it lazy.
+  jitiInstance ??= import('jiti').then(({ createJiti }) =>
+    // Defaults only. `interopDefault` already defaults to `true`, and `fsCache` degrades
+    // gracefully rather than throwing when its directory is unwritable (measured against
+    // 2.6.1) — so a read-only or containerised CI needs no Thymian-specific cache option.
+    // `JITI_FS_CACHE=false` is the existing escape hatch if one is ever wanted.
+    createJiti(import.meta.url),
+  );
+
+  return jitiInstance;
+}
+
+async function resolveThroughJiti(
+  location: string,
+  cwd: string,
+): Promise<string | undefined> {
+  const jiti = await getJiti();
+
+  // `try: true` makes jiti answer `undefined` instead of throwing. The declared overload
+  // widens `try` to `boolean`, which would hide that case, so the annotation restores it.
+  const resolvedUrl: string | undefined = jiti.esmResolve(location, {
+    try: true,
+    // Resolve relative and bare specifiers from the user's project, not from core's `dist/`.
+    parentURL: pathToFileURL(path.join(cwd, '_')),
+  });
+
+  if (resolvedUrl === undefined || !resolvedUrl.startsWith('file:')) {
+    return undefined;
+  }
+
+  let resolvedPath: string;
+
+  try {
+    resolvedPath = fileURLToPath(resolvedUrl);
+  } catch {
+    // jiti can answer with a well-formed URL around a nonsense path — a Node builtin comes
+    // back as `file:///<cwd>/node:fs` — which `fileURLToPath` may reject outright.
+    return undefined;
+  }
+
+  // Same nonsense-path case, for the platforms where the conversion succeeds.
+  return existsSync(resolvedPath) ? resolvedPath : undefined;
+}
+
+export interface ResolveUserModuleOptions {
+  /** Try `<cwd>/<specifier>` on disk before `require.resolve`. Default `true`. */
+  preferCwdRelative?: boolean;
+}
+
+/**
+ * Resolves a user-supplied module specifier to an absolute filesystem path, or `undefined` when
+ * the specifier does not name a loadable user module. Never throws.
+ *
+ * Resolution order stops at the first hit: `existsSync` on `<cwd>/<specifier>`, then
+ * `require.resolve`, then jiti's `esmResolve`. `require.resolve` already handles TypeScript with
+ * an explicit extension, so the jiti fallback is reached for *resolution* only by extensionless
+ * and NodeNext `.js`→`.ts` specifiers.
+ *
+ * @param specifier The user's rule, rule-set or plugin specifier.
+ * @param cwd Directory that cwd-relative and bare specifiers resolve against.
+ * @param options See {@link ResolveUserModuleOptions}.
+ */
+export async function resolveUserModule(
+  specifier: string,
+  cwd: string = process.cwd(),
+  { preferCwdRelative = true }: ResolveUserModuleOptions = {},
+): Promise<string | undefined> {
+  let location = specifier;
+
+  if (preferCwdRelative) {
+    const fileLocation = path.resolve(cwd, specifier);
+
+    if (existsSync(fileLocation)) {
+      location = fileLocation;
+    }
+  }
+
+  let resolved: string | undefined;
+
+  try {
+    resolved = require.resolve(location);
+  } catch {
+    resolved = await resolveThroughJiti(location, cwd);
+  }
+
+  if (resolved === undefined || DECLARATION_FILE.test(resolved)) {
+    return undefined;
+  }
+
+  if (!path.isAbsolute(resolved)) {
+    // `require.resolve` answers a builtin specifier with the bare id (`fs`, `node:fs`). That is
+    // not a loadable user module, and passing it on would turn into a nonsense
+    // `file://<cwd>/node:fs` import rather than the caller's "cannot resolve" message.
+    return undefined;
+  }
+
+  return resolved;
+}
+
+/**
+ * Imports an already-resolved user module and returns its **namespace** — not its default
+ * export, because callers check `'default' in module` to detect a missing default export.
+ *
+ * @param resolvedPath An absolute path from {@link resolveUserModule}.
+ */
+export async function loadUserModule(
+  resolvedPath: string,
+): Promise<Record<string, unknown>> {
+  if (TYPESCRIPT_EXTENSION.test(resolvedPath)) {
+    const jiti = await getJiti();
+
+    return await jiti.import<Record<string, unknown>>(resolvedPath);
+  }
+
+  const module: Record<string, unknown> = await import(
+    pathToFileURL(resolvedPath).href
+  );
+
+  return module;
+}

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -41,6 +41,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Jiti } from 'jiti';
 
+import { ThymianBaseError } from './thymian.error.js';
 import { isRecord } from './utils.js';
 
 const require = createRequire(import.meta.url);
@@ -94,6 +95,27 @@ const UNSUPPORTED_EXTENSION = /\.(?:[cm]?[jt]sx|json)$/i;
  * exists to stop. Checked before {@link TYPESCRIPT_EXTENSION}, which `.d.ts` also matches.
  */
 const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
+
+/**
+ * Why a resolved path can never be loaded, or `undefined` when it can.
+ *
+ * Shared by both halves of the seam so they cannot drift: `resolveUserModule` turns a reason into
+ * `undefined`, and `loadUserModule` turns it into a framed error. Without the second check a path
+ * obtained some other way — a `loadRuleSet` glob, a config `path` — bypasses the guard entirely,
+ * and a `.d.ts` then imports as an EMPTY module, so the caller reports "does not use default
+ * export": the exact confusion the guard exists to prevent.
+ */
+function unloadableReason(resolvedPath: string): string | undefined {
+  if (DECLARATION_FILE.test(resolvedPath)) {
+    return 'a TypeScript declaration file contains no runtime code';
+  }
+
+  if (UNSUPPORTED_EXTENSION.test(resolvedPath)) {
+    return 'no dispatch branch can load this file extension';
+  }
+
+  return undefined;
+}
 
 /** `./x`, `../x`, `.` or `..` — specifiers Node resolves against the importer, not `node_modules`. */
 const RELATIVE_SPECIFIER = /^\.\.?(?:[/\\]|$)/;
@@ -265,10 +287,7 @@ export async function resolveUserModule(
     return undefined;
   }
 
-  if (
-    DECLARATION_FILE.test(normalised) ||
-    UNSUPPORTED_EXTENSION.test(normalised)
-  ) {
+  if (unloadableReason(normalised) !== undefined) {
     return undefined;
   }
 
@@ -306,6 +325,21 @@ async function importThroughJiti(
 export async function loadUserModule(
   resolvedPath: string,
 ): Promise<Record<string, unknown>> {
+  const reason = unloadableReason(resolvedPath);
+
+  if (reason !== undefined) {
+    throw new ThymianBaseError(
+      `Cannot load user module ${resolvedPath}: ${reason}.`,
+      {
+        name: 'UserModuleLoadError',
+        suggestions: [
+          'Point at the implementation file rather than its declarations or a non-module asset.',
+          'Resolve the specifier with resolveUserModule first — it declines paths that cannot be loaded.',
+        ],
+      },
+    );
+  }
+
   if (!TYPESCRIPT_EXTENSION.test(resolvedPath)) {
     const module: unknown = await import(pathToFileURL(resolvedPath).href);
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -21,9 +21,13 @@
  *   to a module with only named exports (`interopDefault: false` does not separate them either).
  *   Synthesising a default would let a named-only module masquerade as a rule, so this seam
  *   reports it as "no default export" rather than guessing. Tracked as epic follow-up work.
- * - **`.tsx`/`.mtsx`/`.ctsx` are declined at resolution.** jiti's `jsx` option is off by default,
- *   so dispatching them to jiti yields a bare `ParseError` with no file or line. Declining lets
- *   the caller say "cannot resolve", which is the more useful message.
+ * - **JSX and `.json` are declined at resolution.** Neither dispatch branch can load them: jiti's
+ *   `jsx` option is off by default (a `.tsx` yields a bare `ParseError` with no file or line) and
+ *   Node rejects `.jsx` outright, while `.json` needs an `import ... with { type: 'json' }`
+ *   attribute this seam deliberately does not pass — nothing in Thymian consumes a JSON rule set.
+ *   Declining lets the caller say "cannot resolve", which is the more useful message.
+ *   `.node` and `.wasm` are deliberately NOT declined: Node genuinely imports both, so a valid
+ *   addon or wasm module loads through the native branch (verified).
  * - **A *bare* specifier that resolves only from the user's project still instantiates jiti**,
  *   even when it is plain JavaScript. `require` is anchored to core's install directory, so a
  *   package present only in the user's `node_modules` misses it and reaches the jiti fallback
@@ -48,10 +52,14 @@ const require = createRequire(import.meta.url);
 const TYPESCRIPT_EXTENSION = /\.[cm]?ts$/;
 
 /**
- * Extensions the dispatch has no working branch for. Declined at resolution so the caller phrases
- * the error, rather than surfacing a jiti `ParseError` or a Node `ERR_UNKNOWN_FILE_EXTENSION`.
+ * Extensions no dispatch branch can load, declined at resolution so the caller phrases the error
+ * rather than surfacing a raw `ParseError`, `ERR_UNKNOWN_FILE_EXTENSION` or
+ * `ERR_IMPORT_ATTRIBUTE_MISSING`. Covers the JSX family (`.jsx`/`.tsx` and their `.m`/`.c`
+ * variants) and `.json` — the latter resolves without any user typo, since `.json` is in jiti's
+ * default extension list. `.node` and `.wasm` are absent on purpose: Node imports both, so a
+ * valid addon or wasm module must keep working.
  */
-const UNSUPPORTED_EXTENSION = /\.[cm]?tsx$/i;
+const UNSUPPORTED_EXTENSION = /\.(?:[cm]?[jt]sx|json)$/i;
 
 /**
  * Declaration files are never loadable. Case-insensitive: on Windows and default macOS volumes a

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -10,7 +10,8 @@
  * 2. **Dispatch on the *resolved* extension, before any import.** TypeScript goes through jiti,
  *    everything else through a plain dynamic `import()`.
  * 3. **Never import-then-retry, and never evaluate twice.** A module's top-level side effects
- *    must run exactly once, so concurrent loads of one file share a single in-flight import.
+ *    must run exactly once — across BOTH dispatch branches, across every spelling of its path,
+ *    and under concurrency. A cycle is reported rather than deadlocked.
  * 4. **jiti only for TypeScript, imported lazily.** `loadRules` runs on every single invocation
  *    for all built-in rules, and those are JavaScript; that path must never pay for jiti.
  *
@@ -37,6 +38,7 @@
  * user's project does not carry them.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { existsSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
@@ -136,11 +138,21 @@ function getJiti(): Promise<Jiti> {
   // import is the only `jiti` reference in the built output — that is what keeps it lazy.
   jitiInstance ??= import('jiti')
     .then(({ createJiti }) =>
-      // Defaults only. `interopDefault` already defaults to `true`, and `fsCache` degrades
-      // gracefully rather than throwing when its directory is unwritable (measured against
-      // 2.6.1) — so a read-only or containerised CI needs no Thymian-specific cache option.
+      // `interopDefault` already defaults to `true`, and `fsCache` degrades gracefully rather
+      // than throwing when its directory is unwritable (measured against 2.6.1) — so a
+      // read-only or containerised CI needs no Thymian-specific cache option.
       // `JITI_FS_CACHE=false` is the existing escape hatch if one is ever wanted.
-      createJiti(import.meta.url),
+      //
+      // `extensions` is narrowed to TypeScript so jiti DELEGATES `.js` to Node's loader instead
+      // of registering it itself. With the default list, a `.js` module imported by both a
+      // natively-loaded JS rule and a jiti-loaded TS rule lands in two registries and evaluates
+      // TWICE, handing the two rules non-identical objects — measured, and the thing contract
+      // item 3 forbids. Narrowing unifies them: one evaluation, `===` identical. Resolution is
+      // unaffected (the list governs extension *guessing*, and every case here was measured
+      // identical), because explicit paths and `.js`→`.ts` NodeNext mapping still work.
+      createJiti(import.meta.url, {
+        extensions: ['.ts', '.mts', '.cts'],
+      }),
     )
     .catch((error: unknown) => {
       jitiInstance = undefined;
@@ -293,6 +305,33 @@ export async function resolveUserModule(
 }
 
 /**
+ * Collapses the spellings of one file to a single identity: `/base/x.ts`, `/base/sub/../x.ts` and
+ * a symlink to it must not look like three modules. Without this the in-flight map keys on the raw
+ * string and the same file evaluates once per spelling. Also fixes the dispatch for a mis-cased
+ * path reaching this function directly (a `loadRuleSet` glob, a config `path`): only
+ * `resolveUserModule` normalised casing, so `PLAIN.TS` matched no branch and died raw.
+ */
+function canonicalise(resolvedPath: string): string {
+  try {
+    return realpathSync.native(resolvedPath);
+  } catch {
+    // Not on disk — keep the caller's path so the import surfaces the real error.
+    return path.resolve(resolvedPath);
+  }
+}
+
+/**
+ * The chain of user modules being evaluated on this async path.
+ *
+ * Node's loader and jiti's registry each resolve their own import cycles, but the in-flight map
+ * cannot: a module that re-enters this seam during its own evaluation would await a promise only
+ * its own return can settle, and the process hangs silently — Node exits 13, "Detected unsettled
+ * top-level await". `AsyncLocalStorage` carries the chain into module top-level code on both
+ * branches (verified), so re-entry is detectable and can be reported instead of hung.
+ */
+const evaluationChain = new AsyncLocalStorage<readonly string[]>();
+
+/**
  * In-flight TypeScript loads, keyed by resolved path. jiti only populates its module cache once a
  * load *completes*, so without this two concurrent loads of one file evaluate it twice and return
  * two distinct namespaces — the double-evaluation contract item 3 forbids. Node's own loader
@@ -302,6 +341,14 @@ const inFlightTypeScriptLoads = new Map<
   string,
   Promise<Record<string, unknown>>
 >();
+
+async function importNatively(
+  resolvedPath: string,
+): Promise<Record<string, unknown>> {
+  const module: unknown = await import(pathToFileURL(resolvedPath).href);
+
+  return isRecord(module) ? module : { default: module };
+}
 
 async function importThroughJiti(
   resolvedPath: string,
@@ -323,11 +370,27 @@ async function importThroughJiti(
 export async function loadUserModule(
   resolvedPath: string,
 ): Promise<Record<string, unknown>> {
-  const reason = unloadableReason(resolvedPath);
+  if (!path.isAbsolute(resolvedPath)) {
+    // Documented precondition, previously unchecked — and failing silently rather than loudly:
+    // the native branch would anchor a relative path at `process.cwd()` while the jiti branch
+    // anchored it at CORE's install directory, so one input searched two different trees.
+    throw new ThymianBaseError(
+      `Cannot load user module ${resolvedPath}: an absolute path is required.`,
+      {
+        name: 'UserModuleLoadError',
+        suggestions: [
+          'Resolve the specifier with resolveUserModule first — it always answers an absolute path.',
+        ],
+      },
+    );
+  }
+
+  const canonical = canonicalise(resolvedPath);
+  const reason = unloadableReason(canonical);
 
   if (reason !== undefined) {
     throw new ThymianBaseError(
-      `Cannot load user module ${resolvedPath}: ${reason}.`,
+      `Cannot load user module ${canonical}: ${reason}.`,
       {
         name: 'UserModuleLoadError',
         suggestions: [
@@ -338,25 +401,40 @@ export async function loadUserModule(
     );
   }
 
-  if (!TYPESCRIPT_EXTENSION.test(resolvedPath)) {
-    const module: unknown = await import(pathToFileURL(resolvedPath).href);
+  const chain = evaluationChain.getStore() ?? [];
 
-    return isRecord(module) ? module : { default: module };
+  if (chain.includes(canonical)) {
+    throw new ThymianBaseError(
+      `Cannot load user module ${canonical}: it is already being evaluated, so the import cycle ` +
+        `${[...chain, canonical].join(' -> ')} can never complete.`,
+      {
+        name: 'UserModuleLoadError',
+        suggestions: [
+          'Break the cycle by importing the shared module directly instead of loading it through Thymian.',
+        ],
+      },
+    );
   }
 
-  const pending = inFlightTypeScriptLoads.get(resolvedPath);
+  const nested = [...chain, canonical];
+
+  if (!TYPESCRIPT_EXTENSION.test(canonical)) {
+    return await evaluationChain.run(nested, () => importNatively(canonical));
+  }
+
+  const pending = inFlightTypeScriptLoads.get(canonical);
 
   if (pending !== undefined) {
     return await pending;
   }
 
-  const load = importThroughJiti(resolvedPath);
+  const load = evaluationChain.run(nested, () => importThroughJiti(canonical));
 
-  inFlightTypeScriptLoads.set(resolvedPath, load);
+  inFlightTypeScriptLoads.set(canonical, load);
 
   try {
     return await load;
   } finally {
-    inFlightTypeScriptLoads.delete(resolvedPath);
+    inFlightTypeScriptLoads.delete(canonical);
   }
 }

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -46,6 +46,14 @@
  * up front is what let a same-named file or directory shadow an installed package and silently run
  * in its place. Core's anchor stays so Thymian's bundled rule packages keep resolving when the
  * user's project does not carry them.
+ *
+ * ONE exception, defined by what Node's resolver ANSWERS rather than by a list of names: a plain
+ * specifier `require.resolve` reports as a bare builtin id. That is the *bare-requirable* builtins
+ * only — `http`, `util`, `punycode` — and NOT the `node:`-prefix-only ones, since
+ * `require.resolve('sqlite')` throws and so resolves installed-first like any other name. For that
+ * set the installed copy is unreachable by bare specifier through Node's own resolver anyway, so a
+ * `<cwd>` DIRECTORY of the same name is allowed to win. A same-named plain FILE is not: `util.js`
+ * is an ordinary helper filename, and running it for `rules: ['util']` would be an accident.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -128,6 +136,11 @@ function isFile(candidate: string): boolean {
     // Missing, or a path whose parent is not a directory — either way, not a module.
     return false;
   }
+}
+
+/** An existing directory. Keeps the discarded-builtin-id fallback to directories — see below. */
+function isDirectory(candidate: string): boolean {
+  return statSync(candidate, { throwIfNoEntry: false })?.isDirectory() === true;
 }
 
 /**
@@ -230,6 +243,15 @@ function unloadableReason(resolvedPath: string): string | undefined {
 
   return undefined;
 }
+
+/**
+ * A resolver answer that is a plain single segment — no separator, no `:`. `require.resolve` reports
+ * a Node builtin as the bare id rather than a path, and only the PLAIN spelling of one is ambiguous
+ * enough to be worth a `<cwd>` fallback: a builtin SUBPATH (`fs/promises`) and the explicit `node:`
+ * spelling name the builtin unambiguously, so they keep their non-absolute value and are refused by
+ * the absolute-path guard at the end of {@link resolveUserModule}.
+ */
+const PLAIN_ID = /^[^/\\:]+$/;
 
 /** `./x`, `../x`, `.` or `..` — specifiers Node resolves against the importer, not `node_modules`. */
 const RELATIVE_SPECIFIER = /^\.\.?(?:[/\\]|$)/;
@@ -375,7 +397,9 @@ export interface ResolveUserModuleOptions {
    * Fall back to `<cwd>/<specifier>` when nothing is installed under that name. Default `true`.
    *
    * A *fallback*, not a preference: installed packages are resolved first, so a same-named file
-   * or directory in `cwd` can never shadow one. Governs **bare** specifiers only — relative
+   * or directory in `cwd` cannot shadow one — except that a `<cwd>` DIRECTORY may win for a
+   * bare-requirable builtin name, whose installed path Node's resolver never answers (see the file
+   * header). Governs **bare** specifiers only — relative
    * specifiers are always anchored at `cwd` regardless of this flag, being unambiguously paths.
    */
   preferCwdRelative?: boolean;
@@ -388,7 +412,8 @@ export interface ResolveUserModuleOptions {
  *
  * Resolution stops at the first hit and runs the same three-resolver chain
  * ({@link resolveLocation}) over at most two candidates: the specifier itself, and — for a bare
- * name nothing is installed under — `<cwd>/<specifier>`. Within a candidate the order is
+ * name nothing is installed under, or whose only answer was a bare builtin id — `<cwd>/<specifier>`,
+ * which for the builtin-id case must be a directory. Within a candidate the order is
  * `require.resolve`, then a `.mjs`/`.cjs` extension guess ({@link resolveThroughGuessing}), then
  * jiti's `esmResolve`. `require.resolve` already handles TypeScript with an explicit extension, so
  * the jiti step is reached for *resolution* only by extensionless and NodeNext `.js`→`.ts`
@@ -442,6 +467,26 @@ export async function resolveUserModule(
       resolveThroughGuessing(specifier) ??
       (await resolveThroughJiti(specifier, base));
 
+    // A plain non-absolute answer is not an answer. `require.resolve` reports a Node builtin as the
+    // bare id (`http`), which is truthy — so the `??` chain stopped there and the candidate below
+    // was never tried. A user whose config said `rules: ['http']`, meaning their own `<cwd>/http/`
+    // directory of rules, was told "cannot resolve http" with the directory sitting on disk.
+    //
+    // Narrow on purpose ({@link PLAIN_ID}): `fs/promises` and `node:fs` name the builtin
+    // unambiguously, so they are NOT discarded and the absolute-path guard below refuses them —
+    // which is what keeps that guard load-bearing. It also keeps `node:fs` away from
+    // `path.resolve` for the builtin `node:` names, where on Windows the joined path would be an
+    // NTFS alternate-data-stream reference. A `node:`-spelled NON-builtin (a typo, or a
+    // prefix-only name on an older runtime) is not answered as a bare id at all, so it still
+    // reaches `path.resolve`; the guarantee is about what the resolver answered, not the spelling.
+    // {@link PLAIN_ID} alone defines the discard set — the thing to look at before widening this.
+    // No `path.isAbsolute` test is needed: no absolute spelling on any platform can match it.
+    const discardedBareId = resolved !== undefined && PLAIN_ID.test(resolved);
+
+    if (discardedBareId) {
+      resolved = undefined;
+    }
+
     if (
       resolved === undefined &&
       preferCwdRelative &&
@@ -451,7 +496,18 @@ export async function resolveUserModule(
       // the user meant. Resolving the absolute path (rather than using it verbatim) keeps a
       // directory holding `index.js` or a `package.json` `main` working, which is the shape
       // today's `rule-loader` accepts for `rules: ['my-rules']`.
-      resolved = await resolveLocation(path.resolve(base, specifier), base);
+      const candidate = path.resolve(base, specifier);
+
+      // For a name reached here only by discarding a builtin id, the candidate must be a
+      // DIRECTORY. `util.js`, `os.js`, `path.js`, `events.js` are ordinary root-level helper
+      // filenames; executing one for `rules: ['util']` is an accident, where a directory named
+      // after a builtin is deliberate. Ordinary bare names keep accepting a plain file, as before.
+      // It also keeps the answer honest when the only local candidate is a non-module:
+      // `<cwd>/http.json` is not a directory, so this reports a plain "not found" rather than a
+      // `reason` about JSON support for a file the user never named.
+      if (!discardedBareId || isDirectory(candidate)) {
+        resolved = await resolveLocation(candidate, base);
+      }
     }
   }
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -65,9 +65,21 @@ const require = createRequire(import.meta.url);
  * Cwd-anchored resolvers, memoised. `resolveThroughRequire` runs for every specifier — including
  * every built-in rule on every invocation, the path the file header singles out as needing to stay
  * cheap — and `cwd` is stable within a run, so building the anchor each time was pure waste.
+ *
+ * Keyed by an **absolute** directory, which {@link resolveUserModule} guarantees by resolving its
+ * `cwd` argument once on entry. The key has to be normalised because a *relative* `cwd` is
+ * otherwise interpreted at two different times: `pathToFileURL` resolves it against
+ * `process.cwd()` when the anchor is BUILT, while every other resolver resolves it again on each
+ * CALL. After a `process.chdir` those disagree, the memo hands back an anchor pointing at the old
+ * directory, and `require.resolve` misses a package that is plainly installed — so resolution
+ * degrades to the jiti fallback and a plain-JavaScript package pays for jiti, which contract item 4
+ * forbids. Measured with `JITI_DEBUG=1`: jiti initialised on the second call and not on a control
+ * call with an absolute `cwd`. Normalising also collapses `.`, `./x/..` and the absolute spelling of
+ * one directory onto a single entry instead of one per spelling.
  */
 const cwdRequireCache = new Map<string, NodeJS.Require>();
 
+/** @param cwd An absolute directory — see {@link cwdRequireCache}. */
 function requireFrom(cwd: string): NodeJS.Require {
   let anchored = cwdRequireCache.get(cwd);
 
@@ -397,6 +409,12 @@ export async function resolveUserModule(
 ): Promise<ResolveUserModuleResult> {
   const { preferCwdRelative = true } = options;
 
+  // Normalised ONCE, here, so every resolver below and the {@link cwdRequireCache} key agree on
+  // which directory `cwd` names. A relative `cwd` is resolved against `process.cwd()` — the
+  // behaviour it already had, now stated and now consistent rather than depending on when each
+  // resolver happened to look. See {@link cwdRequireCache} for what the inconsistency cost.
+  const base = path.resolve(cwd);
+
   let resolved: string | undefined;
 
   if (RELATIVE_SPECIFIER.test(specifier)) {
@@ -406,7 +424,7 @@ export async function resolveUserModule(
     // (`./index.js` resolves core's barrel), so anchor it here instead of delegating.
     // Unconditional: `preferCwdRelative` governs bare names, and a relative specifier is
     // unambiguously a path.
-    resolved = await resolveLocation(path.resolve(cwd, specifier), cwd);
+    resolved = await resolveLocation(path.resolve(base, specifier), base);
   } else {
     // Installed packages FIRST — through all three resolvers, not just the first two. The third
     // one earns its place: a bare SUBPATH whose target is TypeScript (`my-pkg/rules`, or its
@@ -420,9 +438,9 @@ export async function resolveUserModule(
     // is what let a same-named local file or directory shadow — and silently execute in place
     // of — an installed package.
     resolved =
-      resolveThroughRequire(specifier, cwd) ??
+      resolveThroughRequire(specifier, base) ??
       resolveThroughGuessing(specifier) ??
-      (await resolveThroughJiti(specifier, cwd));
+      (await resolveThroughJiti(specifier, base));
 
     if (
       resolved === undefined &&
@@ -433,7 +451,7 @@ export async function resolveUserModule(
       // the user meant. Resolving the absolute path (rather than using it verbatim) keeps a
       // directory holding `index.js` or a `package.json` `main` working, which is the shape
       // today's `rule-loader` accepts for `rules: ['my-rules']`.
-      resolved = await resolveLocation(path.resolve(cwd, specifier), cwd);
+      resolved = await resolveLocation(path.resolve(base, specifier), base);
     }
   }
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -28,13 +28,16 @@
  *   Declining lets the caller say "cannot resolve", which is the more useful message.
  *   `.node` and `.wasm` are deliberately NOT declined: Node genuinely imports both, so a valid
  *   addon or wasm module loads through the native branch (verified).
- * Bare specifiers are resolved from the **user's project first**, then from core's own install
- * directory. A package the user named in their config is theirs, so a globally installed CLI must
- * not answer with its own copy of a colliding name; core's anchor stays as a fallback so
- * Thymian's bundled rule packages keep resolving when the user's project does not carry them.
+ * Bare specifiers resolve installed packages first — the user's project, then core's own install
+ * directory — and only fall back to `<cwd>/<specifier>` when nothing is installed under that name.
+ * Two reasons for that order: a package the user named in their config is theirs, so a globally
+ * installed CLI must not answer with its own copy of a colliding name; and preferring the cwd path
+ * up front is what let a same-named file or directory shadow an installed package and silently run
+ * in its place. Core's anchor stays so Thymian's bundled rule packages keep resolving when the
+ * user's project does not carry them.
  */
 
-import { existsSync, realpathSync, statSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -148,19 +151,6 @@ function getJiti(): Promise<Jiti> {
   return jitiInstance;
 }
 
-/** True for specifiers Node resolves against the importer rather than the `node_modules` chain. */
-function isPathLike(specifier: string): boolean {
-  return RELATIVE_SPECIFIER.test(specifier) || path.isAbsolute(specifier);
-}
-
-function isFile(candidate: string): boolean {
-  try {
-    return statSync(candidate).isFile();
-  } catch {
-    return false;
-  }
-}
-
 async function resolveThroughJiti(
   location: string,
   cwd: string,
@@ -204,11 +194,11 @@ async function resolveThroughJiti(
 
 export interface ResolveUserModuleOptions {
   /**
-   * Try `<cwd>/<specifier>` on disk before `require.resolve`. Default `true`.
+   * Fall back to `<cwd>/<specifier>` when nothing is installed under that name. Default `true`.
    *
-   * Governs **bare** specifiers only, and applies to them only when they name a *file*, so a
-   * same-named directory in `cwd` can no longer shadow an installed package. Relative specifiers
-   * are always anchored at `cwd` regardless of this flag — they are unambiguously paths.
+   * A *fallback*, not a preference: installed packages are resolved first, so a same-named file
+   * or directory in `cwd` can never shadow one. Governs **bare** specifiers only — relative
+   * specifiers are always anchored at `cwd` regardless of this flag, being unambiguously paths.
    */
   preferCwdRelative?: boolean;
 }
@@ -235,7 +225,7 @@ export async function resolveUserModule(
 ): Promise<string | undefined> {
   const { preferCwdRelative = true } = options;
 
-  let location = specifier;
+  let resolved: string | undefined;
 
   if (RELATIVE_SPECIFIER.test(specifier)) {
     // A relative specifier is relative to the USER's cwd, never to core's install directory —
@@ -244,25 +234,33 @@ export async function resolveUserModule(
     // (`./index.js` resolves core's barrel), so anchor it here instead of delegating.
     // Unconditional: `preferCwdRelative` governs bare names, and a relative specifier is
     // unambiguously a path.
-    location = path.resolve(cwd, specifier);
-  } else if (preferCwdRelative) {
-    const fileLocation = path.resolve(cwd, specifier);
+    const location = path.resolve(cwd, specifier);
 
-    // A bare specifier is only preferred when it names a file. A same-named directory in `cwd`
-    // would otherwise win and then either fail to resolve or — worse — load a decoy package's
-    // code under the name of an installed one.
+    resolved =
+      resolveThroughRequire(location, cwd) ??
+      (await resolveThroughJiti(location, cwd));
+  } else {
+    // Installed packages FIRST. Preferring `<cwd>/<specifier>` up front is what let a same-named
+    // file or directory shadow — and silently execute in place of — an installed package.
+    resolved = resolveThroughRequire(specifier, cwd);
+
     if (
-      existsSync(fileLocation) &&
-      (isPathLike(specifier) || isFile(fileLocation))
+      resolved === undefined &&
+      preferCwdRelative &&
+      !path.isAbsolute(specifier)
     ) {
-      location = fileLocation;
+      // Nothing is installed under that name, so a local file or directory of that name is what
+      // the user meant. Resolving the absolute path (rather than using it verbatim) keeps a
+      // directory holding `index.js` or a `package.json` `main` working, which is the shape
+      // today's `rule-loader` accepts for `rules: ['my-rules']`.
+      const fileLocation = path.resolve(cwd, specifier);
+
+      if (existsSync(fileLocation)) {
+        resolved = resolveThroughRequire(fileLocation, cwd);
+      }
     }
-  }
 
-  let resolved = resolveThroughRequire(location, cwd);
-
-  if (resolved === undefined) {
-    resolved = await resolveThroughJiti(location, cwd);
+    resolved ??= await resolveThroughJiti(specifier, cwd);
   }
 
   if (resolved === undefined) {

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -25,6 +25,12 @@
  * - **Only JavaScript and TypeScript are loadable**, enforced as an allow-list at resolution so
  *   the caller phrases the error. See {@link LOADABLE_EXTENSION} for why each excluded extension
  *   is excluded — including `.node`, which is not importable on the `engines.node` floor at all.
+ * - **tsconfig `paths` aliases are not honoured in a user TypeScript module.** jiti is given no
+ *   `alias` option and does not read the user's `tsconfig.json`, so a rule importing `@lib/x.js`
+ *   under `paths: { "@lib/*": [...] }` resolves and then fails at load with a raw
+ *   `MODULE_NOT_FOUND`. Nested *package* imports from the user's own `node_modules` DO work; it is
+ *   specifically the alias case. Probably the first limitation a real user writing TypeScript
+ *   rules meets, so it wants a decision rather than silence.
  * Bare specifiers resolve installed packages first — the user's project, then core's own install
  * directory — and only fall back to `<cwd>/<specifier>` when nothing is installed under that name.
  * Two reasons for that order: a package the user named in their config is theirs, so a globally
@@ -60,11 +66,29 @@ const require = createRequire(import.meta.url);
  * Only **bare** specifiers are affected: a relative one is already an absolute path by the time it
  * gets here, and both anchors resolve an absolute path identically.
  */
+/**
+ * Cwd-anchored resolvers, memoised. `resolveThroughRequire` runs for every specifier — including
+ * every built-in rule on every invocation, the path the file header singles out as needing to stay
+ * cheap — and `cwd` is stable within a run, so building the anchor each time was pure waste.
+ */
+const cwdRequireCache = new Map<string, NodeJS.Require>();
+
+function requireFrom(cwd: string): NodeJS.Require {
+  let anchored = cwdRequireCache.get(cwd);
+
+  if (anchored === undefined) {
+    anchored = createRequire(pathToFileURL(path.join(cwd, '_')));
+    cwdRequireCache.set(cwd, anchored);
+  }
+
+  return anchored;
+}
+
 function resolveThroughRequire(
   location: string,
   cwd: string,
 ): string | undefined {
-  const anchors = [createRequire(pathToFileURL(path.join(cwd, '_'))), require];
+  const anchors = [requireFrom(cwd), require];
 
   for (const anchor of anchors) {
     try {
@@ -366,6 +390,14 @@ async function importThroughJiti(
 
   // `export = <primitive>` yields the bare value, so `'default' in module` would throw a
   // `TypeError`. A non-object export can only ever have been a default.
+  //
+  // Note the boundary this draws, which is narrower than it looks: `isRecord` excludes
+  // primitives, arrays and functions, so those gain a `default` — but `export = { … }`, the
+  // natural rule-set shape, is a record and passes through unwrapped, where jiti's proxy answers
+  // `'default' in module` with `false`. That is the SAME limitation as `module.exports = { … }`
+  // documented in the file header, and for the same reason: through the proxy it is
+  // indistinguishable from a module with only named exports, so synthesising a default here
+  // would let a named-only module masquerade as a rule. Pinned by test, not left implicit.
   return isRecord(module) ? module : { default: module };
 }
 

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -22,13 +22,9 @@
  *   to a module with only named exports (`interopDefault: false` does not separate them either).
  *   Synthesising a default would let a named-only module masquerade as a rule, so this seam
  *   reports it as "no default export" rather than guessing. Tracked as epic follow-up work.
- * - **JSX and `.json` are declined at resolution.** Neither dispatch branch can load them: jiti's
- *   `jsx` option is off by default (a `.tsx` yields a bare `ParseError` with no file or line) and
- *   Node rejects `.jsx` outright, while `.json` needs an `import ... with { type: 'json' }`
- *   attribute this seam deliberately does not pass — nothing in Thymian consumes a JSON rule set.
- *   Declining lets the caller say "cannot resolve", which is the more useful message.
- *   `.node` and `.wasm` are deliberately NOT declined: Node genuinely imports both, so a valid
- *   addon or wasm module loads through the native branch (verified).
+ * - **Only JavaScript and TypeScript are loadable**, enforced as an allow-list at resolution so
+ *   the caller phrases the error. See {@link LOADABLE_EXTENSION} for why each excluded extension
+ *   is excluded — including `.node`, which is not importable on the `engines.node` floor at all.
  * Bare specifiers resolve installed packages first — the user's project, then core's own install
  * directory — and only fall back to `<cwd>/<specifier>` when nothing is installed under that name.
  * Two reasons for that order: a package the user named in their config is theirs, so a globally
@@ -85,14 +81,26 @@ function resolveThroughRequire(
 const TYPESCRIPT_EXTENSION = /\.[cm]?ts$/;
 
 /**
- * Extensions no dispatch branch can load, declined at resolution so the caller phrases the error
- * rather than surfacing a raw `ParseError`, `ERR_UNKNOWN_FILE_EXTENSION` or
- * `ERR_IMPORT_ATTRIBUTE_MISSING`. Covers the JSX family (`.jsx`/`.tsx` and their `.m`/`.c`
- * variants) and `.json` — the latter resolves without any user typo, since `.json` is in jiti's
- * default extension list. `.node` and `.wasm` are absent on purpose: Node imports both, so a
- * valid addon or wasm module must keep working.
+ * The extensions a user module may have — an ALLOW-list, because the loadable set is the closed
+ * one and the unloadable set is not. A deny-list was tried and found wanting twice: `require.resolve`
+ * answers with any existing absolute file regardless of extension, so everything unenumerated
+ * resolved and then died in the native importer with a raw error. `.yaml`, `.yml`, `.md`, `.txt`,
+ * `.toml`, `.json5` and `.jsonc` all gave `ERR_UNKNOWN_FILE_EXTENSION` unframed — the very class
+ * of error `.json` had been declined to prevent.
+ *
+ * Deliberately excluded, each for its own reason:
+ * - The JSX family (`.jsx`/`.tsx` and `.m`/`.c` variants): jiti's `jsx` option is off by default,
+ *   so a `.tsx` yields a bare `ParseError` with no file or line, and Node rejects `.jsx` outright.
+ * - `.json`: needs an `import ... with { type: 'json' }` attribute this seam does not pass, and
+ *   nothing in Thymian consumes a JSON rule set. It resolves without any user typo, since `.json`
+ *   is in jiti's own default extension list.
+ * - `.node`: NOT importable on Node 22 at all — the `engines.node` floor and in the CI matrix —
+ *   where it gives `ERR_UNKNOWN_FILE_EXTENSION`; addon imports need `--experimental-addon-modules`,
+ *   which only exists on much later versions. Measured on 22.19 and 26.7.
+ * - `.wasm`: does load on 22 and 26, but needs `--experimental-wasm-modules` on Node 20 (also in
+ *   the matrix), and a valid wasm module exports no `default`, so it cannot carry a rule anyway.
  */
-const UNSUPPORTED_EXTENSION = /\.(?:[cm]?[jt]sx|json)$/i;
+const LOADABLE_EXTENSION = /\.[cm]?[jt]s$/;
 
 /**
  * Declaration files are never loadable. Case-insensitive: on Windows and default macOS volumes a
@@ -115,8 +123,8 @@ function unloadableReason(resolvedPath: string): string | undefined {
     return 'a TypeScript declaration file contains no runtime code';
   }
 
-  if (UNSUPPORTED_EXTENSION.test(resolvedPath)) {
-    return 'no dispatch branch can load this file extension';
+  if (!LOADABLE_EXTENSION.test(resolvedPath)) {
+    return 'only JavaScript and TypeScript modules can be loaded';
   }
 
   return undefined;

--- a/packages/core/test/fixtures/user-modules/Legacy.D.ts
+++ b/packages/core/test/fixtures/user-modules/Legacy.D.ts
@@ -1,0 +1,6 @@
+// Fixture: a declaration file spelled with a capital `D`. A case-sensitive guard would miss this
+// and hand an empty module to the caller; the file name is literal so the case holds on
+// case-sensitive filesystems too.
+declare const legacyMarker: string;
+
+export default legacyMarker;

--- a/packages/core/test/fixtures/user-modules/component.jsx
+++ b/packages/core/test/fixtures/user-modules/component.jsx
@@ -1,0 +1,5 @@
+// Fixture: JSX in a `.jsx` file. Node rejects the extension outright and jiti's `jsx` option is
+// off by default, so no dispatch branch can load it — it must be declined at resolution.
+const element = <div className="thyme">hi</div>;
+
+export default element;

--- a/packages/core/test/fixtures/user-modules/component.tsx
+++ b/packages/core/test/fixtures/user-modules/component.tsx
@@ -1,0 +1,5 @@
+// Fixture: JSX. jiti's `jsx` option is off by default, so this must be declined at resolution
+// rather than dispatched to a transform that cannot parse it.
+const element = <div className="thyme">hi</div>;
+
+export default element;

--- a/packages/core/test/fixtures/user-modules/concurrent-cycle-a.ts
+++ b/packages/core/test/fixtures/user-modules/concurrent-cycle-a.ts
@@ -1,0 +1,22 @@
+// Fixture: half of a cycle entered by TWO concurrent roots — a different defect from the one
+// `cycle-a.ts` covers. There one root re-enters the loader for itself and its own evaluation chain
+// catches it. Here root A evaluates this file while root B evaluates its partner, so neither chain
+// contains the other's module, and only the wait-for graph can see the ring.
+//
+// Deliberately not reusing the `cycle-a`/`cycle-b` pair: those carry jiti registry state from
+// another test, which would make this outcome depend on test order.
+//
+// The loader arrives through `globalThis` rather than an import — see loader-under-test.ts, which
+// is the whole reason this test can fail when the fix is reverted.
+//
+// `fileURLToPath`, not `new URL(...).pathname`: see cycle-a.ts for the Windows drive-letter
+// mangling that costs.
+import { fileURLToPath } from 'node:url';
+
+import { loaderUnderTest } from './loader-under-test.js';
+
+export const partner = await loaderUnderTest()(
+  fileURLToPath(new URL('./concurrent-cycle-b.ts', import.meta.url)),
+);
+
+export default 'concurrent-cycle-a';

--- a/packages/core/test/fixtures/user-modules/concurrent-cycle-b.ts
+++ b/packages/core/test/fixtures/user-modules/concurrent-cycle-b.ts
@@ -1,0 +1,22 @@
+// Fixture: half of a cycle entered by TWO concurrent roots — a different defect from the one
+// `cycle-a.ts` covers. There one root re-enters the loader for itself and its own evaluation chain
+// catches it. Here root A evaluates this file while root B evaluates its partner, so neither chain
+// contains the other's module, and only the wait-for graph can see the ring.
+//
+// Deliberately not reusing the `cycle-a`/`cycle-b` pair: those carry jiti registry state from
+// another test, which would make this outcome depend on test order.
+//
+// The loader arrives through `globalThis` rather than an import — see loader-under-test.ts, which
+// is the whole reason this test can fail when the fix is reverted.
+//
+// `fileURLToPath`, not `new URL(...).pathname`: see cycle-a.ts for the Windows drive-letter
+// mangling that costs.
+import { fileURLToPath } from 'node:url';
+
+import { loaderUnderTest } from './loader-under-test.js';
+
+export const partner = await loaderUnderTest()(
+  fileURLToPath(new URL('./concurrent-cycle-a.ts', import.meta.url)),
+);
+
+export default 'concurrent-cycle-b';

--- a/packages/core/test/fixtures/user-modules/concurrent-dep-x.ts
+++ b/packages/core/test/fixtures/user-modules/concurrent-dep-x.ts
@@ -1,0 +1,11 @@
+// Fixture: one of two roots that both wait on `concurrent-shared.ts` — the shape that must NOT be
+// reported as a cycle. Loader via `globalThis`; see loader-under-test.ts.
+import { fileURLToPath } from 'node:url';
+
+import { loaderUnderTest } from './loader-under-test.js';
+
+export const shared = await loaderUnderTest()(
+  fileURLToPath(new URL('./concurrent-shared.ts', import.meta.url)),
+);
+
+export default 'concurrent-dep-x';

--- a/packages/core/test/fixtures/user-modules/concurrent-dep-y.ts
+++ b/packages/core/test/fixtures/user-modules/concurrent-dep-y.ts
@@ -1,0 +1,11 @@
+// Fixture: one of two roots that both wait on `concurrent-shared.ts` — the shape that must NOT be
+// reported as a cycle. Loader via `globalThis`; see loader-under-test.ts.
+import { fileURLToPath } from 'node:url';
+
+import { loaderUnderTest } from './loader-under-test.js';
+
+export const shared = await loaderUnderTest()(
+  fileURLToPath(new URL('./concurrent-shared.ts', import.meta.url)),
+);
+
+export default 'concurrent-dep-y';

--- a/packages/core/test/fixtures/user-modules/concurrent-shared.ts
+++ b/packages/core/test/fixtures/user-modules/concurrent-shared.ts
@@ -1,0 +1,10 @@
+// Fixture: a dependency two concurrent roots both wait for — the shape that must NOT be reported
+// as a cycle, and the reason cycle detection cannot simply refuse every cross-root wait. Counts its
+// own evaluations on `globalThis` (not module scope) so the test can still see the count when the
+// module is, correctly, evaluated only once.
+const globals = globalThis as { __thymianSharedEvaluations?: number };
+
+globals.__thymianSharedEvaluations =
+  (globals.__thymianSharedEvaluations ?? 0) + 1;
+
+export default { evaluations: globals.__thymianSharedEvaluations };

--- a/packages/core/test/fixtures/user-modules/cycle-a.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-a.ts
@@ -1,0 +1,9 @@
+// Fixture: re-enters the loader for its partner during its own evaluation. Left undetected this
+// awaits a promise only its own return can settle, and the process hangs.
+import { loadUserModule } from '../../../src/load-user-module.js';
+
+export const partner = await loadUserModule(
+  new URL('./cycle-b.ts', import.meta.url).pathname,
+);
+
+export default 'cycle-a';

--- a/packages/core/test/fixtures/user-modules/cycle-a.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-a.ts
@@ -9,9 +9,9 @@
 // Observed on all three windows-2022 legs of the CI matrix.
 import { fileURLToPath } from 'node:url';
 
-import { loadUserModule } from '../../../src/load-user-module.js';
+import { loaderUnderTest } from './loader-under-test.js';
 
-export const partner = await loadUserModule(
+export const partner = await loaderUnderTest()(
   fileURLToPath(new URL('./cycle-b.ts', import.meta.url)),
 );
 

--- a/packages/core/test/fixtures/user-modules/cycle-a.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-a.ts
@@ -1,9 +1,18 @@
 // Fixture: re-enters the loader for its partner during its own evaluation. Left undetected this
 // awaits a promise only its own return can settle, and the process hangs.
+//
+// `fileURLToPath`, not `new URL(...).pathname`: a URL pathname is not a filesystem path. It is
+// percent-encoded everywhere, and on Windows it carries a leading slash before the drive letter
+// (`/D:/…`) — which `path.isAbsolute` accepts, `realpathSync.native` then rejects, and
+// `canonicalise`'s `path.resolve` fallback re-anchors on the current drive as `D:\D:\…`. The
+// evaluation chain misses, jiti throws a raw MODULE_NOT_FOUND, and this fixture proves nothing.
+// Observed on all three windows-2022 legs of the CI matrix.
+import { fileURLToPath } from 'node:url';
+
 import { loadUserModule } from '../../../src/load-user-module.js';
 
 export const partner = await loadUserModule(
-  new URL('./cycle-b.ts', import.meta.url).pathname,
+  fileURLToPath(new URL('./cycle-b.ts', import.meta.url)),
 );
 
 export default 'cycle-a';

--- a/packages/core/test/fixtures/user-modules/cycle-b.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-b.ts
@@ -1,0 +1,8 @@
+// Fixture: the other half of the cycle.
+import { loadUserModule } from '../../../src/load-user-module.js';
+
+export const partner = await loadUserModule(
+  new URL('./cycle-a.ts', import.meta.url).pathname,
+);
+
+export default 'cycle-b';

--- a/packages/core/test/fixtures/user-modules/cycle-b.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-b.ts
@@ -1,8 +1,11 @@
-// Fixture: the other half of the cycle.
+// Fixture: the other half of the cycle. See cycle-a.ts for why this is `fileURLToPath` rather
+// than `new URL(...).pathname`.
+import { fileURLToPath } from 'node:url';
+
 import { loadUserModule } from '../../../src/load-user-module.js';
 
 export const partner = await loadUserModule(
-  new URL('./cycle-a.ts', import.meta.url).pathname,
+  fileURLToPath(new URL('./cycle-a.ts', import.meta.url)),
 );
 
 export default 'cycle-b';

--- a/packages/core/test/fixtures/user-modules/cycle-b.ts
+++ b/packages/core/test/fixtures/user-modules/cycle-b.ts
@@ -2,9 +2,9 @@
 // than `new URL(...).pathname`.
 import { fileURLToPath } from 'node:url';
 
-import { loadUserModule } from '../../../src/load-user-module.js';
+import { loaderUnderTest } from './loader-under-test.js';
 
-export const partner = await loadUserModule(
+export const partner = await loaderUnderTest()(
   fileURLToPath(new URL('./cycle-a.ts', import.meta.url)),
 );
 

--- a/packages/core/test/fixtures/user-modules/enum.ts
+++ b/packages/core/test/fixtures/user-modules/enum.ts
@@ -1,0 +1,7 @@
+// Fixture: non-erasable syntax. An `enum` emits a runtime object, so type stripping can never
+// support this file — it is the case that requires a real transform (jiti).
+export enum Flavour {
+  Thyme = 'thyme',
+}
+
+export default Flavour.Thyme;

--- a/packages/core/test/fixtures/user-modules/helper.ts
+++ b/packages/core/test/fixtures/user-modules/helper.ts
@@ -1,0 +1,8 @@
+// Fixture: imported by `split.ts` as `./helper.js`.
+interface Marker {
+  readonly value: string;
+}
+
+const marker: Marker = { value: 'split-ts-via-helper' };
+
+export const helperMarker = marker.value;

--- a/packages/core/test/fixtures/user-modules/js-rule-using-shared.js
+++ b/packages/core/test/fixtures/user-modules/js-rule-using-shared.js
@@ -1,0 +1,4 @@
+// Fixture: the native dispatch branch reaching the shared dependency.
+import dep from './shared-dep.js';
+
+export default { name: 'js-rule', dep };

--- a/packages/core/test/fixtures/user-modules/loader-under-test.ts
+++ b/packages/core/test/fixtures/user-modules/loader-under-test.ts
@@ -1,0 +1,27 @@
+// The loader instance the TEST is exercising, handed to fixtures through `globalThis`.
+//
+// A fixture must NOT do `import { loadUserModule } from '../../../src/load-user-module.js'`. That
+// specifier is resolved and loaded by **jiti**, whose registry is separate from the one Vitest used
+// for the test file, so the fixture receives a SECOND copy of the seam — its own in-flight map, its
+// own evaluation chain, its own wait-for graph. Measured: the two `loadUserModule` functions are not
+// `===`. Anything a fixture then proves, it proves about the copy.
+//
+// That mattered. It is why a concurrent-cycle deadlock in the real module could sit behind a green
+// cycle test, and why reverting the fix left that test green until the fixtures were switched over.
+export type UserModuleLoader = (
+  resolvedPath: string,
+) => Promise<Record<string, unknown>>;
+
+export function loaderUnderTest(): UserModuleLoader {
+  const injected = (
+    globalThis as { __thymianLoadUserModule?: UserModuleLoader }
+  ).__thymianLoadUserModule;
+
+  if (injected === undefined) {
+    throw new Error(
+      'Fixture needs globalThis.__thymianLoadUserModule set to the loadUserModule under test.',
+    );
+  }
+
+  return injected;
+}

--- a/packages/core/test/fixtures/user-modules/object-export.cts
+++ b/packages/core/test/fixtures/user-modules/object-export.cts
@@ -1,0 +1,5 @@
+// Fixture: `export =` with an OBJECT — the natural rule-set shape, and the case the wrap in
+// `importThroughJiti` deliberately does NOT cover. Through jiti's proxy this is indistinguishable
+// from a module with only named exports, so it must surface as "no default export" rather than be
+// guessed at. Its sibling `primitive.cts` covers the case that IS wrapped.
+export = { name: 'object-export' };

--- a/packages/core/test/fixtures/user-modules/plain.cts
+++ b/packages/core/test/fixtures/user-modules/plain.cts
@@ -1,0 +1,8 @@
+// Fixture: explicit CommonJS TypeScript extension.
+interface Marker {
+  readonly value: string;
+}
+
+const marker: Marker = { value: 'plain-cts' };
+
+export default marker.value;

--- a/packages/core/test/fixtures/user-modules/plain.js
+++ b/packages/core/test/fixtures/user-modules/plain.js
@@ -1,0 +1,5 @@
+// Fixture: the JavaScript path with the bare `.js` extension. Loading this must never
+// instantiate jiti (AC6).
+const marker = 'plain-js';
+
+export default marker;

--- a/packages/core/test/fixtures/user-modules/plain.js
+++ b/packages/core/test/fixtures/user-modules/plain.js
@@ -1,5 +1,5 @@
 // Fixture: the JavaScript path with the bare `.js` extension. Loading this must never
-// instantiate jiti (AC6).
+// instantiate jiti.
 const marker = 'plain-js';
 
 export default marker;

--- a/packages/core/test/fixtures/user-modules/plain.mjs
+++ b/packages/core/test/fixtures/user-modules/plain.mjs
@@ -1,0 +1,4 @@
+// Fixture: the JavaScript path. Loading this must never instantiate jiti.
+const marker = 'plain-mjs';
+
+export default marker;

--- a/packages/core/test/fixtures/user-modules/plain.mts
+++ b/packages/core/test/fixtures/user-modules/plain.mts
@@ -1,0 +1,8 @@
+// Fixture: explicit ESM TypeScript extension.
+interface Marker {
+  readonly value: string;
+}
+
+const marker: Marker = { value: 'plain-mts' };
+
+export default marker.value;

--- a/packages/core/test/fixtures/user-modules/plain.ts
+++ b/packages/core/test/fixtures/user-modules/plain.ts
@@ -1,0 +1,9 @@
+// Fixture: the ordinary TypeScript case. Interfaces and annotations are erasable syntax, so this
+// is the one shape native Node type stripping could also have handled.
+interface Marker {
+  readonly value: string;
+}
+
+const marker: Marker = { value: 'plain-ts' };
+
+export default marker.value;

--- a/packages/core/test/fixtures/user-modules/primitive.cts
+++ b/packages/core/test/fixtures/user-modules/primitive.cts
@@ -1,0 +1,3 @@
+// Fixture: `export =` with a primitive. CommonJS TypeScript can export a bare value, which has
+// no namespace to search — so a caller doing `'default' in module` needs it wrapped.
+export = 'primitive-cts';

--- a/packages/core/test/fixtures/user-modules/rules.json
+++ b/packages/core/test/fixtures/user-modules/rules.json
@@ -1,0 +1,4 @@
+{
+  "name": "json-rule-set",
+  "note": "Fixture: resolvable without any user typo, because .json is in jiti's default extension list. Must be declined at resolution rather than reaching a native import that demands an import attribute."
+}

--- a/packages/core/test/fixtures/user-modules/shared-dep.js
+++ b/packages/core/test/fixtures/user-modules/shared-dep.js
@@ -1,0 +1,7 @@
+// Fixture: a plain-JS dependency shared by a JS rule and a TS rule. Counting evaluations on a
+// global proves the two dispatch branches land in ONE module registry, not two.
+const counter = globalThis;
+
+counter.sharedDepEvaluations = (counter.sharedDepEvaluations ?? 0) + 1;
+
+export default { evaluation: counter.sharedDepEvaluations };

--- a/packages/core/test/fixtures/user-modules/side-effect.ts
+++ b/packages/core/test/fixtures/user-modules/side-effect.ts
@@ -1,0 +1,11 @@
+// Fixture: records every evaluation on a global counter, so a test can prove the module's
+// top-level body runs exactly once even when several callers load it concurrently.
+interface Counter {
+  sideEffectLoads?: number;
+}
+
+const counter: Counter = globalThis;
+
+counter.sideEffectLoads = (counter.sideEffectLoads ?? 0) + 1;
+
+export default counter.sideEffectLoads;

--- a/packages/core/test/fixtures/user-modules/split.ts
+++ b/packages/core/test/fixtures/user-modules/split.ts
@@ -1,0 +1,5 @@
+// Fixture: a multi-file module. The `./helper.js` specifier is the NodeNext convention — it
+// names the *emitted* file, while only `helper.ts` exists on disk.
+import { helperMarker } from './helper.js';
+
+export default helperMarker;

--- a/packages/core/test/fixtures/user-modules/ts-rule-using-shared.ts
+++ b/packages/core/test/fixtures/user-modules/ts-rule-using-shared.ts
@@ -1,0 +1,13 @@
+// Fixture: the jiti dispatch branch reaching the same shared dependency. Declares an interface
+// rather than annotating a literal, so the file is genuinely TypeScript without tripping
+// `no-inferrable-types`.
+import dep from './shared-dep.js';
+
+interface SharedRule {
+  name: string;
+  dep: unknown;
+}
+
+const rule: SharedRule = { name: 'ts-rule', dep };
+
+export default rule;

--- a/packages/core/test/fixtures/user-modules/types.d.ts
+++ b/packages/core/test/fixtures/user-modules/types.d.ts
@@ -1,0 +1,6 @@
+// Fixture: a declaration file. jiti resolves and imports this successfully as an *empty* module,
+// so `resolveUserModule` must decline it outright rather than let a confusing
+// "does not use default export" error reach the user.
+declare const declaredMarker: string;
+
+export default declaredMarker;

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -155,6 +155,27 @@ describe('load user module', () => {
       },
     );
 
+    it('pins the export= boundary: primitives wrap, objects do not', async () => {
+      // The wrap covers only non-records, so the boundary is narrower than it looks. Documented
+      // and pinned rather than left implicit, because the UNWRAPPED side is the natural rule-set
+      // shape and a downstream implementer would otherwise meet it as a mystery.
+      const wrapped = await loadUserModule(
+        await resolveOrFail(join(fixtures, 'primitive.cts')),
+      );
+
+      expect('default' in wrapped).toBe(true);
+
+      const unwrapped = await loadUserModule(
+        await resolveOrFail(join(fixtures, 'object-export.cts')),
+      );
+
+      // Deliberate: through jiti's proxy this shape cannot be told apart from a module with only
+      // named exports, so synthesising a default would let a named-only module pass as a rule.
+      // Callers therefore report "does not use default export" for it, which is correct.
+      expect('default' in unwrapped).toBe(false);
+      expect(unwrapped.name).toBe('object-export');
+    });
+
     it('evaluates a TypeScript module once across concurrent loads', async () => {
       const resolved = await resolveOrFail(join(fixtures, 'side-effect.ts'));
 

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -563,9 +563,218 @@ describe('load user module', () => {
     });
 
     it('returns undefined for a Node builtin specifier', async () => {
-      // `require.resolve` answers builtins with the bare id (`node:fs`), which is not an
-      // absolute path and not a loadable user module.
+      // `require.resolve` answers builtins with the bare id (`node:fs`), which is not an absolute
+      // path and not a loadable user module. Still declined after the plain-name `<cwd>` fallback
+      // (thymian-internal#687) — but now because `node:fs` is NOT a plain id, so it keeps its
+      // non-absolute value and the absolute-path guard refuses it. `node:fs` never reaches
+      // `path.resolve`; `builtin-colliding names` below covers the spellings that do.
       await expectDeclined('node:fs');
+    });
+
+    describe('builtin-colliding names', () => {
+      // `require.resolve` reports a bare-requirable builtin as the bare id, which the resolver
+      // chain read as a hit — so the `<cwd>` candidate was unreachable (thymian-internal#687).
+      // One helper, one fixture shape: duplicating setup let "same fixture, opposite verdict"
+      // pairs drift with nothing to catch it.
+      async function withFixture(
+        build: (cwd: string) => Promise<void>,
+        run: (cwd: string) => Promise<void>,
+      ): Promise<void> {
+        const cwd = await mkdtemp(join(tmpdir(), 'thymian-builtin-'));
+
+        try {
+          await build(cwd);
+          await run(cwd);
+        } finally {
+          // Never let cleanup replace a real assertion failure with an unlink error.
+          await rm(cwd, { recursive: true, force: true }).catch(
+            () => undefined,
+          );
+        }
+      }
+
+      async function writeModule(dir: string, marker: string): Promise<void> {
+        const name = basename(dir);
+
+        await mkdir(dir, { recursive: true });
+        await writeFile(
+          join(dir, 'package.json'),
+          JSON.stringify({ name, main: 'index.js', type: 'module' }),
+        );
+        await writeFile(join(dir, 'index.js'), `export default '${marker}';\n`);
+      }
+
+      it('falls back to a local directory named after a Node builtin', async () => {
+        await withFixture(
+          (cwd) => writeModule(join(cwd, 'http'), 'LOCAL'),
+          async (cwd) => {
+            const resolved = await resolveOrFail('http', cwd);
+
+            expect(resolved).toBe(
+              join(realpathSync.native(cwd), 'http', 'index.js'),
+            );
+            expect((await loadUserModule(resolved)).default).toBe('LOCAL');
+          },
+        );
+      });
+
+      it('declines a same-named plain FILE, which is an ordinary helper name', async () => {
+        // `util.js`, `os.js`, `path.js` are commonplace at a project root. Running one for
+        // `rules: ['util']` would be an accident, so only a DIRECTORY qualifies.
+        await withFixture(
+          async (cwd) => {
+            await writeFile(join(cwd, 'util.js'), "export default 'HELPER';\n");
+          },
+          async (cwd) => {
+            const declined = await expectDeclined('util', cwd);
+
+            // And no `reason`: nothing loadable was named, so this is plain "not found".
+            expect(declined.reason).toBeUndefined();
+          },
+        );
+      });
+
+      it('declines when the only local candidate is a non-module', async () => {
+        // `<cwd>/http.json` is not a directory, so it is never tried — the user gets "cannot
+        // resolve http" rather than a sentence about JSON support for a file they never named.
+        await withFixture(
+          async (cwd) => {
+            await writeFile(join(cwd, 'http.json'), '{"note":"config"}\n');
+          },
+          async (cwd) => {
+            const declined = await expectDeclined('http', cwd);
+
+            expect(declined.reason).toBeUndefined();
+          },
+        );
+      });
+
+      it('still accepts a plain FILE for an ordinary bare name', async () => {
+        // Guards against over-fixing: the directory rule applies ONLY to discarded builtin ids.
+        await withFixture(
+          async (cwd) => {
+            await writeFile(
+              join(cwd, 'myrules.js'),
+              "export default 'PLAIN';\n",
+            );
+          },
+          async (cwd) => {
+            const resolved = await resolveOrFail('myrules', cwd);
+
+            expect(resolved).toBe(join(realpathSync.native(cwd), 'myrules.js'));
+          },
+        );
+      });
+
+      it('lets a local directory win over a same-named installed package', async () => {
+        // Deliberate, and the one place installed-first bends. The installed copy is created AND
+        // asserted reachable by subpath, so this fixture cannot rot into decoration: bare `util`
+        // answers local precisely because Node answers the BUILTIN for the bare name, leaving the
+        // installed copy unreachable that way.
+        await withFixture(
+          async (cwd) => {
+            await writeModule(join(cwd, 'util'), 'LOCAL');
+            await writeModule(join(cwd, 'node_modules', 'util'), 'INSTALLED');
+          },
+          async (cwd) => {
+            const bare = await resolveOrFail('util', cwd);
+
+            expect(bare).toBe(
+              join(realpathSync.native(cwd), 'util', 'index.js'),
+            );
+            expect((await loadUserModule(bare)).default).toBe('LOCAL');
+
+            const subpath = await resolveOrFail('util/index.js', cwd);
+
+            expect(subpath).toBe(
+              join(
+                realpathSync.native(cwd),
+                'node_modules',
+                'util',
+                'index.js',
+              ),
+            );
+            expect((await loadUserModule(subpath)).default).toBe('INSTALLED');
+          },
+        );
+      });
+
+      it('honours preferCwdRelative for a builtin-colliding name, both ways', async () => {
+        // Both flag values against ONE fixture is what makes this discriminating.
+        await withFixture(
+          (cwd) => writeModule(join(cwd, 'http'), 'LOCAL'),
+          async (cwd) => {
+            const enabled = await resolveUserModule('http', cwd, {
+              preferCwdRelative: true,
+            });
+
+            expect(enabled.ok && enabled.path).toBe(
+              join(realpathSync.native(cwd), 'http', 'index.js'),
+            );
+
+            // Plugins pass `false` and never had a cwd fallback; the fix must not hand them one.
+            const declined = await expectDeclined('http', cwd, {
+              preferCwdRelative: false,
+            });
+
+            expect(declined.reason).toBeUndefined();
+          },
+        );
+      });
+
+      it.each(['fs/promises', 'inspector/promises'])(
+        'declines the builtin subpath %s even with a local candidate',
+        async (specifier) => {
+          // Not a plain id, so not discarded — the absolute-path guard refuses it. Two spellings,
+          // because the guard's only other regression test is Windows-skipped below.
+          await withFixture(
+            async (cwd) => {
+              const [dir, file] = specifier.split('/');
+
+              await mkdir(join(cwd, dir), { recursive: true });
+              await writeFile(
+                join(cwd, dir, `${file}.mjs`),
+                "export default 'LOCAL-SUBPATH';\n",
+              );
+            },
+            async (cwd) => {
+              const declined = await expectDeclined(specifier, cwd);
+
+              expect(declined.reason).toBeUndefined();
+            },
+          );
+        },
+      );
+
+      it('declines a node:-prefixed specifier even with a local candidate', async () => {
+        // `node:fs` is the explicit builtin spelling and never reaches `path.resolve`.
+        await withFixture(
+          async (cwd) => {
+            // A ':' is illegal in a Windows path component, so the candidate is unconstructible
+            // there — which is itself why the specifier can never resolve on Windows. The
+            // assertion below still runs on every platform.
+            if (process.platform !== 'win32') {
+              await writeModule(join(cwd, 'node:fs'), 'LOCAL-NODE-FS');
+            }
+          },
+          async (cwd) => {
+            await expectDeclined('node:fs', cwd);
+          },
+        );
+      });
+
+      it('declines a plain builtin name with nothing local at all', async () => {
+        // Isolated cwd on purpose: against the shared fixture root this would silently flip the
+        // day someone adds an `fs.*` fixture for an unrelated test.
+        await withFixture(
+          async () => undefined,
+          async (cwd) => {
+            const declined = await expectDeclined('fs', cwd);
+
+            expect(declined.reason).toBeUndefined();
+          },
+        );
+      });
     });
 
     it('prefers the user project node_modules over core own for a colliding name', async () => {

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -1,0 +1,225 @@
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, isAbsolute, join } from 'node:path';
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { loadUserModule, resolveUserModule } from '../src/load-user-module.js';
+
+const fixtures = join(import.meta.dirname, 'fixtures', 'user-modules');
+
+const BARE_PACKAGE = '@thymian/rules-rfc-9110';
+
+/**
+ * Resolves a specifier and asserts the contract every resolvable case shares: a defined,
+ * absolute filesystem path that is never a `file://` URL. `loadRuleSet` feeds this value
+ * straight into `path.dirname` as a glob base, so a URL leaking through here would break
+ * every rule-set glob rather than fail loudly.
+ */
+async function resolveOrFail(
+  specifier: string,
+  cwd: string = fixtures,
+): Promise<string> {
+  const resolved = await resolveUserModule(specifier, cwd);
+
+  if (resolved === undefined) {
+    throw new Error(`Expected "${specifier}" to resolve from ${cwd}.`);
+  }
+
+  expect(isAbsolute(resolved)).toBe(true);
+  expect(resolved.startsWith('file:')).toBe(false);
+  expect(existsSync(resolved)).toBe(true);
+
+  return resolved;
+}
+
+describe('load user module', () => {
+  describe('extension dispatch', () => {
+    it.each([
+      ['plain.ts', 'plain-ts'],
+      ['plain.mts', 'plain-mts'],
+      ['plain.cts', 'plain-cts'],
+      ['plain.mjs', 'plain-mjs'],
+      ['plain.js', 'plain-js'],
+    ])('resolves and loads %s', async (fileName, expected) => {
+      const resolved = await resolveOrFail(join(fixtures, fileName));
+
+      expect(basename(resolved)).toBe(fileName);
+
+      const module = await loadUserModule(resolved);
+
+      // The namespace, not the default export — `loadRules` checks `'default' in module`.
+      expect('default' in module).toBe(true);
+      expect(module.default).toBe(expected);
+    });
+
+    it('loads a module whose syntax is not erasable', async () => {
+      const resolved = await resolveOrFail(join(fixtures, 'enum.ts'));
+      const module = await loadUserModule(resolved);
+
+      // An `enum` emits a runtime object, so this is the case native Node type stripping
+      // can never support — it is why the loader carries a real transform.
+      expect(module.default).toBe('thyme');
+      expect(module.Flavour).toEqual({ Thyme: 'thyme' });
+    });
+
+    it('loads a module that imports a sibling through a NodeNext .js specifier', async () => {
+      const resolved = await resolveOrFail(join(fixtures, 'split.ts'));
+      const module = await loadUserModule(resolved);
+
+      expect(module.default).toBe('split-ts-via-helper');
+    });
+  });
+
+  describe('resolution', () => {
+    it('resolves an extensionless specifier to its .ts file', async () => {
+      // `helper`, not `plain`: the `plain.*` fixtures deliberately share a basename to cover
+      // extension dispatch, which would make an extensionless `plain` ambiguous.
+      const resolved = await resolveOrFail(join(fixtures, 'helper'));
+
+      expect(basename(resolved)).toBe('helper.ts');
+    });
+
+    it('resolves a relative NodeNext .js specifier to the .ts file on disk', async () => {
+      const resolved = await resolveOrFail('./helper.js');
+
+      expect(basename(resolved)).toBe('helper.ts');
+    });
+
+    it('resolves and loads a bare package specifier unchanged', async () => {
+      const resolved = await resolveOrFail(BARE_PACKAGE);
+      const module = await loadUserModule(resolved);
+
+      expect('default' in module).toBe(true);
+    }, 15_000);
+
+    it('declines an explicit declaration-file specifier', async () => {
+      // jiti resolves and imports a `.d.ts` successfully, as an empty module. Without the
+      // guard the user would see "does not use default export" instead of "cannot resolve".
+      await expect(
+        resolveUserModule(join(fixtures, 'types.d.ts'), fixtures),
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns undefined for an unresolvable specifier', async () => {
+      await expect(
+        resolveUserModule('@thymian/definitely-not-a-real-package', fixtures),
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns undefined for a Node builtin specifier', async () => {
+      // `require.resolve` answers builtins with the bare id (`node:fs`), which is not an
+      // absolute path and not a loadable user module.
+      await expect(
+        resolveUserModule('node:fs', fixtures),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('preferCwdRelative', () => {
+    let decoyCwd = '';
+
+    beforeAll(async () => {
+      // A same-named directory in cwd is exactly what hijacks a bare package specifier.
+      decoyCwd = await mkdtemp(join(tmpdir(), 'thymian-decoy-cwd-'));
+      await mkdir(join(decoyCwd, BARE_PACKAGE), { recursive: true });
+    });
+
+    afterAll(async () => {
+      await rm(decoyCwd, { recursive: true, force: true });
+    });
+
+    it('is hijacked by a same-named directory in cwd when left at its default', async () => {
+      await expect(
+        resolveUserModule(BARE_PACKAGE, decoyCwd),
+      ).resolves.toBeUndefined();
+    });
+
+    it('resolves the installed package when preferCwdRelative is false', async () => {
+      const resolved = await resolveUserModule(BARE_PACKAGE, decoyCwd, {
+        preferCwdRelative: false,
+      });
+
+      if (resolved === undefined) {
+        throw new Error(
+          `Expected "${BARE_PACKAGE}" to resolve from ${decoyCwd}.`,
+        );
+      }
+
+      expect(isAbsolute(resolved)).toBe(true);
+      expect(resolved.startsWith(decoyCwd)).toBe(false);
+      expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
+    }, 15_000);
+  });
+
+  describe('lazy jiti import', () => {
+    let jitiFactoryCalls = 0;
+
+    beforeEach(() => {
+      jitiFactoryCalls = 0;
+      // The jiti instance is memoised in a module-level variable, so the module registry has
+      // to be reset around each assertion — a stale memo is the most likely way the
+      // "never imported" case passes for the wrong reason.
+      vi.resetModules();
+      vi.doMock('jiti', async () => {
+        jitiFactoryCalls += 1;
+
+        return await vi.importActual<typeof import('jiti')>('jiti');
+      });
+    });
+
+    afterEach(() => {
+      vi.doUnmock('jiti');
+      vi.resetModules();
+    });
+
+    it('never imports jiti on the JavaScript path', async () => {
+      const loader = await import('../src/load-user-module.js');
+
+      for (const specifier of [
+        BARE_PACKAGE,
+        join(fixtures, 'plain.mjs'),
+        join(fixtures, 'plain.js'),
+      ]) {
+        const resolved = await loader.resolveUserModule(specifier, fixtures);
+
+        if (resolved === undefined) {
+          throw new Error(`Expected "${specifier}" to resolve.`);
+        }
+
+        await loader.loadUserModule(resolved);
+      }
+
+      expect(jitiFactoryCalls).toBe(0);
+    }, 15_000);
+
+    it('imports jiti exactly once across two TypeScript loads', async () => {
+      const loader = await import('../src/load-user-module.js');
+
+      for (const fileName of ['plain.ts', 'plain.mts']) {
+        const resolved = await loader.resolveUserModule(
+          join(fixtures, fileName),
+          fixtures,
+        );
+
+        if (resolved === undefined) {
+          throw new Error(`Expected "${fileName}" to resolve.`);
+        }
+
+        await loader.loadUserModule(resolved);
+      }
+
+      expect(jitiFactoryCalls).toBe(1);
+    });
+  });
+});

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -125,10 +125,18 @@ describe('load user module', () => {
 
     it('reports an import cycle instead of hanging', async () => {
       // Undetected this never settles — Node exits 13, "Detected unsettled top-level await".
+      //
+      // The MESSAGE is asserted, not just the error name. `unloadableReason` throws
+      // `UserModuleLoadError` too, so a name-only check also passes for a fixture that merely
+      // failed to load — which is how a `new URL(…).pathname` in the fixtures stayed invisible
+      // here while turning this into a raw MODULE_NOT_FOUND on all three windows-2022 legs.
       await expect(
         loadUserModule(join(fixtures, 'cycle-a.ts')),
       ).rejects.toThrowError(
-        expect.objectContaining({ name: 'UserModuleLoadError' }),
+        expect.objectContaining({
+          name: 'UserModuleLoadError',
+          message: expect.stringContaining('import cycle'),
+        }),
       );
     }, 15_000);
 

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -37,17 +37,42 @@ async function resolveOrFail(
   specifier: string,
   cwd: string = fixtures,
 ): Promise<string> {
-  const resolved = await resolveUserModule(specifier, cwd);
+  const result = await resolveUserModule(specifier, cwd);
 
-  if (resolved === undefined) {
-    throw new Error(`Expected "${specifier}" to resolve from ${cwd}.`);
+  if (!result.ok) {
+    throw new Error(
+      `Expected "${specifier}" to resolve from ${cwd}` +
+        (result.reason === undefined ? '.' : `, but: ${result.reason}.`),
+    );
   }
 
-  expect(isAbsolute(resolved)).toBe(true);
-  expect(resolved.startsWith('file:')).toBe(false);
-  expect(existsSync(resolved)).toBe(true);
+  expect(isAbsolute(result.path)).toBe(true);
+  expect(result.path.startsWith('file:')).toBe(false);
+  expect(existsSync(result.path)).toBe(true);
 
-  return resolved;
+  return result.path;
+}
+
+/**
+ * Asserts a specifier is declined, and hands back the failure so a caller can go on to assert the
+ * REASON. Kept separate from `resolveOrFail` because the two halves of the discriminated result
+ * are the thing under test: a bare `toBeUndefined()` could not tell "no such file" apart from
+ * "exists but unloadable", which is exactly the conflation the result type exists to end.
+ */
+async function expectDeclined(
+  specifier: string,
+  cwd: string = fixtures,
+  options?: Parameters<typeof resolveUserModule>[2],
+): Promise<{ readonly ok: false; readonly reason?: string }> {
+  const result = await resolveUserModule(specifier, cwd, options);
+
+  if (result.ok) {
+    throw new Error(
+      `Expected "${specifier}" to be declined from ${cwd}, got ${result.path}.`,
+    );
+  }
+
+  return result;
 }
 
 describe('load user module', () => {
@@ -259,22 +284,24 @@ describe('load user module', () => {
     it('declines an explicit declaration-file specifier', async () => {
       // jiti resolves and imports a `.d.ts` successfully, as an empty module. Without the
       // guard the user would see "does not use default export" instead of "cannot resolve".
-      await expect(
-        resolveUserModule(join(fixtures, 'types.d.ts'), fixtures),
-      ).resolves.toBeUndefined();
+      const declined = await expectDeclined(join(fixtures, 'types.d.ts'));
+
+      expect(declined.reason).toBe(
+        'a TypeScript declaration file contains no runtime code',
+      );
     });
 
     it('declines a declaration file whose extension is not lower-case', async () => {
       // `Legacy.D.ts` is literal on disk, so this holds on case-sensitive volumes too.
-      await expect(
-        resolveUserModule(join(fixtures, 'Legacy.D.ts'), fixtures),
-      ).resolves.toBeUndefined();
+      await expectDeclined(join(fixtures, 'Legacy.D.ts'));
     });
 
     it('declines a .tsx specifier rather than handing it to a transform that cannot parse it', async () => {
-      await expect(
-        resolveUserModule(join(fixtures, 'component.tsx'), fixtures),
-      ).resolves.toBeUndefined();
+      const declined = await expectDeclined(join(fixtures, 'component.tsx'));
+
+      expect(declined.reason).toBe(
+        'only JavaScript and TypeScript modules can be loaded',
+      );
     });
 
     it.each([
@@ -283,9 +310,7 @@ describe('load user module', () => {
     ])(
       'declines %s, which no dispatch branch can load',
       async (_label, fileName) => {
-        await expect(
-          resolveUserModule(join(fixtures, fileName), fixtures),
-        ).resolves.toBeUndefined();
+        await expectDeclined(join(fixtures, fileName));
       },
     );
 
@@ -415,10 +440,14 @@ describe('load user module', () => {
         }
 
         for (const name of declined) {
-          await expect(
-            resolveUserModule(`./${name}`, cwd),
-            `expected ./${name} to be declined`,
-          ).resolves.toBeUndefined();
+          const declined = await expectDeclined(`./${name}`, cwd);
+
+          // The REASON, not just the decline: this is the sentence the caller phrases its error
+          // with, and returning it is the whole point of the discriminated result.
+          expect(
+            declined.reason,
+            `expected ./${name} to be declined with a reason`,
+          ).toBe('only JavaScript and TypeScript modules can be loaded');
         }
 
         // The allow-list itself still admits every loadable shape.
@@ -428,7 +457,7 @@ describe('load user module', () => {
           await expect(
             resolveUserModule(`./${name}`, cwd),
             `expected ./${name} to resolve`,
-          ).resolves.toBeDefined();
+          ).resolves.toMatchObject({ ok: true });
         }
       } finally {
         await rm(cwd, { recursive: true, force: true });
@@ -452,17 +481,19 @@ describe('load user module', () => {
     );
 
     it('returns undefined for an unresolvable specifier', async () => {
-      await expect(
-        resolveUserModule('@thymian/definitely-not-a-real-package', fixtures),
-      ).resolves.toBeUndefined();
+      const declined = await expectDeclined(
+        '@thymian/definitely-not-a-real-package',
+      );
+
+      // No reason: nothing is known beyond "not found", and the caller's own
+      // "cannot resolve <specifier>" is the right sentence for that.
+      expect(declined.reason).toBeUndefined();
     });
 
     it('returns undefined for a Node builtin specifier', async () => {
       // `require.resolve` answers builtins with the bare id (`node:fs`), which is not an
       // absolute path and not a loadable user module.
-      await expect(
-        resolveUserModule('node:fs', fixtures),
-      ).resolves.toBeUndefined();
+      await expectDeclined('node:fs');
     });
 
     it('prefers the user project node_modules over core own for a colliding name', async () => {
@@ -513,9 +544,7 @@ describe('load user module', () => {
           './thymian.js',
           '../src/utils.ts',
         ]) {
-          await expect(
-            resolveUserModule(specifier, emptyCwd),
-          ).resolves.toBeUndefined();
+          await expectDeclined(specifier, emptyCwd);
         }
       } finally {
         await rm(emptyCwd, { recursive: true, force: true });
@@ -619,30 +648,28 @@ describe('load user module', () => {
       // The observable difference the flag makes: with the fallback off, a local-only rule
       // directory is not resolvable at all. Nothing else in the suite distinguishes the flag,
       // so without this test the option can be deleted with the suite still green.
-      await expect(
-        resolveUserModule('my-rules', decoyCwd, { preferCwdRelative: false }),
-      ).resolves.toBeUndefined();
+      await expectDeclined('my-rules', decoyCwd, { preferCwdRelative: false });
 
       await expect(
         resolveUserModule('my-rules', decoyCwd, { preferCwdRelative: true }),
-      ).resolves.toBeDefined();
+      ).resolves.toMatchObject({ ok: true });
     });
 
     it('resolves an installed package identically with the fallback off', async () => {
-      const resolved = await resolveUserModule(BARE_PACKAGE, decoyCwd, {
+      const result = await resolveUserModule(BARE_PACKAGE, decoyCwd, {
         preferCwdRelative: false,
       });
 
-      if (resolved === undefined) {
+      if (!result.ok) {
         throw new Error(
           `Expected "${BARE_PACKAGE}" to resolve from ${decoyCwd}.`,
         );
       }
 
-      expect(isAbsolute(resolved)).toBe(true);
-      expect(resolved.startsWith('file:')).toBe(false);
-      expect(resolved.startsWith(decoyCwd)).toBe(false);
-      expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
+      expect(isAbsolute(result.path)).toBe(true);
+      expect(result.path.startsWith('file:')).toBe(false);
+      expect(result.path.startsWith(decoyCwd)).toBe(false);
+      expect(result.path).toContain(join('rules-rfc-9110', 'dist'));
     }, 15_000);
   });
 
@@ -680,12 +707,16 @@ describe('load user module', () => {
       });
 
       const loader = await import('../src/load-user-module.js');
-      const resolved = await loader.resolveUserModule(
+      const result = await loader.resolveUserModule(
         join(fixtures, 'plain.ts'),
         fixtures,
       );
 
-      await loader.loadUserModule(String(resolved));
+      if (!result.ok) {
+        throw new Error('Expected the TypeScript fixture to resolve.');
+      }
+
+      await loader.loadUserModule(result.path);
 
       expect(captured).toMatchObject({ extensions: ['.ts', '.mts', '.cts'] });
     });
@@ -720,13 +751,13 @@ describe('load user module', () => {
         join(fixtures, 'plain.mjs'),
         join(fixtures, 'plain.js'),
       ]) {
-        const resolved = await loader.resolveUserModule(specifier, fixtures);
+        const result = await loader.resolveUserModule(specifier, fixtures);
 
-        if (resolved === undefined) {
+        if (!result.ok) {
           throw new Error(`Expected "${specifier}" to resolve.`);
         }
 
-        await loader.loadUserModule(resolved);
+        await loader.loadUserModule(result.path);
       }
 
       // A bare JS package installed ONLY in the user's project. This is the case that used to
@@ -749,16 +780,16 @@ describe('load user module', () => {
         );
         await writeFile(join(pkg, 'index.js'), "export default 'user-js';\n");
 
-        const resolved = await loader.resolveUserModule(
+        const result = await loader.resolveUserModule(
           'user-js-rules',
           userProject,
         );
 
-        if (resolved === undefined) {
+        if (!result.ok) {
           throw new Error('Expected "user-js-rules" to resolve.');
         }
 
-        await loader.loadUserModule(resolved);
+        await loader.loadUserModule(result.path);
       } finally {
         await rm(userProject, { recursive: true, force: true });
       }
@@ -770,16 +801,16 @@ describe('load user module', () => {
       const loader = await import('../src/load-user-module.js');
 
       for (const fileName of ['plain.ts', 'plain.mts']) {
-        const resolved = await loader.resolveUserModule(
+        const result = await loader.resolveUserModule(
           join(fixtures, fileName),
           fixtures,
         );
 
-        if (resolved === undefined) {
+        if (!result.ok) {
           throw new Error(`Expected "${fileName}" to resolve.`);
         }
 
-        await loader.loadUserModule(resolved);
+        await loader.loadUserModule(result.path);
       }
 
       expect(jitiFactoryCalls).toBe(1);
@@ -804,25 +835,25 @@ describe('load user module', () => {
       // "simulated broken jiti install" surfacing from a *resolution* attempt would replace it.
       await expect(
         broken.resolveUserModule(join(fixtures, 'helper'), fixtures),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ ok: false });
 
-      // Still undefined, not a cached rejection escaping as a throw.
+      // Still a plain decline, not a cached rejection escaping as a throw.
       await expect(
         broken.resolveUserModule(join(fixtures, 'helper'), fixtures),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ ok: false });
 
       // A rejected first import must not be memoised: once jiti works, resolution works.
       vi.doUnmock('jiti');
       vi.resetModules();
 
       const repaired = await import('../src/load-user-module.js');
-      const resolved = await repaired.resolveUserModule(
+      const result = await repaired.resolveUserModule(
         join(fixtures, 'helper'),
         fixtures,
       );
 
-      expect(resolved).toBeDefined();
-      expect(basename(String(resolved))).toBe('helper.ts');
+      expect(result.ok).toBe(true);
+      expect(basename(result.ok ? result.path : '')).toBe('helper.ts');
     });
 
     it.each([
@@ -848,7 +879,7 @@ describe('load user module', () => {
         // shortest route into the jiti fallback where these three guards live.
         await expect(
           loader.resolveUserModule(join(fixtures, 'helper'), fixtures),
-        ).resolves.toBeUndefined();
+        ).resolves.toEqual({ ok: false });
       },
     );
   });

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -223,6 +223,42 @@ describe('load user module', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('prefers the user project node_modules over core own for a colliding name', async () => {
+      // `graphology` is a real dependency of core, so before the two-anchor cascade the CLI's own
+      // copy won and the user's pinned one was unreachable. A package the user named in their
+      // config is theirs.
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-user-project-'),
+      );
+
+      try {
+        const pkg = join(userProject, 'node_modules', 'graphology');
+
+        await mkdir(pkg, { recursive: true });
+        await writeFile(
+          join(pkg, 'package.json'),
+          JSON.stringify({
+            name: 'graphology',
+            main: 'index.js',
+            type: 'module',
+          }),
+        );
+        await writeFile(join(pkg, 'index.js'), "export default 'USER-COPY';\n");
+
+        const resolved = await resolveOrFail('graphology', userProject);
+
+        expect(resolved.startsWith(realpathSync.native(userProject))).toBe(
+          true,
+        );
+
+        const module = await loadUserModule(resolved);
+
+        expect(module.default).toBe('USER-COPY');
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    });
+
     it('never resolves a relative specifier against core own directory', async () => {
       // `require` is anchored to core's install directory. A relative specifier absent from the
       // user's cwd must come back unresolved, never as one of Thymian's own modules.
@@ -358,6 +394,40 @@ describe('load user module', () => {
         }
 
         await loader.loadUserModule(resolved);
+      }
+
+      // A bare JS package installed ONLY in the user's project. This is the case that used to
+      // miss core's anchor and fall through to the jiti fallback, so a plain-JavaScript rule
+      // package paid for jiti — the assertion below passed before only because every other
+      // fixture happened to be reachable from core's own tree.
+      const userProject = await mkdtemp(join(tmpdir(), 'thymian-user-js-'));
+
+      try {
+        const pkg = join(userProject, 'node_modules', 'user-js-rules');
+
+        await mkdir(pkg, { recursive: true });
+        await writeFile(
+          join(pkg, 'package.json'),
+          JSON.stringify({
+            name: 'user-js-rules',
+            main: 'index.js',
+            type: 'module',
+          }),
+        );
+        await writeFile(join(pkg, 'index.js'), "export default 'user-js';\n");
+
+        const resolved = await loader.resolveUserModule(
+          'user-js-rules',
+          userProject,
+        );
+
+        if (resolved === undefined) {
+          throw new Error('Expected "user-js-rules" to resolve.');
+        }
+
+        await loader.loadUserModule(resolved);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
       }
 
       expect(jitiFactoryCalls).toBe(0);

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -327,9 +327,7 @@ describe('load user module', () => {
         await mkdtemp(join(tmpdir(), 'thymian-decoy-cwd-')),
       );
 
-      // A *loadable* decoy: a same-named directory in cwd that resolves as a real package. This
-      // is the dangerous shape — left unguarded it runs the decoy's code under the name of the
-      // installed package.
+      // A *loadable* decoy directory named after an installed package.
       const decoyPackage = join(decoyCwd, BARE_PACKAGE);
 
       await mkdir(decoyPackage, { recursive: true });
@@ -339,15 +337,33 @@ describe('load user module', () => {
       );
       await writeFile(
         join(decoyPackage, 'index.js'),
-        "export default 'DECOY';\n",
+        "export default 'DECOY-DIR';\n",
       );
 
-      // A bare *subpath* specifier that names a real file in cwd. The cwd preference must still
-      // apply here, or `rules: ['my-rules/index.js']` would regress.
+      // A decoy *file* named after a package core really depends on. Extensionless, so
+      // `existsSync` sees it — this is the shape a file-vs-directory gate cannot catch.
+      await writeFile(
+        join(decoyCwd, 'graphology'),
+        "export default 'DECOY-FILE';\n",
+      );
+
+      // A local rule *directory* with no installed package of that name: the legitimate case
+      // that must keep resolving, because today's `rule-loader` resolves it.
       await mkdir(join(decoyCwd, 'my-rules'), { recursive: true });
       await writeFile(
         join(decoyCwd, 'my-rules', 'index.js'),
-        "export default 'local-subpath';\n",
+        "export default 'local-dir';\n",
+      );
+
+      // Same, via `package.json` `main` rather than `index.js`.
+      await mkdir(join(decoyCwd, 'pkg-rules'), { recursive: true });
+      await writeFile(
+        join(decoyCwd, 'pkg-rules', 'package.json'),
+        JSON.stringify({ name: 'pkg-rules', main: 'main.js' }),
+      );
+      await writeFile(
+        join(decoyCwd, 'pkg-rules', 'main.js'),
+        "export default 'local-main';\n",
       );
     });
 
@@ -355,28 +371,58 @@ describe('load user module', () => {
       await rm(decoyCwd, { recursive: true, force: true });
     });
 
-    it('does not let a loadable same-named directory in cwd shadow an installed package', async () => {
-      const resolved = await resolveOrFail(BARE_PACKAGE, decoyCwd);
+    it.each([
+      ['a directory decoy', BARE_PACKAGE, 'DECOY-DIR'],
+      ['an extensionless file decoy', 'graphology', 'DECOY-FILE'],
+    ])(
+      'does not let %s in cwd shadow an installed package',
+      async (_label, specifier, decoyMarker) => {
+        // Installed-first ordering is what stops this. A file-vs-directory gate cannot: the
+        // file decoy is indistinguishable from a legitimate local module by shape alone.
+        const resolved = await resolveOrFail(specifier, decoyCwd);
 
-      expect(resolved.startsWith(decoyCwd)).toBe(false);
-      expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
+        expect(resolved.startsWith(decoyCwd)).toBe(false);
 
-      const module = await loadUserModule(resolved);
+        const module = await loadUserModule(resolved);
 
-      expect(module.default).not.toBe('DECOY');
-    }, 15_000);
+        expect(module.default).not.toBe(decoyMarker);
+      },
+      15_000,
+    );
 
-    it('still prefers a cwd-relative file named by a bare subpath specifier', async () => {
-      const resolved = await resolveOrFail('my-rules/index.js', decoyCwd);
+    it.each([
+      ['a directory holding index.js', 'my-rules', 'local-dir'],
+      ['a directory with a package.json main', 'pkg-rules', 'local-main'],
+      ['a bare subpath naming a file', 'my-rules/index.js', 'local-dir'],
+    ])(
+      'falls back to %s when nothing is installed under that name',
+      async (_label, specifier, expected) => {
+        // `rules: ['my-rules']` resolves through today's `rule-loader`, so the seam must accept
+        // it too. An `isFile()` gate on the cwd step broke exactly this.
+        const resolved = await resolveOrFail(specifier, decoyCwd);
 
-      expect(resolved.startsWith(decoyCwd)).toBe(true);
+        expect(resolved.startsWith(decoyCwd)).toBe(true);
 
-      const module = await loadUserModule(resolved);
+        const module = await loadUserModule(resolved);
 
-      expect(module.default).toBe('local-subpath');
+        expect(module.default).toBe(expected);
+      },
+    );
+
+    it('skips the cwd fallback entirely when preferCwdRelative is false', async () => {
+      // The observable difference the flag makes: with the fallback off, a local-only rule
+      // directory is not resolvable at all. Nothing else in the suite distinguishes the flag,
+      // so without this test the option can be deleted with the suite still green.
+      await expect(
+        resolveUserModule('my-rules', decoyCwd, { preferCwdRelative: false }),
+      ).resolves.toBeUndefined();
+
+      await expect(
+        resolveUserModule('my-rules', decoyCwd, { preferCwdRelative: true }),
+      ).resolves.toBeDefined();
     });
 
-    it('resolves the installed package when preferCwdRelative is false', async () => {
+    it('resolves an installed package identically with the fallback off', async () => {
       const resolved = await resolveUserModule(BARE_PACKAGE, decoyCwd, {
         preferCwdRelative: false,
       });

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, realpathSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, isAbsolute, join } from 'node:path';
 
@@ -19,6 +19,13 @@ import { loadUserModule, resolveUserModule } from '../src/load-user-module.js';
 const fixtures = join(import.meta.dirname, 'fixtures', 'user-modules');
 
 const BARE_PACKAGE = '@thymian/rules-rfc-9110';
+
+/**
+ * True when the filesystem under the fixtures is case-insensitive (default macOS, Windows). The
+ * casing-normalisation behaviour can only be observed there — on a case-sensitive volume a
+ * mis-cased specifier simply does not exist.
+ */
+const CASE_INSENSITIVE_FS = existsSync(join(fixtures, 'PLAIN.TS'));
 
 /**
  * Resolves a specifier and asserts the contract every resolvable case shares: a defined,
@@ -79,6 +86,30 @@ describe('load user module', () => {
 
       expect(module.default).toBe('split-ts-via-helper');
     });
+
+    it('wraps a non-object `export =` so the missing-default check cannot throw', async () => {
+      const resolved = await resolveOrFail(join(fixtures, 'primitive.cts'));
+      const module = await loadUserModule(resolved);
+
+      // Without the wrap this is the bare string, and `'default' in module` throws
+      // "Cannot use 'in' operator to search for 'default' in primitive-cts".
+      expect(() => 'default' in module).not.toThrow();
+      expect('default' in module).toBe(true);
+      expect(module.default).toBe('primitive-cts');
+    });
+
+    it('evaluates a TypeScript module once across concurrent loads', async () => {
+      const resolved = await resolveOrFail(join(fixtures, 'side-effect.ts'));
+
+      // jiti populates its cache only once a load *completes*, so without in-flight
+      // de-duplication four concurrent loads evaluate the module four times and hand back
+      // four distinct namespaces.
+      const modules = await Promise.all(
+        [1, 2, 3, 4].map(() => loadUserModule(resolved)),
+      );
+
+      expect(modules.map((module) => module.default)).toEqual([1, 1, 1, 1]);
+    });
   });
 
   describe('resolution', () => {
@@ -111,6 +142,35 @@ describe('load user module', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('declines a declaration file whose extension is not lower-case', async () => {
+      // `Legacy.D.ts` is literal on disk, so this holds on case-sensitive volumes too.
+      await expect(
+        resolveUserModule(join(fixtures, 'Legacy.D.ts'), fixtures),
+      ).resolves.toBeUndefined();
+    });
+
+    it('declines a .tsx specifier rather than handing it to a transform that cannot parse it', async () => {
+      await expect(
+        resolveUserModule(join(fixtures, 'component.tsx'), fixtures),
+      ).resolves.toBeUndefined();
+    });
+
+    it.skipIf(!CASE_INSENSITIVE_FS)(
+      'normalises a mis-cased TypeScript specifier to its on-disk casing',
+      async () => {
+        // Both resolvers echo the caller's spelling, so without normalisation this reaches the
+        // dispatch as `.TS`, matches no branch, and dies with ERR_UNKNOWN_FILE_EXTENSION —
+        // on two of the three CI platforms but not on ubuntu.
+        const resolved = await resolveOrFail(join(fixtures, 'PLAIN.TS'));
+
+        expect(basename(resolved)).toBe('plain.ts');
+
+        const module = await loadUserModule(resolved);
+
+        expect(module.default).toBe('plain-ts');
+      },
+    );
+
     it('returns undefined for an unresolvable specifier', async () => {
       await expect(
         resolveUserModule('@thymian/definitely-not-a-real-package', fixtures),
@@ -124,25 +184,86 @@ describe('load user module', () => {
         resolveUserModule('node:fs', fixtures),
       ).resolves.toBeUndefined();
     });
+
+    it('never resolves a relative specifier against core own directory', async () => {
+      // `require` is anchored to core's install directory. A relative specifier absent from the
+      // user's cwd must come back unresolved, never as one of Thymian's own modules.
+      const emptyCwd = await mkdtemp(join(tmpdir(), 'thymian-empty-cwd-'));
+
+      try {
+        for (const specifier of [
+          './index.js',
+          './utils.js',
+          './thymian.js',
+          '../src/utils.ts',
+        ]) {
+          await expect(
+            resolveUserModule(specifier, emptyCwd),
+          ).resolves.toBeUndefined();
+        }
+      } finally {
+        await rm(emptyCwd, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('preferCwdRelative', () => {
     let decoyCwd = '';
 
     beforeAll(async () => {
-      // A same-named directory in cwd is exactly what hijacks a bare package specifier.
-      decoyCwd = await mkdtemp(join(tmpdir(), 'thymian-decoy-cwd-'));
-      await mkdir(join(decoyCwd, BARE_PACKAGE), { recursive: true });
+      // `tmpdir()` is a symlink on macOS (`/var` -> `/private/var`) and resolved paths are
+      // realpathed, so the base has to be realpathed too for `startsWith` to mean anything.
+      decoyCwd = realpathSync.native(
+        await mkdtemp(join(tmpdir(), 'thymian-decoy-cwd-')),
+      );
+
+      // A *loadable* decoy: a same-named directory in cwd that resolves as a real package. This
+      // is the dangerous shape — left unguarded it runs the decoy's code under the name of the
+      // installed package.
+      const decoyPackage = join(decoyCwd, BARE_PACKAGE);
+
+      await mkdir(decoyPackage, { recursive: true });
+      await writeFile(
+        join(decoyPackage, 'package.json'),
+        JSON.stringify({ name: BARE_PACKAGE, main: 'index.js' }),
+      );
+      await writeFile(
+        join(decoyPackage, 'index.js'),
+        "export default 'DECOY';\n",
+      );
+
+      // A bare *subpath* specifier that names a real file in cwd. The cwd preference must still
+      // apply here, or `rules: ['my-rules/index.js']` would regress.
+      await mkdir(join(decoyCwd, 'my-rules'), { recursive: true });
+      await writeFile(
+        join(decoyCwd, 'my-rules', 'index.js'),
+        "export default 'local-subpath';\n",
+      );
     });
 
     afterAll(async () => {
       await rm(decoyCwd, { recursive: true, force: true });
     });
 
-    it('is hijacked by a same-named directory in cwd when left at its default', async () => {
-      await expect(
-        resolveUserModule(BARE_PACKAGE, decoyCwd),
-      ).resolves.toBeUndefined();
+    it('does not let a loadable same-named directory in cwd shadow an installed package', async () => {
+      const resolved = await resolveOrFail(BARE_PACKAGE, decoyCwd);
+
+      expect(resolved.startsWith(decoyCwd)).toBe(false);
+      expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
+
+      const module = await loadUserModule(resolved);
+
+      expect(module.default).not.toBe('DECOY');
+    }, 15_000);
+
+    it('still prefers a cwd-relative file named by a bare subpath specifier', async () => {
+      const resolved = await resolveOrFail('my-rules/index.js', decoyCwd);
+
+      expect(resolved.startsWith(decoyCwd)).toBe(true);
+
+      const module = await loadUserModule(resolved);
+
+      expect(module.default).toBe('local-subpath');
     });
 
     it('resolves the installed package when preferCwdRelative is false', async () => {
@@ -157,6 +278,7 @@ describe('load user module', () => {
       }
 
       expect(isAbsolute(resolved)).toBe(true);
+      expect(resolved.startsWith('file:')).toBe(false);
       expect(resolved.startsWith(decoyCwd)).toBe(false);
       expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
     }, 15_000);
@@ -221,5 +343,72 @@ describe('load user module', () => {
 
       expect(jitiFactoryCalls).toBe(1);
     });
+  });
+
+  describe('when jiti is unavailable or misbehaving', () => {
+    afterEach(() => {
+      vi.doUnmock('jiti');
+      vi.resetModules();
+    });
+
+    it('returns undefined instead of throwing, and does not poison later loads', async () => {
+      vi.resetModules();
+      vi.doMock('jiti', () => {
+        throw new Error('simulated broken jiti install');
+      });
+
+      const broken = await import('../src/load-user-module.js');
+
+      // Resolution must stay silent: the caller owns the user-facing message, and a raw
+      // "simulated broken jiti install" surfacing from a *resolution* attempt would replace it.
+      await expect(
+        broken.resolveUserModule(join(fixtures, 'helper'), fixtures),
+      ).resolves.toBeUndefined();
+
+      // Still undefined, not a cached rejection escaping as a throw.
+      await expect(
+        broken.resolveUserModule(join(fixtures, 'helper'), fixtures),
+      ).resolves.toBeUndefined();
+
+      // A rejected first import must not be memoised: once jiti works, resolution works.
+      vi.doUnmock('jiti');
+      vi.resetModules();
+
+      const repaired = await import('../src/load-user-module.js');
+      const resolved = await repaired.resolveUserModule(
+        join(fixtures, 'helper'),
+        fixtures,
+      );
+
+      expect(resolved).toBeDefined();
+      expect(basename(String(resolved))).toBe('helper.ts');
+    });
+
+    it.each([
+      ['a specifier jiti cannot resolve', undefined],
+      ['a non-file URL', 'https://example.test/rule.ts'],
+      ['a file URL for a path that does not exist', 'file:///nope/missing.ts'],
+    ])(
+      'declines %s from the jiti fallback',
+      async (_label, esmResolveResult) => {
+        vi.resetModules();
+        vi.doMock('jiti', () => ({
+          createJiti: () => ({
+            esmResolve: () => esmResolveResult,
+            import: () => {
+              throw new Error('should never be reached');
+            },
+          }),
+        }));
+
+        const loader = await import('../src/load-user-module.js');
+
+        // An extensionless specifier misses `existsSync` and `require.resolve`, so it is the
+        // shortest route into the jiti fallback where these three guards live.
+        await expect(
+          loader.resolveUserModule(join(fixtures, 'helper'), fixtures),
+        ).resolves.toBeUndefined();
+      },
+    );
   });
 });

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -281,6 +281,106 @@ describe('load user module', () => {
       },
     );
 
+    describe('extensionless .mjs and .cjs', () => {
+      // Narrowing jiti's `extensions` to TypeScript also narrows what it GUESSES with: jiti
+      // derives `additionalExts` from `extensions` by dropping only `.js`, so `.mjs` and `.cjs`
+      // leave the guessing list along with the registry. Node's CJS resolver inside
+      // `require.resolve` never tried them either (`.js`, `.json`, `.node` only), which left a
+      // hole between the two resolvers — measured against jiti 2.6.1: extensionless `./a` with
+      // `a.mjs` on disk resolved with the default list and returned `undefined` with the narrowed
+      // one. `resolveThroughGuessing` fills it, and these pin both the hole and its ordering.
+      let cwd: string;
+
+      beforeAll(async () => {
+        cwd = await mkdtemp(join(tmpdir(), 'thymian-guess-'));
+
+        await writeFile(join(cwd, 'only-mjs.mjs'), 'export default "mjs";\n');
+        await writeFile(join(cwd, 'only-cjs.cjs'), 'module.exports = "cjs";\n');
+
+        // Precedence fixtures: each basename exists in two spellings at once.
+        await writeFile(join(cwd, 'js-and-mjs.js'), 'export default "js";\n');
+        await writeFile(join(cwd, 'js-and-mjs.mjs'), 'export default "mjs";\n');
+        await writeFile(join(cwd, 'mjs-and-ts.mjs'), 'export default "mjs";\n');
+        await writeFile(join(cwd, 'mjs-and-ts.ts'), 'export default "ts";\n');
+        await writeFile(
+          join(cwd, 'mjs-and-cjs.mjs'),
+          'export default "mjs";\n',
+        );
+        await writeFile(
+          join(cwd, 'mjs-and-cjs.cjs'),
+          'module.exports = "cjs";\n',
+        );
+
+        await mkdir(join(cwd, 'dir-mjs'));
+        await writeFile(
+          join(cwd, 'dir-mjs', 'index.mjs'),
+          'export default "mjs";\n',
+        );
+        await mkdir(join(cwd, 'dir-cjs'));
+        await writeFile(
+          join(cwd, 'dir-cjs', 'index.cjs'),
+          'module.exports = "cjs";\n',
+        );
+      });
+
+      afterAll(async () => {
+        await rm(cwd, { recursive: true, force: true });
+      });
+
+      it.each([
+        ['./only-mjs', 'only-mjs.mjs'],
+        ['./only-cjs', 'only-cjs.cjs'],
+      ])('resolves the extensionless %s to %s', async (specifier, expected) => {
+        const resolved = await resolveOrFail(specifier, cwd);
+
+        expect(basename(resolved)).toBe(expected);
+      });
+
+      it('resolves an absolute extensionless specifier too, which takes the other branch', async () => {
+        // Absolute specifiers are not RELATIVE_SPECIFIER matches, so they travel the bare-name
+        // path — the same path every `join(fixtures, …)` test in this file uses.
+        const resolved = await resolveOrFail(join(cwd, 'only-mjs'), cwd);
+
+        expect(basename(resolved)).toBe('only-mjs.mjs');
+      });
+
+      it.each([
+        ['./dir-mjs', 'index.mjs'],
+        ['./dir-cjs', 'index.cjs'],
+      ])(
+        'resolves %s, a directory carrying only %s',
+        async (specifier, expected) => {
+          const resolved = await resolveOrFail(specifier, cwd);
+
+          expect(basename(resolved)).toBe(expected);
+        },
+      );
+
+      it('loads what it guessed, so resolution and dispatch agree', async () => {
+        const module = await loadUserModule(
+          await resolveOrFail('./only-mjs', cwd),
+        );
+
+        expect(module.default).toBe('mjs');
+      });
+
+      it.each([
+        // Guessing runs AFTER `require.resolve`, so a sibling `.js` still wins…
+        ['a sibling .js over .mjs', './js-and-mjs', 'js-and-mjs.js'],
+        // …and BEFORE the jiti fallback, so `.mjs` still wins over a sibling `.ts`…
+        ['.mjs over a sibling .ts', './mjs-and-ts', 'mjs-and-ts.mjs'],
+        // …and within the guess itself, `.mjs` precedes `.cjs`.
+        ['.mjs over a sibling .cjs', './mjs-and-cjs', 'mjs-and-cjs.mjs'],
+      ])(
+        'prefers %s, reproducing unnarrowed jiti order',
+        async (_label, specifier, expected) => {
+          const resolved = await resolveOrFail(specifier, cwd);
+
+          expect(basename(resolved)).toBe(expected);
+        },
+      );
+    });
+
     it('declines every extension outside the JavaScript/TypeScript allow-list', async () => {
       // `require.resolve` answers with any existing absolute file regardless of extension, so a
       // deny-list left all of these resolving and then dying in the native importer with a raw

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -155,6 +155,44 @@ describe('load user module', () => {
       ).resolves.toBeUndefined();
     });
 
+    it.each([
+      ['a .jsx specifier', 'component.jsx'],
+      ['a .json specifier', 'rules.json'],
+    ])(
+      'declines %s, which no dispatch branch can load',
+      async (_label, fileName) => {
+        await expect(
+          resolveUserModule(join(fixtures, fileName), fixtures),
+        ).resolves.toBeUndefined();
+      },
+    );
+
+    it('does not decline extensions Node genuinely imports', async () => {
+      // `.node` and `.wasm` are deliberately NOT in UNSUPPORTED_EXTENSION — Node imports both,
+      // so declining them would break a working case. Only resolution is asserted here: the
+      // load is Node's business, and Vitest's module runner refuses to `import()` wasm at all
+      // ("ESM integration proposal for Wasm is not supported"). Loading a minimal valid wasm
+      // module through `loadUserModule` was verified out-of-band under plain Node.
+      const nativeExtCwd = await mkdtemp(join(tmpdir(), 'thymian-native-ext-'));
+
+      try {
+        // Magic + version: a complete wasm module that exports nothing.
+        await writeFile(
+          join(nativeExtCwd, 'mod.wasm'),
+          Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
+        );
+        await writeFile(join(nativeExtCwd, 'addon.node'), 'stub\n');
+
+        for (const specifier of ['./mod.wasm', './addon.node']) {
+          await expect(
+            resolveUserModule(specifier, nativeExtCwd),
+          ).resolves.toBeDefined();
+        }
+      } finally {
+        await rm(nativeExtCwd, { recursive: true, force: true });
+      }
+    });
+
     it.skipIf(!CASE_INSENSITIVE_FS)(
       'normalises a mis-cased TypeScript specifier to its on-disk casing',
       async () => {

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -600,6 +600,47 @@ describe('load user module', () => {
         join(decoyCwd, 'pkg-rules', 'main.js'),
         "export default 'local-main';\n",
       );
+
+      // Local TypeScript, in the three spellings a bare specifier can name it: extensionless
+      // file, directory with a TypeScript index, and the NodeNext `.js` spelling of a `.ts`
+      // file. None of these is an installed package, and none of them existed under the exact
+      // spelling the fallback used to gate on.
+      await writeFile(
+        join(decoyCwd, 'ts-rule.ts'),
+        "const rule: string = 'local-ts-file';\nexport default rule;\n",
+      );
+
+      await mkdir(join(decoyCwd, 'ts-dir'), { recursive: true });
+      await writeFile(
+        join(decoyCwd, 'ts-dir', 'index.ts'),
+        "const rule: string = 'local-ts-dir';\nexport default rule;\n",
+      );
+
+      await writeFile(
+        join(decoyCwd, 'nodenext-rule.ts'),
+        "const rule: string = 'local-ts-nodenext';\nexport default rule;\n",
+      );
+
+      // A bare SUBPATH collision: the same `<pkg>/rules` path exists both installed and in cwd,
+      // and only jiti can resolve either — `require.resolve` refuses a `.ts` subpath. This is
+      // what pins the jiti step to the INSTALLED candidate rather than the cwd one.
+      const installedSubpath = join(decoyCwd, 'node_modules', 'subpath-rules');
+
+      await mkdir(installedSubpath, { recursive: true });
+      await writeFile(
+        join(installedSubpath, 'package.json'),
+        JSON.stringify({ name: 'subpath-rules', type: 'module' }),
+      );
+      await writeFile(
+        join(installedSubpath, 'rules.ts'),
+        "const rule: string = 'INSTALLED-SUBPATH';\nexport default rule;\n",
+      );
+
+      await mkdir(join(decoyCwd, 'subpath-rules'), { recursive: true });
+      await writeFile(
+        join(decoyCwd, 'subpath-rules', 'rules.ts'),
+        "const rule: string = 'DECOY-SUBPATH';\nexport default rule;\n",
+      );
     });
 
     afterAll(async () => {
@@ -641,6 +682,54 @@ describe('load user module', () => {
         const module = await loadUserModule(resolved);
 
         expect(module.default).toBe(expected);
+      },
+    );
+
+    it.each([
+      ['an extensionless local .ts file', 'ts-rule', 'local-ts-file'],
+      ['a local directory with a TypeScript index', 'ts-dir', 'local-ts-dir'],
+      [
+        'the NodeNext .js spelling of a local .ts file',
+        'nodenext-rule.js',
+        'local-ts-nodenext',
+      ],
+    ])(
+      'falls back to %s named by a BARE specifier',
+      async (_label, specifier, expected) => {
+        // The headline case for this seam, and the shape `rule-loader` accepts today, yet none
+        // of these resolved: the fallback gated on `existsSync(<cwd>/<specifier>)` — the
+        // EXTENSIONLESS spelling, which is not what is on disk — and the jiti step it fell
+        // through to was handed the BARE name, which searches `node_modules` only. Measured:
+        // bare `ts-rule` came back `undefined` from jiti while `<cwd>/ts-rule` came back
+        // `ts-rule.ts`. The identical file resolved fine spelled `./ts-rule`.
+        const resolved = await resolveOrFail(specifier, decoyCwd);
+
+        expect(resolved.startsWith(decoyCwd)).toBe(true);
+
+        const module = await loadUserModule(resolved);
+
+        expect(module.default).toBe(expected);
+      },
+    );
+
+    it.each([
+      ['a bare TypeScript subpath', 'subpath-rules/rules'],
+      ['its NodeNext .js spelling', 'subpath-rules/rules.js'],
+    ])(
+      'resolves %s to the installed package, not the same path in cwd',
+      async (_label, specifier) => {
+        // Both candidates exist and only jiti can resolve either, so this is decided purely by
+        // WHICH candidate the jiti step is given first. Running it on the cwd path before the
+        // bare one — the shape the fix could easily have taken — resolves the decoy instead and
+        // turns this red, which is the whole reason installed-first is ordered by candidate
+        // rather than by resolver.
+        const resolved = await resolveOrFail(specifier, decoyCwd);
+
+        expect(resolved).toContain(join('node_modules', 'subpath-rules'));
+
+        const module = await loadUserModule(resolved);
+
+        expect(module.default).toBe('INSTALLED-SUBPATH');
       },
     );
 

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -260,29 +260,49 @@ describe('load user module', () => {
       },
     );
 
-    it('does not decline extensions Node genuinely imports', async () => {
-      // `.node` and `.wasm` are deliberately NOT in UNSUPPORTED_EXTENSION — Node imports both,
-      // so declining them would break a working case. Only resolution is asserted here: the
-      // load is Node's business, and Vitest's module runner refuses to `import()` wasm at all
-      // ("ESM integration proposal for Wasm is not supported"). Loading a minimal valid wasm
-      // module through `loadUserModule` was verified out-of-band under plain Node.
-      const nativeExtCwd = await mkdtemp(join(tmpdir(), 'thymian-native-ext-'));
+    it('declines every extension outside the JavaScript/TypeScript allow-list', async () => {
+      // `require.resolve` answers with any existing absolute file regardless of extension, so a
+      // deny-list left all of these resolving and then dying in the native importer with a raw
+      // ERR_UNKNOWN_FILE_EXTENSION. `.node` is here because it is not importable on Node 22 at
+      // all (the engines floor); `.wasm` because it needs a flag on Node 20 and exports no
+      // default, so it cannot carry a rule.
+      const cwd = await mkdtemp(join(tmpdir(), 'thymian-allowlist-'));
 
       try {
-        // Magic + version: a complete wasm module that exports nothing.
-        await writeFile(
-          join(nativeExtCwd, 'mod.wasm'),
-          Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
-        );
-        await writeFile(join(nativeExtCwd, 'addon.node'), 'stub\n');
+        const declined = [
+          'rules.yaml',
+          'rules.yml',
+          'rules.toml',
+          'rules.json5',
+          'rules.jsonc',
+          'notes.md',
+          'notes.txt',
+          'addon.node',
+          'mod.wasm',
+        ];
 
-        for (const specifier of ['./mod.wasm', './addon.node']) {
+        for (const name of declined) {
+          await writeFile(join(cwd, name), 'stub\n');
+        }
+
+        for (const name of declined) {
           await expect(
-            resolveUserModule(specifier, nativeExtCwd),
+            resolveUserModule(`./${name}`, cwd),
+            `expected ./${name} to be declined`,
+          ).resolves.toBeUndefined();
+        }
+
+        // The allow-list itself still admits every loadable shape.
+        for (const name of ['rule.js', 'rule.mjs', 'rule.cjs']) {
+          await writeFile(join(cwd, name), 'export default 1;\n');
+
+          await expect(
+            resolveUserModule(`./${name}`, cwd),
+            `expected ./${name} to resolve`,
           ).resolves.toBeDefined();
         }
       } finally {
-        await rm(nativeExtCwd, { recursive: true, force: true });
+        await rm(cwd, { recursive: true, force: true });
       }
     });
 

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -958,6 +958,56 @@ describe('load user module', () => {
       expect(jitiFactoryCalls).toBe(0);
     }, 15_000);
 
+    it('keeps require.resolve working for a relative cwd across a chdir', async () => {
+      // The require anchor is memoised per directory, and a RELATIVE `cwd` names a different
+      // directory before and after a `chdir`. Keyed by the raw string, the second call got the
+      // first call's anchor: `require.resolve` missed a package that was plainly installed and
+      // resolution fell through to the jiti fallback — a plain-JavaScript package paying for jiti,
+      // which contract item 4 forbids. Measured with `JITI_DEBUG=1` before the fix.
+      //
+      // Asserted through the jiti counter rather than the returned path, because the path came back
+      // CORRECT either way: jiti found what the stale anchor had missed. Only the cost differed,
+      // which is exactly the kind of regression a result assertion cannot see.
+      const loader = await import('../src/load-user-module.js');
+      const original = process.cwd();
+      const root = await mkdtemp(join(tmpdir(), 'thymian-relative-cwd-'));
+
+      try {
+        for (const name of ['first', 'second']) {
+          const pkg = join(root, name, 'node_modules', `${name}-rules`);
+
+          await mkdir(pkg, { recursive: true });
+          await writeFile(
+            join(pkg, 'package.json'),
+            JSON.stringify({
+              name: `${name}-rules`,
+              main: 'index.js',
+              type: 'module',
+            }),
+          );
+          await writeFile(join(pkg, 'index.js'), `export default '${name}';\n`);
+        }
+
+        process.chdir(join(root, 'first'));
+
+        await expect(
+          loader.resolveUserModule('first-rules', '.'),
+        ).resolves.toMatchObject({ ok: true });
+
+        // Same relative spelling, different directory.
+        process.chdir(join(root, 'second'));
+
+        await expect(
+          loader.resolveUserModule('second-rules', '.'),
+        ).resolves.toMatchObject({ ok: true });
+
+        expect(jitiFactoryCalls).toBe(0);
+      } finally {
+        process.chdir(original);
+        await rm(root, { recursive: true, force: true });
+      }
+    }, 15_000);
+
     it('imports jiti exactly once across two TypeScript loads', async () => {
       const loader = await import('../src/load-user-module.js');
 

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from 'node:fs';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, isAbsolute, join } from 'node:path';
 
@@ -97,6 +97,63 @@ describe('load user module', () => {
       expect('default' in module).toBe(true);
       expect(module.default).toBe('primitive-cts');
     });
+
+    it('treats a symlink and its target as the same module', async () => {
+      // Identity, not a counter: `side-effect.ts` is loaded by other tests too. Keyed on the raw
+      // string these two spellings are two entries and the body runs once per spelling.
+      // (An earlier version of this test used `join(fixtures, 'nested', '..', name)` — which
+      // `path.join` normalises at construction, so both paths were already the same string and
+      // the test could not fail.)
+      const linkDir = await mkdtemp(join(tmpdir(), 'thymian-symlink-'));
+
+      try {
+        const link = join(linkDir, 'aliased.ts');
+
+        await symlink(join(fixtures, 'side-effect.ts'), link);
+
+        const viaLink = await loadUserModule(link);
+        const direct = await loadUserModule(join(fixtures, 'side-effect.ts'));
+
+        // Compares the exported evaluation counter, not the namespace: jiti hands back a FRESH
+        // interop proxy per import even for a cached module, so object identity is not a usable
+        // signal. Two identities for one file would give consecutive counter values.
+        expect(viaLink.default).toBe(direct.default);
+      } finally {
+        await rm(linkDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports an import cycle instead of hanging', async () => {
+      // Undetected this never settles — Node exits 13, "Detected unsettled top-level await".
+      await expect(
+        loadUserModule(join(fixtures, 'cycle-a.ts')),
+      ).rejects.toThrowError(
+        expect.objectContaining({ name: 'UserModuleLoadError' }),
+      );
+    }, 15_000);
+
+    it('refuses a relative path rather than guessing a base', async () => {
+      // The two branches anchored a relative path differently: process.cwd() natively, core's
+      // install directory through jiti.
+      await expect(loadUserModule('./plain.ts')).rejects.toThrow(
+        /absolute path is required/,
+      );
+    });
+
+    it.skipIf(!CASE_INSENSITIVE_FS)(
+      'treats two casings of one path as the same module',
+      async () => {
+        // Only `resolveUserModule` normalised casing, so a glob- or config-supplied `PLAIN.TS`
+        // reaching `loadUserModule` directly matched no dispatch branch and died raw. Asserted
+        // as identity because that discriminates under Vitest, where a raw `.TS` import happens
+        // to succeed; the plain-Node dispatch failure is covered by the external harness.
+        const upper = await loadUserModule(join(fixtures, 'PLAIN.TS'));
+        const lower = await loadUserModule(join(fixtures, 'plain.ts'));
+
+        expect(upper.default).toBe(lower.default);
+        expect(upper.default).toBe('plain-ts');
+      },
+    );
 
     it('evaluates a TypeScript module once across concurrent loads', async () => {
       const resolved = await resolveOrFail(join(fixtures, 'side-effect.ts'));
@@ -438,6 +495,51 @@ describe('load user module', () => {
       expect(resolved.startsWith(decoyCwd)).toBe(false);
       expect(resolved).toContain(join('rules-rfc-9110', 'dist'));
     }, 15_000);
+  });
+
+  describe('jiti configuration', () => {
+    afterEach(() => {
+      vi.doUnmock('jiti');
+      vi.resetModules();
+    });
+
+    it('narrows jiti to TypeScript extensions so .js stays with Node', async () => {
+      // WHY this asserts the option rather than its consequence: with jiti's default extension
+      // list, a `.js` module imported by both a natively-loaded JS rule and a jiti-loaded TS
+      // rule lands in two registries and evaluates twice, handing the two rules non-identical
+      // objects. That consequence is NOT observable here — Vitest's module runner intercepts
+      // `import()`, so jiti's delegation never reaches Node's loader and the two registries stay
+      // split regardless of this option. Measured against the BUILT loader under plain Node:
+      // 2 evaluations and `===` false with the defaults, 1 and `===` true with this narrowing.
+      // The standing external harness asserts the consequence; this asserts the cause, so
+      // removing the option still turns a test red.
+      vi.resetModules();
+
+      let captured: unknown;
+
+      vi.doMock('jiti', async () => {
+        const actual = await vi.importActual<typeof import('jiti')>('jiti');
+
+        return {
+          ...actual,
+          createJiti: (parentUrl: string, options?: unknown) => {
+            captured = options;
+
+            return actual.createJiti(parentUrl, options as never);
+          },
+        };
+      });
+
+      const loader = await import('../src/load-user-module.js');
+      const resolved = await loader.resolveUserModule(
+        join(fixtures, 'plain.ts'),
+        fixtures,
+      );
+
+      await loader.loadUserModule(String(resolved));
+
+      expect(captured).toMatchObject({ extensions: ['.ts', '.mts', '.cts'] });
+    });
   });
 
   describe('lazy jiti import', () => {

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -165,6 +165,78 @@ describe('load user module', () => {
       );
     }, 15_000);
 
+    // The concurrent fixtures reach the loader through `globalThis`, not through an import: jiti
+    // hands an importing fixture its OWN copy of the seam, and a cycle built across two copies
+    // exercises neither one's machinery. See fixtures/user-modules/loader-under-test.ts.
+    beforeAll(() => {
+      (globalThis as Record<string, unknown>).__thymianLoadUserModule =
+        loadUserModule;
+    });
+
+    afterAll(() => {
+      delete (globalThis as Record<string, unknown>).__thymianLoadUserModule;
+    });
+
+    it('reports a cycle formed by two concurrent roots instead of deadlocking', async () => {
+      // A DIFFERENT defect from the test above, and invisible to the machinery that catches that
+      // one. Each root's evaluation chain holds only its own path, so when root A's top level
+      // waits for `b` and root B's waits for `a`, neither chain contains the other's module: the
+      // in-flight entry is awaited, the chain is never extended, and the two promises await each
+      // other. Reproduced against the built dist before the fix — Node printed "Detected unsettled
+      // top-level await" and exited without settling either root.
+      //
+      // `loadRules` fans out over array input with `Promise.all`, so this is reachable from a
+      // user's `rules: [...]`, not just from a fixture.
+      const roots = Promise.allSettled([
+        loadUserModule(join(fixtures, 'concurrent-cycle-a.ts')),
+        loadUserModule(join(fixtures, 'concurrent-cycle-b.ts')),
+      ]);
+
+      const settled = await roots;
+
+      // Both roots settle at all — that is the deadlock assertion, and it is why this test asserts
+      // on `allSettled` rather than awaiting a rejection.
+      expect(settled.map((outcome) => outcome.status)).toEqual([
+        'rejected',
+        'rejected',
+      ]);
+
+      for (const outcome of settled) {
+        expect(outcome).toMatchObject({
+          reason: expect.objectContaining({
+            name: 'UserModuleLoadError',
+            // The RING, not just the words "import cycle": the error has to name the loop the user
+            // has to break, and a detector that reported the two modules which happened to notice
+            // each other would name the wrong pair.
+            message: expect.stringMatching(
+              /import cycle .*concurrent-cycle-[ab]\.ts -> .*concurrent-cycle-[ab]\.ts -> .*concurrent-cycle-[ab]\.ts/,
+            ),
+          }),
+        });
+      }
+    }, 20_000);
+
+    it('lets two concurrent roots share a dependency without calling it a cycle', async () => {
+      // The false positive that a cruder fix produces. Refusing every cross-root wait, or treating
+      // any in-flight entry as a cycle, turns this legitimate shape — two rule files importing one
+      // helper, loaded together by `loadRules` — into a spurious cycle error. It also pins that
+      // waiting is what makes exactly-once hold: the helper must evaluate ONCE and both roots must
+      // receive the same namespace object.
+      const [x, y] = await Promise.all([
+        loadUserModule(join(fixtures, 'concurrent-dep-x.ts')),
+        loadUserModule(join(fixtures, 'concurrent-dep-y.ts')),
+      ]);
+
+      expect(x.default).toBe('concurrent-dep-x');
+      expect(y.default).toBe('concurrent-dep-y');
+
+      // `===`, not a deep match: two evaluations would produce equal-looking distinct objects.
+      expect(x.shared).toBe(y.shared);
+      expect(
+        (x.shared as { default: { evaluations: number } }).default.evaluations,
+      ).toBe(1);
+    }, 20_000);
+
     it('refuses a relative path rather than guessing a base', async () => {
       // The two branches anchored a relative path differently: process.cwd() natively, core's
       // install directory through jiti.

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -112,6 +112,42 @@ describe('load user module', () => {
     });
   });
 
+  describe('loadUserModule guards', () => {
+    // `loadUserModule` is exported alongside `resolveUserModule`, so a caller can reach it with a
+    // path the resolver would have declined — a `loadRuleSet` glob or a config `path`. Left
+    // unguarded a `.d.ts` imports as an EMPTY module and the caller reports "does not use default
+    // export", which is precisely the confusion the resolver's guard prevents.
+    it.each([
+      ['a declaration file', 'types.d.ts'],
+      ['a declaration file spelled with a capital D', 'Legacy.D.ts'],
+      ['a .tsx file', 'component.tsx'],
+      ['a .jsx file', 'component.jsx'],
+      ['a .json file', 'rules.json'],
+    ])('refuses %s with a framed error', async (_label, fileName) => {
+      await expect(
+        loadUserModule(join(fixtures, fileName)),
+      ).rejects.toThrowError(
+        expect.objectContaining({ name: 'UserModuleLoadError' }),
+      );
+    });
+
+    it('explains a declaration file rather than returning an empty module', async () => {
+      // The regression that matters: this used to RESOLVE to `{}` with no `default`, so the
+      // failure surfaced as a misleading complaint about the user's export style.
+      await expect(
+        loadUserModule(join(fixtures, 'types.d.ts')),
+      ).rejects.toThrow(/contains no runtime code/);
+    });
+
+    it('still loads a path the resolver accepts', async () => {
+      const resolved = await resolveOrFail(join(fixtures, 'plain.ts'));
+
+      await expect(loadUserModule(resolved)).resolves.toMatchObject({
+        default: 'plain-ts',
+      });
+    });
+  });
+
   describe('resolution', () => {
     it('resolves an extensionless specifier to its .ts file', async () => {
       // `helper`, not `plain`: the `plain.*` fixtures deliberately share a basename to cover


### PR DESCRIPTION
Adds one shared seam in `@thymian/core` for loading a **user-supplied** module — a rule, a rule set
or a plugin — so that `rule-loader.ts` and `base-cli-run-command.ts` can later migrate onto identical
semantics instead of each reinventing TypeScript loading.

**This PR adds the seam and its tests. It changes no call site.** `packages/core/src/rules/` and
`packages/common-cli/` are byte-identical to `main`; the diff is purely additive
(26 files, +1370/−0).

## What it does

`packages/core/src/load-user-module.ts` exports two functions and one options interface:

```ts
resolveUserModule(specifier, cwd?, options?): Promise<string | undefined>  // never throws
loadUserModule(resolvedPath): Promise<Record<string, unknown>>             // returns the namespace
```

Resolution and loading are separate steps because callers need the resolved path in its own right
(`loadRuleSet` uses it as a glob base) and need "cannot resolve" to stay distinguishable from
"failed to load", so each keeps its own user-facing message.

**Resolution order.** Relative specifiers are anchored at `cwd` before resolution — delegating them
would hand back core's *own* modules as the user's rule. Bare specifiers resolve installed packages
first (the user's project, then core's install directory) and fall back to `<cwd>/<specifier>` only
when nothing is installed under that name, so a same-named local file or directory cannot shadow and
silently execute in place of an installed package. Resolved paths are then gated on being absolute,
normalised to their on-disk casing, and checked against a closed allow-list of loadable extensions.

**Dispatch.** `/\.[cm]?ts$/` goes through jiti; everything else through a plain dynamic `import()`.

**jiti stays off the JavaScript path.** It is imported lazily via a memoised *promise* (memoising the
instance would let concurrent TypeScript loads each start their own import), and the only `jiti`
reference in the built output is inside that dynamic import. This matters because the built-in rules
are JavaScript and load on every single invocation.

**Exactly once.** A module's top-level side effects run once — across both dispatch branches, across
every spelling of its path, and under concurrency:

- jiti's `extensions` is narrowed to TypeScript so it delegates `.js` to Node's loader. With the
  default list a `.js` imported by both a natively-loaded JS rule and a jiti-loaded TS rule lands in
  two registries and evaluates **twice**, handing the two rules non-identical objects.
- Paths are canonicalised through `realpathSync.native`, so `x.ts`, `sub/../x.ts` and a symlink are
  one identity.
- An in-flight promise map de-duplicates concurrent TypeScript loads (jiti populates its cache only
  after a load completes).
- An `AsyncLocalStorage` chain detects a module that re-enters the seam during its own evaluation and
  reports the cycle rather than hanging on a promise only its own return can settle.

## Documented limitations

Each is measured against jiti 2.6.1 and recorded in the file header, not left implicit:

- TypeScript sources must use `export default`. Through jiti's interop, `module.exports = {…}` and
  `export = {…}` are indistinguishable from a module with only named exports, so synthesising a
  default would let a named-only module masquerade as a rule.
- tsconfig `paths` aliases are not honoured in a user TypeScript module. Nested *package* imports
  from the user's own `node_modules` do work; it is specifically the alias case.
- Only JavaScript and TypeScript are loadable. The excluded extensions each carry their reason at
  the constant — including `.node`, which is not importable on the `engines.node` floor at all.
- Both `require.resolve` anchors apply the **CJS condition set**, so a dual-published package
  resolves its CommonJS half and an ESM-only package falls through to jiti. Closing this needs a
  real ESM-conditions resolver; tracked separately.

## Dependency

`jiti@^2.6.1` added to `@thymian/core` — the exact range `plugin-sampler` already uses, so the
lockfile keeps one hoisted copy (the `package-lock.json` diff is a single line). jiti has zero
runtime dependencies and declares no `engines`, so `engines.node` stays `">=22"`.

## Verification

`core:lint` 0 errors / 14 warnings (unchanged from baseline) · `core:test` **382 passed** across 34
files, 49 of them new · `core:build` pass · `nx affected -t test` pass · `nx e2e e2e-tests` pass ·
`nx format:check` clean · `git diff main -- packages/core/src/rules packages/common-cli` empty.

Behaviour was additionally re-checked by running the **built** `dist/load-user-module.js` from
directories outside the monorepo — npm hoisting inside the workspace lets core's `require` see
packages a real consumer's would not, which is precisely what hid several defects from the
in-workspace suite during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
