### PR TITLE
feat(core): load rules and rule sets through the shared user-module seam

### DIFF
--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -51,6 +51,19 @@ export function isRule(rule: unknown): rule is Rule {
   return areFunctionPropertiesIfDefined(rule);
 }
 
+/**
+ * What to name as the source of a rule in a diagnostic.
+ *
+ * The resolved path is the file to open, which is why it replaced the specifier here — but for a
+ * BARE specifier it is a deep install path the user never typed: `@thymian/rules-rfc-9110` resolves
+ * to `…/packages/rules-rfc-9110/dist/index.js`, and naming only that loses the identity they wrote
+ * in their config. Naming both keeps the actionable path without the loss. They collapse to one
+ * when the specifier already IS the resolved path, which is every absolute-path and globbed case.
+ */
+function describeRuleSource(input: string, resolved: string): string {
+  return input === resolved ? resolved : `${input} (${resolved})`;
+}
+
 function throwInvalidRuleError(
   rule: Rule,
   violation: RuleExecutionInvariantViolation,
@@ -200,20 +213,35 @@ function applyProfileThenConfig(
 }
 
 /**
- * The extensions a globbed rule-set match may have, mirroring the allow-list inside
- * `resolveUserModule` — a match this does not admit is one the seam declines, so admitting it could
- * only ever produce an error. Kept case-sensitive for exactly that reason: the seam normalises a
- * resolved path to its on-disk casing and then tests the same case-sensitive pattern, so a
- * `Rule.TS` is not loadable there and must not be waved through here either.
+ * The extensions a globbed rule-set match may have. Character-for-character `LOADABLE_EXTENSION` in
+ * `load-user-module.ts`, and case-sensitive for the same reason: the seam normalises a resolved path
+ * to its on-disk casing and then tests this same case-sensitive pattern, so an `Upper.Rule.JS` is
+ * not loadable there and must not be waved through here either.
  */
 const LOADABLE_RULE_FILE = /\.[cm]?[jt]s$/;
 
 /**
- * Declaration files are never loadable — they contain no runtime code. Case-insensitive to match
- * the seam, because on Windows and default macOS volumes a `Types.D.TS` resolves fine and a
- * case-sensitive guard would wave through the exact file it exists to stop.
+ * Declaration files are never loadable — they contain no runtime code. Case-insensitive like the
+ * seam's copy, though only the `d` can ever reach it: a `Types.D.TS` already fails the
+ * case-sensitive {@link LOADABLE_RULE_FILE}, so the flag earns its keep on `Types.D.ts` alone.
  */
 const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
+
+/**
+ * Whether a globbed match is something the seam can load at all.
+ *
+ * Declaration files are tested FIRST, the order `load-user-module.ts`'s `unloadableReason` uses and
+ * for its stated reason — `.d.ts` also matches the loadable pattern, so a declaration check that ran
+ * second would be dead code for any spelling the loadable pattern happens to admit.
+ *
+ * This duplicates a predicate the seam already composes but does not export. The duplication is
+ * deliberate for now (story 34.2 may not edit `load-user-module.ts`) and tracked as deferred work:
+ * if the seam ever widens — its `.tsx` exclusion is called deliberate but the export-shape
+ * limitation is called follow-up work — this copy silently drops the newly loadable files.
+ */
+function isLoadableRuleFile(file: string): boolean {
+  return !DECLARATION_FILE.test(file) && LOADABLE_RULE_FILE.test(file);
+}
 
 async function loadRuleSet(
   ruleSet: RuleSet,
@@ -261,17 +289,40 @@ async function loadRuleSet(
       // returns matches in filesystem traversal order, which varies between
       // runs and would otherwise make downstream report output non-deterministic.
       //
-      // Then drop what cannot be a module at all. A pattern is a plain glob, so `**/*.ts` picks up
-      // a neighbouring `types.d.ts` and `**/*` also picks up a `rules.json` or a `README.md`; the
-      // seam declines every one of them, so without this filter the whole rule set dies on
-      // `Cannot resolve rule source` naming a file that plainly exists and that the user never
-      // meant to load. A skipped match is not an error and produces no diagnostic.
-      const files = (await glob(pattern, { cwd: dirname }))
-        .sort()
-        .filter(
-          (file) =>
-            LOADABLE_RULE_FILE.test(file) && !DECLARATION_FILE.test(file),
+      // `node_modules` is excluded because a wide pattern reaching into it would IMPORT and execute
+      // every dependency module it matched. Before the loadable-file filter below that failed loudly
+      // on the first non-module; with it, the JavaScript files sail through and run.
+      const matched = (
+        await glob(pattern, { cwd: dirname, ignore: ['**/node_modules/**'] })
+      ).sort();
+
+      // Drop what cannot be a module at all. A pattern is a plain glob, so `**/*.ts` picks up a
+      // neighbouring `types.d.ts` and `**/*` also picks up a `rules.json` or a `README.md`; the seam
+      // declines every one of them, so without this the whole rule set dies on `Cannot resolve rule
+      // source` naming a file that plainly exists and that the user never meant to load.
+      const files = matched.filter(isLoadableRuleFile);
+
+      // An individual skip is silent — that is the point of the filter. But a pattern that matched
+      // files and kept NONE of them is a mistake every time: a typo'd extension, a pattern aimed at
+      // a directory of declarations, `*.tsx`. Left silent it returns zero rules, and `lint` only
+      // whispers `Loaded 0 rule(s)` at info level while `test` and `analyze` say nothing at all —
+      // so the run passes having validated nothing. Fail instead.
+      //
+      // Deliberately counts FILES, not the rules they yield: a rule filter legitimately excludes
+      // every rule it loaded, and that must stay a clean empty result.
+      if (matched.length > 0 && files.length === 0) {
+        throw new ThymianBaseError(
+          `Rule set "${ruleSet.name}" pattern ${pattern} matched ${matched.length} file(s), none of which can be loaded as a rule.`,
+          {
+            suggestions: [
+              'Point the pattern at rule modules (.js, .mjs, .cjs, .ts, .mts, .cts) rather than declarations or data files.',
+              'Check the pattern for a typo in the extension or directory name.',
+            ],
+            name: 'RuleLoadError',
+            ref: 'https://thymian.dev/references/errors/rule-load-error/',
+          },
         );
+      }
 
       for (const file of files) {
         rules.push(
@@ -318,7 +369,7 @@ export async function loadRules(
 
   // Resolution and loading both go through the shared user-module seam, which is what makes a
   // TypeScript rule loadable: it dispatches on the RESOLVED extension, sending `.ts`/`.mts`/`.cts`
-  // through jiti and everything else — the 182 built-in JavaScript rules included — through a plain
+  // through jiti and everything else — every built-in JavaScript rule included — through a plain
   // dynamic import that never pays for jiti. `resolveUserModule` never throws; it answers
   // `undefined`, which is what keeps this error message owned here.
   const resolved = await resolveUserModule(input, cwd);
@@ -331,13 +382,14 @@ export async function loadRules(
   }
 
   const module = await loadUserModule(resolved);
+  const source = describeRuleSource(input, resolved);
 
   if (!('default' in module)) {
     throw new ThymianBaseError(
-      // Names the RESOLVED path rather than the specifier: `…/simple.rule.ts` is the file to open,
-      // where `./simple.rule` left the user to work it out — and for a name that is both installed
-      // and present in `cwd`, a locally recomputed path would name a file that was never loaded.
-      `Rule or rule set at ${resolved} does not use default export.`,
+      // Names the RESOLVED path, not a locally recomputed one: for a name both installed and
+      // present in `cwd`, a recomputed path would name a file that was never loaded. It keeps the
+      // specifier alongside it when the two differ — see `describeRuleSource`.
+      `Rule or rule set at ${source} does not use default export.`,
       {
         suggestions: [
           // Scoped rather than blanket: `module.exports =` in a `.ts`/`.cts` source produces a
@@ -358,7 +410,7 @@ export async function loadRules(
   if (isRule(ruleOrRuleSet)) {
     const rule = applyProfileThenConfig(ruleOrRuleSet, profileConfig, options);
 
-    assertRuleTypeDeclaration(rule, resolved);
+    assertRuleTypeDeclaration(rule, source);
 
     if (!ruleFilter(rule)) {
       return [];
@@ -366,7 +418,7 @@ export async function loadRules(
 
     assertRuleExecutionInvariant(
       rule,
-      resolved,
+      source,
       typeOverrideSuggestions(rule, options),
     );
 

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -370,19 +370,29 @@ export async function loadRules(
   // Resolution and loading both go through the shared user-module seam, which is what makes a
   // TypeScript rule loadable: it dispatches on the RESOLVED extension, sending `.ts`/`.mts`/`.cts`
   // through jiti and everything else — every built-in JavaScript rule included — through a plain
-  // dynamic import that never pays for jiti. `resolveUserModule` never throws; it answers
-  // `undefined`, which is what keeps this error message owned here.
+  // dynamic import that never pays for jiti. `resolveUserModule` never throws; it answers a
+  // result, which is what keeps this error message owned here.
   const resolved = await resolveUserModule(input, cwd);
 
-  if (resolved === undefined) {
-    throw new ThymianBaseError(`Cannot resolve rule source ${input}.`, {
-      name: 'RuleLoadError',
-      ref: 'https://thymian.dev/references/errors/rule-load-error/',
-    });
+  if (!resolved.ok) {
+    // Two failures, two sentences. `reason` is present only when the specifier resolved to a
+    // real file that was then refused for what it IS — a `.yaml`, a `.d.ts` — so reporting
+    // "cannot resolve" there tells the user a file they are looking at cannot be found. With no
+    // reason there is genuinely nothing to add beyond "not found", and the seam says so by
+    // omitting it rather than by inventing a vague one.
+    throw new ThymianBaseError(
+      resolved.reason === undefined
+        ? `Cannot resolve rule source ${input}.`
+        : `Cannot load rule source ${input}: ${resolved.reason}.`,
+      {
+        name: 'RuleLoadError',
+        ref: 'https://thymian.dev/references/errors/rule-load-error/',
+      },
+    );
   }
 
-  const module = await loadUserModule(resolved);
-  const source = describeRuleSource(input, resolved);
+  const module = await loadUserModule(resolved.path);
+  const source = describeRuleSource(input, resolved.path);
 
   if (!('default' in module)) {
     throw new ThymianBaseError(
@@ -430,7 +440,7 @@ export async function loadRules(
 
     return loadRuleSet(
       ruleOrRuleSet,
-      resolved,
+      resolved.path,
       ruleFilter,
       options,
       cwd,

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -1,10 +1,8 @@
-import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 import { glob } from 'tinyglobby';
 
+import { loadUserModule, resolveUserModule } from '../load-user-module.js';
 import { ThymianBaseError } from '../thymian.error.js';
 import { isRecord } from '../utils.js';
 import { validate } from './ajv-validate.js';
@@ -20,8 +18,6 @@ import {
 import type { RuleFilter } from './rule-filter.js';
 import type { RuleSet } from './rule-set.js';
 import { isRuleSeverityLevel } from './rule-severity.js';
-
-const require = createRequire(import.meta.url);
 
 type RecordWithFunctions<Property extends PropertyKey> = Record<
   PropertyKey,
@@ -203,6 +199,22 @@ function applyProfileThenConfig(
   );
 }
 
+/**
+ * The extensions a globbed rule-set match may have, mirroring the allow-list inside
+ * `resolveUserModule` — a match this does not admit is one the seam declines, so admitting it could
+ * only ever produce an error. Kept case-sensitive for exactly that reason: the seam normalises a
+ * resolved path to its on-disk casing and then tests the same case-sensitive pattern, so a
+ * `Rule.TS` is not loadable there and must not be waved through here either.
+ */
+const LOADABLE_RULE_FILE = /\.[cm]?[jt]s$/;
+
+/**
+ * Declaration files are never loadable — they contain no runtime code. Case-insensitive to match
+ * the seam, because on Windows and default macOS volumes a `Types.D.TS` resolves fine and a
+ * case-sensitive guard would wave through the exact file it exists to stop.
+ */
+const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
+
 async function loadRuleSet(
   ruleSet: RuleSet,
   basePath: string,
@@ -248,7 +260,18 @@ async function loadRuleSet(
       // Sort glob results so rule load order is deterministic. tinyglobby
       // returns matches in filesystem traversal order, which varies between
       // runs and would otherwise make downstream report output non-deterministic.
-      const files = (await glob(pattern, { cwd: dirname })).sort();
+      //
+      // Then drop what cannot be a module at all. A pattern is a plain glob, so `**/*.ts` picks up
+      // a neighbouring `types.d.ts` and `**/*` also picks up a `rules.json` or a `README.md`; the
+      // seam declines every one of them, so without this filter the whole rule set dies on
+      // `Cannot resolve rule source` naming a file that plainly exists and that the user never
+      // meant to load. A skipped match is not an error and produces no diagnostic.
+      const files = (await glob(pattern, { cwd: dirname }))
+        .sort()
+        .filter(
+          (file) =>
+            LOADABLE_RULE_FILE.test(file) && !DECLARATION_FILE.test(file),
+        );
 
       for (const file of files) {
         rules.push(
@@ -293,32 +316,36 @@ export async function loadRules(
     ).flat();
   }
 
-  let location = input;
-  const fileLocation = path.resolve(cwd, input);
+  // Resolution and loading both go through the shared user-module seam, which is what makes a
+  // TypeScript rule loadable: it dispatches on the RESOLVED extension, sending `.ts`/`.mts`/`.cts`
+  // through jiti and everything else — the 182 built-in JavaScript rules included — through a plain
+  // dynamic import that never pays for jiti. `resolveUserModule` never throws; it answers
+  // `undefined`, which is what keeps this error message owned here.
+  const resolved = await resolveUserModule(input, cwd);
 
-  if (existsSync(fileLocation)) {
-    location = fileLocation;
-  }
-
-  let resolved: string;
-
-  try {
-    resolved = require.resolve(location);
-  } catch {
+  if (resolved === undefined) {
     throw new ThymianBaseError(`Cannot resolve rule source ${input}.`, {
       name: 'RuleLoadError',
       ref: 'https://thymian.dev/references/errors/rule-load-error/',
     });
   }
 
-  const module = await import(pathToFileURL(resolved).href);
+  const module = await loadUserModule(resolved);
 
   if (!('default' in module)) {
     throw new ThymianBaseError(
-      `Rule or rule set at ${location} does not use default export.`,
+      // Names the RESOLVED path rather than the specifier: `…/simple.rule.ts` is the file to open,
+      // where `./simple.rule` left the user to work it out — and for a name that is both installed
+      // and present in `cwd`, a locally recomputed path would name a file that was never loaded.
+      `Rule or rule set at ${resolved} does not use default export.`,
       {
         suggestions: [
-          'Use "export default" or "module.exports =" to export your rule (set).',
+          // Scoped rather than blanket: `module.exports =` in a `.ts`/`.cts` source produces a
+          // namespace with no `default` key that jiti's interop cannot tell apart from a
+          // named-only module, so the seam cannot honour it. Suggesting it to a TypeScript author
+          // told them to do something that provably fails.
+          'Use "export default" to export your rule (set), or "module.exports =" in a CommonJS JavaScript file.',
+          'A TypeScript source must use "export default" — "module.exports =" there produces a namespace with no default export, indistinguishable from a module with only named exports.',
         ],
         name: 'RuleLoadError',
         ref: 'https://thymian.dev/references/errors/rule-load-error/',
@@ -331,7 +358,7 @@ export async function loadRules(
   if (isRule(ruleOrRuleSet)) {
     const rule = applyProfileThenConfig(ruleOrRuleSet, profileConfig, options);
 
-    assertRuleTypeDeclaration(rule, location);
+    assertRuleTypeDeclaration(rule, resolved);
 
     if (!ruleFilter(rule)) {
       return [];
@@ -339,7 +366,7 @@ export async function loadRules(
 
     assertRuleExecutionInvariant(
       rule,
-      location,
+      resolved,
       typeOverrideSuggestions(rule, options),
     );
 

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed-js/a.rule.mjs
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed-js/a.rule.mjs
@@ -1,0 +1,7 @@
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('globbed-js-a')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed-js/b.rule.mjs
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed-js/b.rule.mjs
@@ -1,0 +1,7 @@
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('globbed-js-b')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed/README.md
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed/README.md
@@ -1,0 +1,1 @@
+Fixture: not a module either. Matched by a `**/*` pattern, skipped by the loadable-extension filter.

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed/a.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed/a.rule.ts
@@ -1,0 +1,19 @@
+// Fixture: one of two rules a rule-set `pattern` glob must pick up.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+interface Marker {
+  readonly name: string;
+}
+
+const marker: Marker = { name: 'globbed-ts-a' };
+
+export default httpRule(marker.name)
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed/b.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed/b.rule.ts
@@ -1,0 +1,20 @@
+// Fixture: the second globbed rule. Sorts after `a.rule.ts`, which is what makes the load order
+// assertion meaningful.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+interface Marker {
+  readonly name: string;
+}
+
+const marker: Marker = { name: 'globbed-ts-b' };
+
+export default httpRule(marker.name)
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed/rules.json
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed/rules.json
@@ -1,0 +1,3 @@
+{
+  "note": "Fixture: not a module. A `**/*` rule-set pattern matches it; the glob loop must skip it."
+}

--- a/packages/core/test/rules/fixtures/rule-sets-ts/globbed/types.d.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/globbed/types.d.ts
@@ -1,0 +1,3 @@
+// Fixture: a declaration file sitting next to the globbed rules. It contains no runtime code, so
+// the glob loop must skip it rather than try to load it.
+export declare const globbedRuleNames: readonly string[];

--- a/packages/core/test/rules/fixtures/rule-sets-ts/inline.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/inline.ruleset.ts
@@ -1,0 +1,27 @@
+// Fixture: a rule set with an inline `rules` array, authored in TypeScript. The inline branch of
+// `loadRuleSet` never touches the filesystem again, so this proves the rule set itself survives the
+// jiti round-trip — `isRuleSet` still recognises it and its inline rules still validate.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule, type Rule } from '@thymian/core';
+
+const inlineRules: Rule[] = [
+  httpRule('inline-ts-a')
+    .severity('error')
+    .type('test', 'analytics')
+    .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+    .done(),
+  httpRule('inline-ts-b')
+    .severity('warn')
+    .type('test', 'analytics')
+    .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+    .done(),
+];
+
+export default {
+  name: 'inline-ts',
+  rules: inlineRules,
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/nonmodules/data.json
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/nonmodules/data.json
@@ -1,0 +1,3 @@
+{
+  "note": "Fixture: data, not a module. Matched by pattern-none.ruleset.ts."
+}

--- a/packages/core/test/rules/fixtures/rule-sets-ts/nonmodules/types.d.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/nonmodules/types.d.ts
@@ -1,0 +1,2 @@
+// Fixture: declaration-only, matched by the pattern in `pattern-none.ruleset.ts`.
+export declare const nothingLoadable: readonly string[];

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-all.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-all.ruleset.ts
@@ -1,0 +1,8 @@
+// Fixture: the same glob branch with a pattern that deliberately sweeps up files that are not
+// modules at all — a declaration file, a JSON file and a README. Every one of them plainly exists,
+// so without the loadable-extension filter the whole rule set dies on `Cannot resolve rule source`
+// naming a file the user never meant to load.
+export default {
+  name: 'pattern-all-ts',
+  pattern: './globbed/**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-array.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-array.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: the `string[]` form of `pattern`, which the glob loop handles explicitly and which no
+// test covered. Mixes a TypeScript glob with a JavaScript one, so both dispatch branches run inside
+// one rule set.
+export default {
+  name: 'pattern-array-ts',
+  pattern: ['./globbed/**/*.rule.ts', './globbed-js/**/*.rule.mjs'],
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-js.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-js.ruleset.ts
@@ -1,0 +1,8 @@
+// Fixture: a glob over JAVASCRIPT rules. Both shipped rule packages reach their rules exactly this
+// way (`pattern: 'rules/**/*.rule.js'`), so this is the production shape of the branch — without it
+// the loadable filter would be exercised only against TypeScript matches, and a filter accidentally
+// narrowed to TypeScript would drop every built-in rule with no failing test.
+export default {
+  name: 'pattern-js-ts',
+  pattern: './globbed-js/**/*.rule.mjs',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-none.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-none.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: a pattern that matches files and keeps none of them. Every match in `nonmodules/` is a
+// declaration or a data file, so the loadable filter drops the lot — the case that must fail loudly
+// instead of returning zero rules and passing.
+export default {
+  name: 'pattern-none-ts',
+  pattern: './nonmodules/**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-ts.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-ts.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: a `**/*.ts` pattern — the shape that makes the declaration-file filter mandatory rather
+// than nice to have. It matches `globbed/types.d.ts`, which `resolveUserModule` declines by design,
+// so without the filter the whole rule set fails on a file that plainly exists.
+export default {
+  name: 'pattern-ts-all-ts',
+  pattern: './globbed/**/*.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-with-profiles.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-with-profiles.ruleset.ts
@@ -1,0 +1,14 @@
+// Fixture: a rule set that has BOTH a `pattern` and `profiles`. The glob loop forwards
+// `profileConfig` into its recursion, so a profile override must reach a globbed rule — stated as a
+// requirement in the story's Dev Notes and otherwise untested, because every other profile fixture
+// uses an inline `rules` array.
+export default {
+  name: 'pattern-with-profiles-ts',
+  pattern: './globbed/**/*.rule.ts',
+  profiles: {
+    recommended: {
+      'globbed-ts-a': 'hint',
+    },
+    strict: {},
+  },
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: the `pattern` branch of `loadRuleSet` — the branch that had no test coverage at all
+// before this story. The glob is resolved against this file's own directory, so every match is
+// re-entered through `loadRules` and must load as TypeScript.
+export default {
+  name: 'pattern-ts',
+  pattern: './globbed/**/*.rule.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/with-profiles.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/with-profiles.ruleset.ts
@@ -1,0 +1,33 @@
+// Fixture: the TypeScript twin of `rule-sets/with-profiles.mjs`. Two inline rules with distinct
+// shipped defaults let a test observe the rule set's `profiles` override applied BEFORE the user's
+// `rules:{}` config — the ordering `applyProfileThenConfig` exists to guarantee.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule, type Rule } from '@thymian/core';
+
+const ruleA: Rule = httpRule('profile-ts-a')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();
+
+const ruleB: Rule = httpRule('profile-ts-b')
+  .severity('warn')
+  .type('static', 'test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();
+
+export default {
+  name: 'with-profiles-ts',
+  rules: [ruleA, ruleB],
+  profiles: {
+    recommended: {
+      'profile-ts-a': 'hint',
+      'profile-ts-b': { type: ['analytics', 'test'] },
+    },
+    strict: {},
+  },
+};

--- a/packages/core/test/rules/fixtures/rules-ts/cts.rule.cts
+++ b/packages/core/test/rules/fixtures/rules-ts/cts.rule.cts
@@ -1,0 +1,16 @@
+// Fixture: explicit CommonJS TypeScript extension, using `export default` — the shape this seam
+// supports. `module.exports =` in a `.cts` file is a documented limitation of the seam (jiti's
+// interop cannot tell it apart from a named-only module), not a bug in this loader.
+import { constant, httpRule } from '@thymian/core';
+
+interface Marker {
+  readonly name: string;
+}
+
+const marker: Marker = { name: 'cts-ts' };
+
+export default httpRule(marker.name)
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/enum.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/enum.rule.ts
@@ -1,0 +1,20 @@
+// Fixture: a real TypeScript `enum`. This is the reproduction from the epic — an enum emits a
+// runtime object, so Node's own type stripping rejects the file outright with
+// ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX and nothing short of a real transform can load it.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+enum Severity {
+  Error = 'error',
+  Warn = 'warn',
+}
+
+export default httpRule('enum-ts')
+  .severity(Severity.Error)
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/helper.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/helper.ts
@@ -1,0 +1,8 @@
+// Fixture: the second half of a rule split across files. Imported once without an extension and
+// once as `./helper.js` (the NodeNext spelling), which are the two shapes Node's loader cannot
+// resolve to a `.ts` file on disk.
+export const helperType = ['test', 'analytics'] as const;
+
+export function helperName(suffix: string): string {
+  return `split-${suffix}`;
+}

--- a/packages/core/test/rules/fixtures/rules-ts/mts.rule.mts
+++ b/packages/core/test/rules/fixtures/rules-ts/mts.rule.mts
@@ -1,0 +1,14 @@
+// Fixture: explicit ESM TypeScript extension.
+import { constant, httpRule } from '@thymian/core';
+
+interface Marker {
+  readonly name: string;
+}
+
+const marker: Marker = { name: 'mts-ts' };
+
+export default httpRule(marker.name)
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/never-runs.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/never-runs.rule.ts
@@ -1,0 +1,22 @@
+// Fixture: the TypeScript twin of `rules/never-runs.rule.mjs` — a hand-constructed rule object that
+// declares an executable type and has no execution function. It exists to reach
+// `assertRuleExecutionInvariant` through the jiti path, which is the only way to observe the source
+// string that `(loaded from …)` prints. No `@thymian/core` import: the builder would refuse to
+// construct this shape.
+interface Meta {
+  readonly name: string;
+  readonly severity: string;
+  readonly type: readonly string[];
+  readonly tags: readonly string[];
+  readonly options: Record<string, never>;
+}
+
+const meta: Meta = {
+  name: 'never-runs-ts',
+  severity: 'error',
+  type: ['static'],
+  tags: [],
+  options: {},
+};
+
+export default { meta };

--- a/packages/core/test/rules/fixtures/rules-ts/no-default.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/no-default.rule.ts
@@ -1,0 +1,14 @@
+// Fixture: a TypeScript module with named exports only. Drives the "does not use default export"
+// message, which now names the RESOLVED path rather than the specifier the user typed.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export const rule = httpRule('no-default-ts')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/simple.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/simple.rule.ts
@@ -1,0 +1,21 @@
+// Fixture: the plainest TypeScript rule there is — an `interface` and a type annotation, so the
+// file is not valid JavaScript and must go through jiti. Loaded both with and without its
+// extension, which is how the extensionless reproduction is exercised.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+interface Marker {
+  readonly name: string;
+}
+
+const marker: Marker = { name: 'simple-ts' };
+
+export default httpRule(marker.name)
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/split-extensionless.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/split-extensionless.rule.ts
@@ -1,0 +1,16 @@
+// Fixture: imports `./helper` with no extension. Native ESM answers ERR_MODULE_NOT_FOUND; jiti's
+// extension guessing finds `helper.ts`.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+import { helperName, helperType } from './helper';
+
+export default httpRule(helperName('extensionless'))
+  .severity('error')
+  .type(...helperType)
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rules-ts/split-nodenext.rule.ts
+++ b/packages/core/test/rules/fixtures/rules-ts/split-nodenext.rule.ts
@@ -1,0 +1,17 @@
+// Fixture: imports `./helper.js` while only `helper.ts` exists — the spelling
+// `verbatimModuleSyntax` + NodeNext mandates in TypeScript source, and the one that makes native
+// ESM answer ERR_MODULE_NOT_FOUND because the `.js` file is never emitted.
+// A test fixture is loaded as a USER module, so it imports Thymian by its public package
+// name exactly as a real user rule does — the shape under test. The boundary rule guards against
+// core PRODUCTION code importing core by name (a circular build dependency); a fixture that is
+// never compiled into the package is precisely the exception.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+import { helperName, helperType } from './helper.js';
+
+export default httpRule(helperName('nodenext'))
+  .severity('error')
+  .type(...helperType)
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -1,0 +1,266 @@
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadRules } from '../../src/rules/rule-loader.js';
+import { ThymianBaseError } from '../../src/thymian.error.js';
+
+// Deliberately a separate file from `load-rules.test.ts`. That file is the JavaScript-path
+// regression baseline: every fixture it loads is `.mjs`, and it must keep passing UNMODIFIED,
+// because a changed assertion there means the JavaScript path moved. Everything TypeScript lives
+// here instead.
+
+const rulesTs = join(import.meta.dirname, 'fixtures', 'rules-ts');
+const ruleSetsTs = join(import.meta.dirname, 'fixtures', 'rule-sets-ts');
+
+function ruleNames(rules: Awaited<ReturnType<typeof loadRules>>): string[] {
+  return rules.map((rule) => rule.meta.name);
+}
+
+function findRule(
+  rules: Awaited<ReturnType<typeof loadRules>>,
+  name: string,
+): Awaited<ReturnType<typeof loadRules>>[number] | undefined {
+  return rules.find((rule) => rule.meta.name === name);
+}
+
+describe('load rules from TypeScript sources', () => {
+  // One test per reproduction the epic recorded as broken. Each is named after the failure it
+  // used to produce, so a regression points straight back at the shape that caused it.
+  describe('the four failing reproductions', () => {
+    it('loads a rule that uses a TypeScript enum (was ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX)', async () => {
+      const rules = await loadRules(join(rulesTs, 'enum.rule.ts'));
+
+      expect(ruleNames(rules)).toEqual(['enum-ts']);
+      expect(rules[0]?.meta.severity).toBe('error');
+    });
+
+    it('loads an extensionless specifier (was RuleLoadError: Cannot resolve rule source)', async () => {
+      // The specifier carries no extension and the file on disk is `simple.rule.ts`. Resolution
+      // therefore depends on the seam's cwd anchoring plus jiti's extension guessing: the relative
+      // specifier becomes `<cwd>/simple.rule` before any resolver sees it, `require.resolve` misses
+      // (it tries `.js`/`.json`/`.node`), and jiti finds the `.ts` file.
+      const rules = await loadRules('./simple.rule', () => true, {}, rulesTs);
+
+      expect(ruleNames(rules)).toEqual(['simple-ts']);
+    });
+
+    it('loads a rule importing "./helper" with no extension (was ERR_MODULE_NOT_FOUND)', async () => {
+      const rules = await loadRules(
+        join(rulesTs, 'split-extensionless.rule.ts'),
+      );
+
+      expect(ruleNames(rules)).toEqual(['split-extensionless']);
+      // The type array comes from the imported helper, so a rule that loaded but got an empty
+      // namespace back would not survive `assertRuleTypeDeclaration`.
+      expect(rules[0]?.meta.type).toEqual(['test', 'analytics']);
+    });
+
+    it('loads a rule importing "./helper.js" with only helper.ts on disk (was ERR_MODULE_NOT_FOUND)', async () => {
+      const rules = await loadRules(join(rulesTs, 'split-nodenext.rule.ts'));
+
+      expect(ruleNames(rules)).toEqual(['split-nodenext']);
+      expect(rules[0]?.meta.type).toEqual(['test', 'analytics']);
+    });
+  });
+
+  describe('TypeScript extensions', () => {
+    it('loads a .ts rule', async () => {
+      const rules = await loadRules(join(rulesTs, 'simple.rule.ts'));
+
+      expect(ruleNames(rules)).toEqual(['simple-ts']);
+    });
+
+    it('loads a .mts rule', async () => {
+      const rules = await loadRules(join(rulesTs, 'mts.rule.mts'));
+
+      expect(ruleNames(rules)).toEqual(['mts-ts']);
+    });
+
+    it('loads a .cts rule', async () => {
+      const rules = await loadRules(join(rulesTs, 'cts.rule.cts'));
+
+      expect(ruleNames(rules)).toEqual(['cts-ts']);
+    });
+  });
+
+  describe('error messages', () => {
+    it('reports an unresolvable rule source with the specifier the user typed', async () => {
+      await expect(
+        loadRules('./does-not-exist.rule', () => true, {}, rulesTs),
+      ).rejects.toThrow(
+        /Cannot resolve rule source \.\/does-not-exist\.rule\./,
+      );
+    });
+
+    it('reports a missing default export naming the resolved path', async () => {
+      await expect(
+        loadRules(join(rulesTs, 'no-default.rule.ts')),
+      ).rejects.toThrow(
+        /Rule or rule set at .*no-default\.rule\.ts does not use default export\./,
+      );
+    });
+
+    it('names the resolved path even when it differs from the specifier', async () => {
+      // The discriminator for the amended message: the specifier is extensionless, so `.rule.ts`
+      // can only appear in the message if the RESOLVED path is what is being named. The old
+      // locally computed `location` would have printed `…/no-default.rule` here.
+      await expect(
+        loadRules('./no-default.rule', () => true, {}, rulesTs),
+      ).rejects.toThrow(
+        /Rule or rule set at .*no-default\.rule\.ts does not use default export\./,
+      );
+    });
+
+    it('suggests only the export shape that actually works for TypeScript', async () => {
+      // `module.exports = …` in a `.ts`/`.cts` file yields a namespace with no `default` key that
+      // jiti's interop cannot tell apart from a named-only module, so the seam cannot honour it.
+      // Suggesting it would tell the user to do something that provably fails.
+      const error = await loadRules(join(rulesTs, 'no-default.rule.ts')).then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+
+      expect(error).toBeInstanceOf(ThymianBaseError);
+      expect((error as ThymianBaseError).options.suggestions).toEqual([
+        'Use "export default" to export your rule (set), or "module.exports =" in a CommonJS JavaScript file.',
+        'A TypeScript source must use "export default" — "module.exports =" there produces a namespace with no default export, indistinguishable from a module with only named exports.',
+      ]);
+    });
+  });
+
+  describe('rule sets authored in TypeScript', () => {
+    it('loads a rule set with an inline rules array', async () => {
+      const rules = await loadRules(join(ruleSetsTs, 'inline.ruleset.ts'));
+
+      expect(ruleNames(rules)).toEqual(['inline-ts-a', 'inline-ts-b']);
+    });
+
+    it('applies a per-rule config override to a TypeScript rule', async () => {
+      const rules = await loadRules(
+        join(rulesTs, 'simple.rule.ts'),
+        () => true,
+        { 'simple-ts': 'hint' },
+      );
+
+      expect(rules[0]?.meta.severity).toBe('hint');
+    });
+
+    it('applies the rule set profile before the user rules config', async () => {
+      const ruleSetPath = join(ruleSetsTs, 'with-profiles.ruleset.ts');
+
+      const rules = await loadRules(
+        ruleSetPath,
+        () => true,
+        {},
+        process.cwd(),
+        { [ruleSetPath]: 'recommended' },
+      );
+
+      // recommended demotes profile-ts-a error -> hint and narrows profile-ts-b's type to drop
+      // `static`.
+      expect(findRule(rules, 'profile-ts-a')?.meta.severity).toBe('hint');
+      expect(findRule(rules, 'profile-ts-b')?.meta.type).toEqual([
+        'analytics',
+        'test',
+      ]);
+    });
+
+    it('lets the user rules config win over a TypeScript rule set profile', async () => {
+      const ruleSetPath = join(ruleSetsTs, 'with-profiles.ruleset.ts');
+
+      const rules = await loadRules(
+        ruleSetPath,
+        () => true,
+        { 'profile-ts-a': 'error' },
+        process.cwd(),
+        { [ruleSetPath]: 'recommended' },
+      );
+
+      expect(findRule(rules, 'profile-ts-a')?.meta.severity).toBe('error');
+    });
+  });
+
+  describe('rule set pattern globs', () => {
+    // First coverage of `loadRuleSet`'s glob branch at all — both pre-existing rule-set fixtures
+    // use an inline `rules` array.
+    it('loads every TypeScript match, in deterministic order', async () => {
+      const rules = await loadRules(join(ruleSetsTs, 'pattern.ruleset.ts'));
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
+    });
+
+    it('skips a declaration file matched by the glob, without loading it and without throwing', async () => {
+      // `./globbed/**/*.ts` matches `types.d.ts` alongside the two rules. `resolveUserModule`
+      // declines a `.d.ts` by design, so the filter is what keeps this from failing the whole
+      // rule set — and a skipped file is not an error, so nothing is reported either.
+      const rules = await loadRules(join(ruleSetsTs, 'pattern-ts.ruleset.ts'));
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
+    });
+
+    it('skips every non-module match of a wide-open glob', async () => {
+      // `./globbed/**/*` sweeps up `types.d.ts`, `rules.json` and `README.md`. All three plainly
+      // exist, so before the filter the whole rule set died with `Cannot resolve rule source`
+      // naming a file the user never meant to load.
+      const rules = await loadRules(join(ruleSetsTs, 'pattern-all.ruleset.ts'));
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
+    });
+  });
+
+  describe('lazy jiti import', () => {
+    let jitiFactoryCalls = 0;
+
+    beforeEach(() => {
+      jitiFactoryCalls = 0;
+      // The seam memoises its jiti instance in a module-level variable, so the module registry has
+      // to be reset around each assertion — a stale memo is the most likely way the
+      // "never imported" case passes for the wrong reason.
+      vi.resetModules();
+      vi.doMock('jiti', async () => {
+        jitiFactoryCalls += 1;
+
+        return await vi.importActual<typeof import('jiti')>('jiti');
+      });
+    });
+
+    afterEach(() => {
+      vi.doUnmock('jiti');
+      vi.resetModules();
+    });
+
+    it('never instantiates jiti for a JavaScript-only load', async () => {
+      const { loadRules: freshLoadRules } =
+        await import('../../src/rules/rule-loader.js');
+
+      // The 182 built-in rules, loaded as a package, plus a local `.mjs` fixture. This is the
+      // "no measurable cold-start regression" criterion, asserted as a fact instead of a
+      // wall-clock measurement.
+      await freshLoadRules('@thymian/rules-rfc-9110');
+      await freshLoadRules(
+        join(import.meta.dirname, 'fixtures', 'rules', 'a.rule.mjs'),
+      );
+
+      expect(jitiFactoryCalls).toBe(0);
+    }, 15_000);
+
+    it('instantiates jiti exactly once across two TypeScript loads', async () => {
+      const { loadRules: freshLoadRules } =
+        await import('../../src/rules/rule-loader.js');
+
+      // Deliberately the `enum` fixture. Vitest transforms a dynamic `import()` of a `.ts` file
+      // through vite, so the reproduction tests above would keep passing even if this loader were
+      // reverted to a native `await import()` — they prove jiti loads the file correctly, not that
+      // jiti is what loads it. This assertion is the one that pins the dispatch: an enum fixture
+      // that never reaches jiti is a file Node itself cannot execute.
+      await freshLoadRules(join(rulesTs, 'enum.rule.ts'));
+
+      expect(jitiFactoryCalls).toBe(1);
+
+      await freshLoadRules(join(rulesTs, 'mts.rule.mts'));
+
+      expect(jitiFactoryCalls).toBe(1);
+    });
+  });
+});

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -92,6 +94,35 @@ describe('load rules from TypeScript sources', () => {
         /Cannot resolve rule source \.\/does-not-exist\.rule\./,
       );
     });
+
+    it.each([
+      ['rules.yaml', 'only JavaScript and TypeScript modules can be loaded'],
+      ['types.d.ts', 'a TypeScript declaration file contains no runtime code'],
+    ])(
+      'says why %s cannot be loaded instead of calling it unresolvable',
+      async (fileName, reason) => {
+        // The file is RIGHT THERE. While the seam answered `string | undefined`, this reported
+        // `Cannot resolve rule source ./rules.yaml.` — telling the user a file they are looking
+        // at cannot be found, because the sentence `unloadableReason` had already produced was
+        // discarded at the seam boundary. The specifier stays in the message either way; only
+        // the verb and the explanation change.
+        const cwd = await mkdtemp(join(tmpdir(), 'thymian-rule-reason-'));
+
+        try {
+          await writeFile(join(cwd, fileName), 'stub\n');
+
+          await expect(
+            loadRules(`./${fileName}`, () => true, {}, cwd),
+          ).rejects.toThrow(
+            new RegExp(
+              `Cannot load rule source \\./${fileName.replaceAll('.', '\\.')}: ${reason}\\.`,
+            ),
+          );
+        } finally {
+          await rm(cwd, { recursive: true, force: true });
+        }
+      },
+    );
 
     it('reports a missing default export naming the resolved path', async () => {
       await expect(

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -108,7 +108,66 @@ describe('load rules from TypeScript sources', () => {
       await expect(
         loadRules('./no-default.rule', () => true, {}, rulesTs),
       ).rejects.toThrow(
-        /Rule or rule set at .*no-default\.rule\.ts does not use default export\./,
+        /Rule or rule set at \.\/no-default\.rule \(.*no-default\.rule\.ts\) does not use default export\./,
+      );
+    });
+
+    it('keeps the specifier alongside the resolved path for a cwd-fallback specifier', async () => {
+      // AC2 unfreezes TWO shapes and this is the second one: a BARE specifier that resolves through
+      // `<cwd>/<specifier>` because nothing is installed under that name. It takes a different
+      // branch of the seam than the relative case above, and it is the shape whose old locally
+      // computed `location` was capable of naming a file that was never loaded.
+      await expect(
+        loadRules(
+          'rules-ts/no-default.rule.ts',
+          () => true,
+          {},
+          join(import.meta.dirname, 'fixtures'),
+        ),
+      ).rejects.toThrow(
+        /Rule or rule set at rules-ts\/no-default\.rule\.ts \(.*no-default\.rule\.ts\) does not use default export\./,
+      );
+    });
+
+    it('loads a bare specifier that resolves through the cwd fallback', async () => {
+      const rules = await loadRules(
+        'rules-ts/simple.rule.ts',
+        () => true,
+        {},
+        join(import.meta.dirname, 'fixtures'),
+      );
+
+      expect(ruleNames(rules)).toEqual(['simple-ts']);
+    });
+
+    it('names the specifier the user typed alongside the path that was loaded', async () => {
+      // Same mechanism as a bare PACKAGE specifier, which is the case that motivated this: a package
+      // resolves to a deep `dist/` path nobody typed, and naming only that lost the identity from
+      // the user's config. Exercised here with a cwd-fallback specifier because it needs no
+      // installed fixture package; `describeRuleSource` does not distinguish the two.
+      const error = await loadRules(
+        'rules-ts/never-runs.rule.ts',
+        () => true,
+        {},
+        join(import.meta.dirname, 'fixtures'),
+      ).then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+
+      expect((error as Error).message).toMatch(
+        /\(loaded from rules-ts\/never-runs\.rule\.ts \(.*never-runs\.rule\.ts\)\)/,
+      );
+    });
+
+    it('reports an execution-invariant violation for a TypeScript rule, naming the resolved path', async () => {
+      // Reaches `assertRuleExecutionInvariant` through the jiti path. Without a TypeScript fixture
+      // that actually violates an invariant, the `source` argument those two helpers receive is
+      // never observed, and swapping it back would leave the whole suite green.
+      await expect(
+        loadRules(join(rulesTs, 'never-runs.rule.ts')),
+      ).rejects.toThrow(
+        /Rule "never-runs-ts" has no execution function for declared type\(s\): static\..*never-runs\.rule\.ts/,
       );
     });
 
@@ -182,8 +241,11 @@ describe('load rules from TypeScript sources', () => {
   });
 
   describe('rule set pattern globs', () => {
-    // First coverage of `loadRuleSet`'s glob branch at all — both pre-existing rule-set fixtures
-    // use an inline `rules` array.
+    // First DIRECT coverage of `loadRuleSet`'s glob branch: both pre-existing rule-set fixtures in
+    // this package use an inline `rules` array. The branch itself was never uncovered — both shipped
+    // rule packages reach their rules through it (`pattern: 'rules/**/*.rule.js'`), exercised
+    // cross-package by `packages/rules-rfc-9110/src/profiles.test.ts`. That also means this filter
+    // sits on the JavaScript path, which is why `loads every JavaScript match` below exists.
     it('loads every TypeScript match, in deterministic order', async () => {
       const rules = await loadRules(join(ruleSetsTs, 'pattern.ruleset.ts'));
 
@@ -197,6 +259,85 @@ describe('load rules from TypeScript sources', () => {
       const rules = await loadRules(join(ruleSetsTs, 'pattern-ts.ruleset.ts'));
 
       expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
+    });
+
+    it('loads every JavaScript match, the shape both shipped rule packages use', async () => {
+      // `pattern: 'rules/**/*.rule.js'` is what `rules-rfc-9110` and
+      // `rules-api-description-validation` ship, so this branch carries every built-in rule. A
+      // filter accidentally narrowed to TypeScript would drop all of them silently; nothing else in
+      // this package would notice.
+      const rules = await loadRules(join(ruleSetsTs, 'pattern-js.ruleset.ts'));
+
+      expect(ruleNames(rules)).toEqual(['globbed-js-a', 'globbed-js-b']);
+    });
+
+    it('loads every glob of a string[] pattern', async () => {
+      // The loop handles an array explicitly and nothing covered it. Mixes a TypeScript glob with a
+      // JavaScript one so both dispatch branches run inside one rule set.
+      const rules = await loadRules(
+        join(ruleSetsTs, 'pattern-array.ruleset.ts'),
+      );
+
+      expect(ruleNames(rules)).toEqual([
+        'globbed-ts-a',
+        'globbed-ts-b',
+        'globbed-js-a',
+        'globbed-js-b',
+      ]);
+    });
+
+    it('applies the rule set profile to a globbed rule', async () => {
+      // The glob loop forwards `profileConfig` into its recursion. Every other profile fixture uses
+      // an inline `rules` array, so this is the only test that proves a profile reaches a rule
+      // loaded through the pattern branch.
+      const ruleSetPath = join(ruleSetsTs, 'pattern-with-profiles.ruleset.ts');
+
+      const rules = await loadRules(
+        ruleSetPath,
+        () => true,
+        {},
+        process.cwd(),
+        { [ruleSetPath]: 'recommended' },
+      );
+
+      expect(findRule(rules, 'globbed-ts-a')?.meta.severity).toBe('hint');
+      expect(findRule(rules, 'globbed-ts-b')?.meta.severity).toBe('error');
+    });
+
+    it('lets the user rules config win over a globbed profile override', async () => {
+      const ruleSetPath = join(ruleSetsTs, 'pattern-with-profiles.ruleset.ts');
+
+      const rules = await loadRules(
+        ruleSetPath,
+        () => true,
+        { 'globbed-ts-a': 'error' },
+        process.cwd(),
+        { [ruleSetPath]: 'recommended' },
+      );
+
+      expect(findRule(rules, 'globbed-ts-a')?.meta.severity).toBe('error');
+    });
+
+    it('throws when a pattern matches files but keeps none of them', async () => {
+      // A skipped file is silent by design, but a pattern that kept NOTHING is a mistake every
+      // time — a typo'd extension, a directory of declarations. Silent, it returns zero rules and
+      // the run passes having validated nothing.
+      await expect(
+        loadRules(join(ruleSetsTs, 'pattern-none.ruleset.ts')),
+      ).rejects.toThrow(
+        /Rule set "pattern-none-ts" pattern \.\/nonmodules\/\*\*\/\* matched 2 file\(s\), none of which can be loaded as a rule\./,
+      );
+    });
+
+    it('does not throw when a rule filter excludes every rule it loaded', async () => {
+      // The counterpart to the test above, and why the guard counts FILES rather than rules: a
+      // filter legitimately rejecting everything must stay a clean empty result.
+      const rules = await loadRules(
+        join(ruleSetsTs, 'pattern.ruleset.ts'),
+        () => false,
+      );
+
+      expect(rules).toEqual([]);
     });
 
     it('skips every non-module match of a wide-open glob', async () => {
@@ -234,13 +375,19 @@ describe('load rules from TypeScript sources', () => {
       const { loadRules: freshLoadRules } =
         await import('../../src/rules/rule-loader.js');
 
-      // The 182 built-in rules, loaded as a package, plus a local `.mjs` fixture. This is the
+      // Every built-in rule, loaded as a package, plus a local `.mjs` fixture. This is the
       // "no measurable cold-start regression" criterion, asserted as a fact instead of a
       // wall-clock measurement.
-      await freshLoadRules('@thymian/rules-rfc-9110');
-      await freshLoadRules(
+      const builtIns = await freshLoadRules('@thymian/rules-rfc-9110');
+      const local = await freshLoadRules(
         join(import.meta.dirname, 'fixtures', 'rules', 'a.rule.mjs'),
       );
+
+      // Assert what loaded, not just that nothing threw. This package reaches its rules through
+      // the glob branch this story modified, so a filter narrowed to TypeScript would return an
+      // empty array here and the jiti assertion below would still pass.
+      expect(builtIns.length).toBeGreaterThan(100);
+      expect(ruleNames(local)).toEqual(['a']);
 
       expect(jitiFactoryCalls).toBe(0);
     }, 15_000);
@@ -260,6 +407,31 @@ describe('load rules from TypeScript sources', () => {
 
       await freshLoadRules(join(rulesTs, 'mts.rule.mts'));
 
+      expect(jitiFactoryCalls).toBe(1);
+    });
+
+    it('loads both split-file reproductions through jiti, not through the test runner', async () => {
+      // The reproduction tests above cannot prove this on their own: vitest transforms a dynamic
+      // `import()` of a `.ts` file, and vite resolves `./helper` and `./helper.js` itself, so both
+      // stayed green on the unfixed loader. Asserting that the rule loaded AND that jiti is what
+      // loaded it pins the mechanism the reproductions actually depend on — jiti's extension
+      // guessing for an import made INSIDE a user module.
+      const { loadRules: freshLoadRules } =
+        await import('../../src/rules/rule-loader.js');
+
+      const extensionless = await freshLoadRules(
+        join(rulesTs, 'split-extensionless.rule.ts'),
+      );
+      const nodenext = await freshLoadRules(
+        join(rulesTs, 'split-nodenext.rule.ts'),
+      );
+
+      expect(extensionless.map((rule) => rule.meta.name)).toEqual([
+        'split-extensionless',
+      ]);
+      expect(nodenext.map((rule) => rule.meta.name)).toEqual([
+        'split-nodenext',
+      ]);
       expect(jitiFactoryCalls).toBe(1);
     });
   });


### PR DESCRIPTION
Rules and rule sets written in TypeScript were not loadable. `loadRules` resolved with
`require.resolve` and imported with a native dynamic `import()`, so the TypeScript that
`thymian generate rule` emits — and that every docs example shows — failed on load. This moves both
steps onto the shared user-module seam from #369.

Four reproductions, each with its own test. Measured against the built `dist/` from outside the
monorepo on Node 26, before and after:

| Reproduction | Before | After |
|---|---|---|
| rule uses a TypeScript `enum` | `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` | loads |
| extensionless `--rule-set ./simple.rule` | `RuleLoadError: Cannot resolve rule source` | loads |
| rule imports `./helper` (no extension) | `ERR_MODULE_NOT_FOUND` | loads |
| rule imports `./helper.js`, `helper.ts` on disk | `ERR_MODULE_NOT_FOUND` | loads |

## The JavaScript path is untouched, and that is asserted

`packages/core/test/rules/load-rules.test.ts` — the JavaScript regression baseline, every fixture
`.mjs` — passes **unmodified**. `rules-rfc-9110` stays green. A lazy-import spy asserts jiti is never
instantiated for a JavaScript-only load, which is how the "no measurable cold-start regression"
criterion is met: as a fact rather than a flaky wall-clock assertion in CI.

## Deliberate behaviour changes

**Three resolution messages, not two.** The seam distinguishes "not found" from "found but refused
for what it is", so a `.d.ts`, `.json` or `.tsx` specifier now says *why* instead of claiming a file
you are looking at cannot be found:

```
./nope.rule    -> Cannot resolve rule source ./nope.rule.
./rules.json   -> Cannot load rule source ./rules.json: only JavaScript and TypeScript modules can be loaded.
./types.d.ts   -> Cannot load rule source ./types.d.ts: a TypeScript declaration file contains no runtime code.
```

**Diagnostics keep the specifier you typed.** The missing-default message names
`input (resolved)` when the two differ, so a package specifier no longer prints only as a deep
install path — `@thymian/rules-rfc-9110` rather than `…/rules-rfc-9110/dist/index.js`. They collapse
to one when the specifier already is the path, so every absolute-path and globbed case is unchanged.

**The export suggestion is scoped.** It no longer offers `module.exports =` unconditionally: in a
`.ts`/`.cts` source that produces a namespace with no `default` key which jiti's interop cannot tell
apart from a named-only module, so the old text told TypeScript authors to do something that
provably fails. It stays offered for CommonJS JavaScript, which `thymian generate rule --cjs` emits.

**A rule-set `pattern` glob no longer dies on a non-module, and no longer passes silently.** Matches
are filtered to the loadable extension set, so `./rules/**/*` stops aborting the whole rule set on a
neighbouring `types.d.ts`, `rules.json` or `README.md`. But a pattern that matched files and kept
**none** of them now throws rather than returning zero rules — a typo'd extension used to produce a
clean pass that validated nothing. The guard counts files, not resulting rules, so a rule filter
legitimately excluding everything stays a clean empty result. `node_modules` is excluded, because a
wide pattern reaching into it would import and execute every dependency module it matched.

## Review

Reviewed adversarially before opening; findings are applied here rather than left for the reviewer.
That pass closed real test gaps — the JavaScript glob path had no asserted rule count, `string[]`
patterns and profiles-through-the-glob were uncovered, and two of the four reproductions passed on
the *unfixed* loader because vitest transforms a dynamic `import()` of a `.ts` file. The lazy-import
spy now pins the `enum` fixture specifically: an enum that never reaches jiti is a file Node itself
cannot execute.

It also corrected three claims that had not been earned — the built-in rule count is 402, not 182;
`loadRuleSet`'s glob branch was already covered cross-package by `rules-rfc-9110`, which means this
filter does sit on the JavaScript path; and the error-reference page never carried the resolved-path
text.

One regression found and deliberately **not** fixed here: a bare specifier equal to a Node builtin
name (`http`, `test`, `url`, …) no longer resolves, because `require.resolve` answers the builtin id
and the `<cwd>/<specifier>` candidate is never tried. The cause is in `load-user-module.ts`, which
this change does not touch, so it is filed rather than patched silently.

## Verification

`nx run core:lint` 0 errors · `nx run core:test` **432 passed** across 35 files · `nx run core:build` ·
`nx affected -t test` 17 projects · `nx e2e e2e-tests` 70 passed across 10 files. The diff is confined
to `packages/core/src/rules/rule-loader.ts` and `packages/core/test/**` — no change to
`load-user-module.ts`, `packages/core/package.json`, `eslint.config.mjs` or `packages/common-cli/`.

## Reviewing this PR

**Stacked on #369** and based on `story/34-1-load-user-module`, so this diff is only this change —
29 files. It cannot merge until #369 does.

The branch history carries each of its three commits more than once: it was rebased onto a moving
base and then merged back, twice. The content is unaffected — the net diff against the base is
byte-for-byte identical to the linear version — and a squash merge flattens it. Read the diff, not
the commit list.

Part of thymianofficial/thymian-internal#628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
