### PR TITLE
fix(core): terminate rule-set glob recursion instead of hanging (#688)

### DIFF
--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -243,6 +243,42 @@ function isLoadableRuleFile(file: string): boolean {
   return !DECLARATION_FILE.test(file) && LOADABLE_RULE_FILE.test(file);
 }
 
+/**
+ * A rule set that is reachable from itself through pattern globs can never finish loading, so it is
+ * reported rather than pursued.
+ *
+ * The seam's own cycle detection cannot see this one. `loadUserModule` tracks an evaluation chain in
+ * `AsyncLocalStorage`, but that store only covers the import itself — by the time this file resumes
+ * after the `await` the store is gone, and the second import of the same rule set is a plain
+ * module-cache hit that is never "in flight". The cycle lives in THIS file's traversal, not in module
+ * evaluation, so it has to be tracked here.
+ *
+ * Shaped after `load-user-module.ts`'s `cycleError`: one sentence, the closed loop rendered as given.
+ * `ring` is printed verbatim, so callers pass a loop that already returns to its first entry.
+ */
+function ruleSetCycleError(
+  canonical: string,
+  ring: readonly string[],
+): ThymianBaseError {
+  return new ThymianBaseError(
+    `Rule set at ${canonical} is reachable from itself, so the rule-set cycle ` +
+      `${ring.join(' -> ')} can never finish loading.`,
+    {
+      suggestions: [
+        'Narrow the `pattern` of one rule set in the cycle so it stops matching the other.',
+        'Point each rule set at a directory of rules rather than at a directory holding rule sets.',
+        // Every entry in `ring` is a canonical, symlink-resolved path, so two different-looking
+        // paths can still be the SAME rule set. Named explicitly: the two "pattern" suggestions
+        // above assume the loop is a pattern-authoring mistake, which is not true when a symlink
+        // is what closes it.
+        'If two entries above resolve through a symlink, remove the symlink or point it elsewhere.',
+      ],
+      name: 'RuleLoadError',
+      ref: 'https://thymian.dev/references/errors/rule-load-error/',
+    },
+  );
+}
+
 async function loadRuleSet(
   ruleSet: RuleSet,
   basePath: string,
@@ -251,6 +287,9 @@ async function loadRuleSet(
   cwd: string,
   ruleProfiles: Record<string, string>,
   profileConfig: RulesConfiguration,
+  // Canonical paths of the rule sets currently being loaded, innermost last, INCLUDING this one.
+  // A stack rather than a cumulative visited set: see `loadRulesInChain`.
+  ruleSetChain: readonly string[],
 ): Promise<Rule[]> {
   if (ruleSet.rules) {
     const source = `rule set "${ruleSet.name}"`;
@@ -292,9 +331,29 @@ async function loadRuleSet(
       // `node_modules` is excluded because a wide pattern reaching into it would IMPORT and execute
       // every dependency module it matched. Before the loadable-file filter below that failed loudly
       // on the first non-module; with it, the JavaScript files sail through and run.
+      //
+      // The rule set's OWN file is dropped before anything else looks at the list. A pattern as
+      // ordinary as `./**/*` matches the file it is written in, and loading that re-recognises the
+      // same rule set and re-runs the same glob forever — no output, no error, no exit, which for a
+      // linter means a CI job that hangs until the runner times out. Skipping is silent because the
+      // pattern is legitimate: the user meant "the rules beside me", and a rule set is not one of
+      // its own rules.
+      //
+      // Removed HERE, before `matched` is formed, so it never reaches the "matched files but kept
+      // none" check below. Filtered afterwards, a rule set alone in its directory would die on
+      // `none of which can be loaded as a rule` — naming a file that loads perfectly well and that
+      // the user cannot act on. A pattern that matched only the rule set itself simply yields no
+      // rules; one that also swept up a `README.md` still fails on the `README.md`.
+      //
+      // Raw string equality is only trustworthy because `basePath` is always the seam's
+      // `realpathSync.native`-canonicalised path (see the two call sites below that pass
+      // `resolved.path`); `dirname` inherits that same canonicalisation. A future call site that
+      // passed a non-canonical `basePath` would silently break this skip and reopen the #688 hang.
       const matched = (
         await glob(pattern, { cwd: dirname, ignore: ['**/node_modules/**'] })
-      ).sort();
+      )
+        .filter((file) => path.join(dirname, file) !== basePath)
+        .sort();
 
       // Drop what cannot be a module at all. A pattern is a plain glob, so `**/*.ts` picks up a
       // neighbouring `types.d.ts` and `**/*` also picks up a `rules.json` or a `README.md`; the seam
@@ -326,13 +385,14 @@ async function loadRuleSet(
 
       for (const file of files) {
         rules.push(
-          ...(await loadRules(
+          ...(await loadRulesInChain(
             path.join(dirname, file),
             ruleFilter,
             options,
             cwd,
             ruleProfiles,
             profileConfig,
+            ruleSetChain,
           )),
         );
       }
@@ -342,16 +402,32 @@ async function loadRuleSet(
   return rules;
 }
 
-export async function loadRules(
+/**
+ * Loads rules, carrying the chain of rule sets currently being loaded.
+ *
+ * The chain is a STACK, not a cumulative visited set: it is pushed on entry to a rule set and
+ * implicitly popped on return, so it describes the current ancestry and nothing else. A set that
+ * accumulated across sibling branches would refuse the SECOND, legitimate load of a rule set that
+ * two different parents both point at — a diamond is not a cycle. Loading such a shared rule set
+ * once per path is the behaviour that already existed and is deliberately preserved.
+ *
+ * Termination rests on this chain, not on the self-match skip in `loadRuleSet`: every step of the
+ * recursion resolves through the seam to a canonical path, so any repeat is caught here. The skip is
+ * the fast path that keeps an ordinary `./**\/*` silent; anything it misses — a symlink beside the
+ * rule set pointing back at it — falls through to a clear error rather than a hang.
+ *
+ * Not exported. `loadRules` is public API with callers across the workspace, so the chain is kept
+ * out of its signature entirely rather than added as a seventh parameter nobody outside this file
+ * should pass.
+ */
+async function loadRulesInChain(
   input: string | string[],
-  ruleFilter: RuleFilter = () => true,
-  options: RulesConfiguration = {},
-  cwd: string = process.cwd(),
-  ruleProfiles: Record<string, string> = {},
-  // The already-resolved profile overrides for the enclosing rule set, threaded
-  // through the pattern-glob recursion. Empty at the top level; a rule set fills
-  // it from its own `profiles` map before recursing into its member rules.
-  profileConfig: RulesConfiguration = {},
+  ruleFilter: RuleFilter,
+  options: RulesConfiguration,
+  cwd: string,
+  ruleProfiles: Record<string, string>,
+  profileConfig: RulesConfiguration,
+  ruleSetChain: readonly string[],
 ): Promise<Rule[]> {
   if (!input || (Array.isArray(input) && input.length === 0)) {
     return [];
@@ -361,7 +437,19 @@ export async function loadRules(
     return (
       await Promise.all(
         input.map((entry) =>
-          loadRules(entry, ruleFilter, options, cwd, ruleProfiles),
+          // Threads `profileConfig` as well as the chain. It was dropped here before, which was
+          // inert only because this branch is unreachable from the glob recursion — it always ran
+          // with the top-level empty map. Passing it keeps the fan-out honest for a caller that
+          // hands an array and a profile map together.
+          loadRulesInChain(
+            entry,
+            ruleFilter,
+            options,
+            cwd,
+            ruleProfiles,
+            profileConfig,
+            ruleSetChain,
+          ),
         ),
       )
     ).flat();
@@ -436,6 +524,23 @@ export async function loadRules(
   }
 
   if (isRuleSet(ruleOrRuleSet)) {
+    // Keyed on the canonical path the seam resolved, never on `input`: the same rule set is reached
+    // as a bare specifier at the top level and as a joined glob match one level down, so comparing
+    // what the user wrote would miss every cycle. `resolveUserModule` has already run the path
+    // through `realpathSync.native`, which is what makes equality here trustworthy.
+    const cycleStart = ruleSetChain.indexOf(resolved.path);
+
+    if (cycleStart !== -1) {
+      // Sliced from the repeat, not the whole chain: an ancestor entered before the cycle began
+      // (X in X -> A -> B -> C -> B) is not part of the loop, and `ruleSetCycleError` promises its
+      // `ring` closes — `ring[0]` equal to `ring[last]`. Reporting the full chain here would name X
+      // and A as "in the cycle" and point the user at the wrong rule set to fix.
+      throw ruleSetCycleError(resolved.path, [
+        ...ruleSetChain.slice(cycleStart),
+        resolved.path,
+      ]);
+    }
+
     const profileName = ruleProfiles[input] ?? DEFAULT_RULE_PROFILE;
 
     return loadRuleSet(
@@ -446,8 +551,33 @@ export async function loadRules(
       cwd,
       ruleProfiles,
       resolveProfileConfig(ruleOrRuleSet, profileName),
+      [...ruleSetChain, resolved.path],
     );
   }
 
   return [];
+}
+
+export async function loadRules(
+  input: string | string[],
+  ruleFilter: RuleFilter = () => true,
+  options: RulesConfiguration = {},
+  cwd: string = process.cwd(),
+  ruleProfiles: Record<string, string> = {},
+  // The already-resolved profile overrides for the enclosing rule set, threaded
+  // through the pattern-glob recursion. Empty at the top level; a rule set fills
+  // it from its own `profiles` map before recursing into its member rules.
+  profileConfig: RulesConfiguration = {},
+): Promise<Rule[]> {
+  // Seeds the rule-set chain empty. Every default lives here rather than on `loadRulesInChain`, so
+  // the internal recursion cannot silently fall back to one when it forgets to thread a value.
+  return loadRulesInChain(
+    input,
+    ruleFilter,
+    options,
+    cwd,
+    ruleProfiles,
+    profileConfig,
+    [],
+  );
 }

--- a/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/p.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/p.ruleset.ts
@@ -1,0 +1,9 @@
+// Fixture: the entry point, deliberately NOT part of the cycle below it. `p` globs `q`, which
+// globs `r`, which globs back to `q` — the loop is `q -> r -> q`, and `p` is only an ancestor.
+// Regression for a real bug: reporting the FULL traversal chain (`p -> q -> r -> q`) instead of
+// slicing from where the repeat actually starts would misname `p` as part of the cycle and could
+// send the user to fix the wrong rule set.
+export default {
+  name: 'cycle-with-ancestor-p',
+  pattern: './q.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/q.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/q.ruleset.ts
@@ -1,0 +1,5 @@
+// Fixture: half of the actual cycle. Reached only through `p`, an uninvolved ancestor.
+export default {
+  name: 'cycle-with-ancestor-q',
+  pattern: './r.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/r.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/cycle-with-ancestor/r.ruleset.ts
@@ -1,0 +1,6 @@
+// Fixture: the other half of the actual cycle — points back at `q`, not at `p`. The closed loop
+// is `q -> r -> q`; `p` must not appear in the reported ring.
+export default {
+  name: 'cycle-with-ancestor-r',
+  pattern: './q.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/cycle/a.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/cycle/a.ruleset.ts
@@ -1,0 +1,6 @@
+// Fixture: half of an indirect rule-set cycle. Neither file matches itself, so the self-match
+// skip cannot help here — only the ancestry chain terminates this.
+export default {
+  name: 'cycle-a',
+  pattern: './b.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/cycle/b.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/cycle/b.ruleset.ts
@@ -1,0 +1,5 @@
+// Fixture: the other half of the indirect cycle — points straight back at `a.ruleset.ts`.
+export default {
+  name: 'cycle-b',
+  pattern: './a.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/diamond/a.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/diamond/a.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: a diamond, which is NOT a cycle. Both nested rule sets point at the same rule, so a
+// cumulative visited set would refuse the second, legitimate load. The chain is a stack, so both
+// paths complete.
+export default {
+  name: 'diamond-a',
+  pattern: './nested/*.ruleset.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/b.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/b.ruleset.ts
@@ -1,0 +1,5 @@
+// Fixture: one of the two diamond arms reaching the shared rule.
+export default {
+  name: 'diamond-b',
+  pattern: './rules/*.rule.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/c.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/c.ruleset.ts
@@ -1,0 +1,5 @@
+// Fixture: the other diamond arm, reaching the same shared rule as `b.ruleset.ts`.
+export default {
+  name: 'diamond-c',
+  pattern: './rules/*.rule.ts',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/rules/shared.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/diamond/nested/rules/shared.rule.ts
@@ -1,0 +1,10 @@
+// Fixture: a plain rule picked up by a rule-set glob. Loaded as a USER module, so it imports
+// Thymian by its public package name exactly as a real user rule does.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('diamond-shared')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-alone/alone.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-alone/alone.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: a self-globbing rule set that is the ONLY file in its directory. The self-match is
+// removed before the "matched files but kept none" accounting, so this yields no rules rather
+// than dying on `none of which can be loaded as a rule` — a message naming a file that loads fine.
+export default {
+  name: 'self-alone',
+  pattern: './**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-with-nonmodule/NOTES.md
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-with-nonmodule/NOTES.md
@@ -1,0 +1,1 @@
+Not a module. Present so the glob keeps a match after the rule set drops itself.

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-with-nonmodule/set.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-with-nonmodule/set.ruleset.ts
@@ -1,0 +1,6 @@
+// Fixture: self-match removal must not swallow story 34.2's non-module guard. After this file is
+// dropped the glob still holds `NOTES.md`, so the "matched but none loadable" throw still fires.
+export default {
+  name: 'self-with-nonmodule',
+  pattern: './**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/self.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/self.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: the reported hang (#688). `./**/*` matches the file it is written in, so before the
+// self-match skip this rule set loaded itself, recognised itself, and re-globbed forever.
+// The two sibling rules are what the user actually meant by "everything beside me".
+export default {
+  name: 'self-with-siblings',
+  pattern: './**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/x.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/x.rule.ts
@@ -1,0 +1,10 @@
+// Fixture: a plain rule picked up by a rule-set glob. Loaded as a USER module, so it imports
+// Thymian by its public package name exactly as a real user rule does.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('self-sibling-x')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/y.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-set-cycles/self-with-siblings/y.rule.ts
@@ -1,0 +1,10 @@
+// Fixture: a plain rule picked up by a rule-set glob. Loaded as a USER module, so it imports
+// Thymian by its public package name exactly as a real user rule does.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('self-sibling-y')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -465,5 +465,164 @@ describe('load rules from TypeScript sources', () => {
       ]);
       expect(jitiFactoryCalls).toBe(1);
     });
+  });
+});
+
+// Regression cover for #688: a rule set reachable from itself through pattern globs used to recurse
+// without bound — no output, no error, no exit, until a CI runner timed out. Every case that used to
+// hang is wrapped in `settlesWithin`, so a reintroduction fails in seconds with a message naming the
+// bug instead of hanging the suite. (A genuine regression leaves the runaway recursion running until
+// vitest tears the worker down; that is the cost of proving termination at all.)
+describe('rule-set glob recursion (#688)', () => {
+  const cycles = join(import.meta.dirname, 'fixtures', 'rule-set-cycles');
+
+  const TIMED_OUT = Symbol('timed-out');
+
+  async function settlesWithin<T>(work: Promise<T>, ms = 5000): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+
+    try {
+      const outcome = await Promise.race([
+        work,
+        new Promise<typeof TIMED_OUT>((resolve) => {
+          timer = setTimeout(() => resolve(TIMED_OUT), ms);
+        }),
+      ]);
+
+      if (outcome === TIMED_OUT) {
+        throw new Error(
+          `loadRules did not settle within ${ms}ms — the #688 rule-set recursion is back.`,
+        );
+      }
+
+      return outcome;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // Splits the rendered loop back out of the message so the test can prove it CLOSES, rather than
+  // merely asserting some arrow-joined text is present.
+  function ringOf(message: string): string[] {
+    const rendered = message.split('rule-set cycle ')[1];
+
+    return (rendered ?? '')
+      .replace(' can never finish loading.', '')
+      .split(' -> ');
+  }
+
+  it('loads the siblings of a self-matching rule set, skipping itself', async () => {
+    const rules = await settlesWithin(
+      loadRules(join(cycles, 'self-with-siblings', 'self.ruleset.ts')),
+    );
+
+    expect(ruleNames(rules)).toEqual(['self-sibling-x', 'self-sibling-y']);
+  });
+
+  it('returns no rules for a self-matching rule set that is alone in its directory', async () => {
+    // The self-match is removed BEFORE story 34.2's match accounting, so this must not surface as
+    // `matched 1 file(s), none of which can be loaded as a rule` — the one file it matched loads
+    // perfectly well, it is just this rule set itself, and the user could not act on that advice.
+    const rules = await settlesWithin(
+      loadRules(join(cycles, 'self-alone', 'alone.ruleset.ts')),
+    );
+
+    expect(rules).toEqual([]);
+  });
+
+  it("still reports a non-module left in a self-matching rule set's glob", async () => {
+    // Self-match removal must not swallow 34.2's guard: after this rule set drops itself the glob
+    // still holds a `NOTES.md`, and that is still a mistake worth failing on.
+    await expect(
+      settlesWithin(
+        loadRules(join(cycles, 'self-with-nonmodule', 'set.ruleset.ts')),
+      ),
+    ).rejects.toThrow(
+      /matched 1 file\(s\), none of which can be loaded as a rule/,
+    );
+  });
+
+  it('reports an indirect cycle between two rule sets instead of hanging', async () => {
+    const error = await settlesWithin(
+      loadRules(join(cycles, 'cycle', 'a.ruleset.ts')),
+    ).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(ThymianBaseError);
+    expect((error as ThymianBaseError).name).toBe('RuleLoadError');
+    expect((error as Error).message).toContain('is reachable from itself');
+
+    // Neither file matches ITSELF, so only the ancestry chain can catch this one.
+    const ring = ringOf((error as Error).message);
+
+    expect(ring).toHaveLength(3);
+    expect(ring[0]).toBe(ring[2]);
+    expect(ring[0]).toMatch(/cycle\/a\.ruleset\.ts$/);
+    expect(ring[1]).toMatch(/cycle\/b\.ruleset\.ts$/);
+  });
+
+  it('excludes an ancestor outside the cycle from the reported ring', async () => {
+    // `p` globs `q`, which globs `r`, which globs back to `q` — the loop is `q -> r -> q`, and `p`
+    // is only an ancestor. Reporting the whole traversal (`p -> q -> r -> q`) instead of slicing
+    // from the actual repeat would misname `p` as being in the cycle.
+    const error = await settlesWithin(
+      loadRules(join(cycles, 'cycle-with-ancestor', 'p.ruleset.ts')),
+    ).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(ThymianBaseError);
+    expect((error as Error).message).toContain('is reachable from itself');
+
+    const ring = ringOf((error as Error).message);
+
+    expect(ring).toHaveLength(3);
+    expect(ring[0]).toBe(ring[2]);
+    expect(ring[0]).toMatch(/cycle-with-ancestor\/q\.ruleset\.ts$/);
+    expect(ring[1]).toMatch(/cycle-with-ancestor\/r\.ruleset\.ts$/);
+    expect(ring.some((entry) => /\/p\.ruleset\.ts$/.test(entry))).toBe(false);
+  });
+
+  it('loads a rule reached twice through a diamond without reporting a cycle', async () => {
+    // A diamond is not a cycle. This is the case a cumulative visited set would break: the second
+    // arm would find the shared rule already seen and silently contribute nothing.
+    const rules = await settlesWithin(
+      loadRules(join(cycles, 'diamond', 'a.ruleset.ts')),
+    );
+
+    expect(ruleNames(rules)).toEqual(['diamond-shared', 'diamond-shared']);
+  });
+
+  it('reports a symlinked self-reference instead of hanging', async () => {
+    // Path equality cannot see this: the symlink is a different name in the same directory. It
+    // falls through to the chain, which resolves both names to one canonical path — so the
+    // documented degradation is a clear error, never a hang.
+    const dir = await mkdtemp(join(tmpdir(), 'rule-set-symlink-'));
+
+    try {
+      await writeFile(
+        join(dir, 'real.ruleset.ts'),
+        "export default { name: 'symlinked', pattern: './**/*' };\n",
+      );
+      await symlink(
+        join(dir, 'real.ruleset.ts'),
+        join(dir, 'alias.ruleset.ts'),
+      );
+
+      const error = await settlesWithin(
+        loadRules(join(dir, 'real.ruleset.ts')),
+      ).then(
+        () => undefined,
+        (thrown: unknown) => thrown,
+      );
+
+      expect(error).toBeInstanceOf(ThymianBaseError);
+      expect((error as Error).message).toContain('is reachable from itself');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -511,6 +511,21 @@ describe('rule-set glob recursion (#688)', () => {
       .split(' -> ');
   }
 
+  // Checks a ring entry's last two path segments via `node:path`, never a hardcoded `/` regex:
+  // the ring holds real canonical filesystem paths, and on Windows those are backslash-separated,
+  // so a forward-slash regex silently never matches there — including in a `.some(...) === false`
+  // assertion, where a mismatched regex passes for the wrong reason instead of failing.
+  function ringEntryIs(
+    fullPath: string,
+    parentDir: string,
+    fileName: string,
+  ): boolean {
+    return (
+      basename(fullPath) === fileName &&
+      basename(dirname(fullPath)) === parentDir
+    );
+  }
+
   it('loads the siblings of a self-matching rule set, skipping itself', async () => {
     const rules = await settlesWithin(
       loadRules(join(cycles, 'self-with-siblings', 'self.ruleset.ts')),
@@ -559,8 +574,8 @@ describe('rule-set glob recursion (#688)', () => {
 
     expect(ring).toHaveLength(3);
     expect(ring[0]).toBe(ring[2]);
-    expect(ring[0]).toMatch(/cycle\/a\.ruleset\.ts$/);
-    expect(ring[1]).toMatch(/cycle\/b\.ruleset\.ts$/);
+    expect(ringEntryIs(ring[0] ?? '', 'cycle', 'a.ruleset.ts')).toBe(true);
+    expect(ringEntryIs(ring[1] ?? '', 'cycle', 'b.ruleset.ts')).toBe(true);
   });
 
   it('excludes an ancestor outside the cycle from the reported ring', async () => {
@@ -581,9 +596,17 @@ describe('rule-set glob recursion (#688)', () => {
 
     expect(ring).toHaveLength(3);
     expect(ring[0]).toBe(ring[2]);
-    expect(ring[0]).toMatch(/cycle-with-ancestor\/q\.ruleset\.ts$/);
-    expect(ring[1]).toMatch(/cycle-with-ancestor\/r\.ruleset\.ts$/);
-    expect(ring.some((entry) => /\/p\.ruleset\.ts$/.test(entry))).toBe(false);
+    expect(
+      ringEntryIs(ring[0] ?? '', 'cycle-with-ancestor', 'q.ruleset.ts'),
+    ).toBe(true);
+    expect(
+      ringEntryIs(ring[1] ?? '', 'cycle-with-ancestor', 'r.ruleset.ts'),
+    ).toBe(true);
+    expect(
+      ring.some((entry) =>
+        ringEntryIs(entry, 'cycle-with-ancestor', 'p.ruleset.ts'),
+      ),
+    ).toBe(false);
   });
 
   it('loads a rule reached twice through a diamond without reporting a cycle', async () => {


### PR DESCRIPTION
## Summary

`loadRuleSet`'s glob branch recursed into `loadRules` for every match with no self-exclusion and no cycle detection. A rule set whose `pattern` matches its own file — or two rule sets whose patterns match each other — recursed without bound: no output, no error, no exit. Verified to hang past an 8s watchdog on both shapes before this fix, on this branch.

Fixes thymianofficial/thymian-internal#688.

- Drops a rule set's own file from its glob matches, before this story's "none loadable" accounting sees the remainder — so a lone self-globbing rule set returns `[]` instead of misfiring that check.
- Threads an internal chain of enclosing rule-set paths through the recursion so a genuine cycle throws a framed `RuleLoadError` naming the loop, instead of recursing forever. The chain never touches the exported `loadRules` signature.
- Adversarial review (Blind Hunter + Edge Case Hunter) caught a real bug in the fix's own error reporting: the ring was built from the whole traversal chain rather than sliced from the actual repeat, so an ancestor entered before a cycle began was misnamed as part of the loop. Confirmed by a temporary-revert test, then fixed and covered with a dedicated `cycle-with-ancestor` regression fixture.

Based on `story/34-2-rule-loader` rather than `main`, since that branch's own PR rewrites the exact glob-loop hunk this fix touches.

## Test plan

- [x] `nx run core:build` — clean, no TS errors
- [x] `nx run core:lint` — 0 errors (14 pre-existing warnings, none in touched files)
- [x] `nx run core:test` — 439/439 pass
- [x] New regression tests cover: self-match with siblings, lone self-match, self-match plus a non-module, 2-node indirect cycle, 3-node cycle with an excluded ancestor, diamond (not a cycle, proving the chain is a stack not a visited set), symlinked self-reference
- [x] Confirmed the ring-slicing fix actually matters by temporarily reverting it and observing the new ancestor-exclusion test fail