### PR TITLE
fix(core): share realpath-aware unloadableReason between the seam and the rule-set glob filter

### DIFF
--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -232,7 +232,7 @@ const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
  * and a `.d.ts` then imports as an EMPTY module, so the caller reports "does not use default
  * export": the exact confusion the guard exists to prevent.
  */
-function unloadableReason(resolvedPath: string): string | undefined {
+export function unloadableReason(resolvedPath: string): string | undefined {
   if (DECLARATION_FILE.test(resolvedPath)) {
     return 'a TypeScript declaration file contains no runtime code';
   }

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -1,8 +1,13 @@
+import { realpathSync } from 'node:fs';
 import * as path from 'node:path';
 
 import { glob } from 'tinyglobby';
 
-import { loadUserModule, resolveUserModule } from '../load-user-module.js';
+import {
+  loadUserModule,
+  resolveUserModule,
+  unloadableReason,
+} from '../load-user-module.js';
 import { ThymianBaseError } from '../thymian.error.js';
 import { isRecord } from '../utils.js';
 import { validate } from './ajv-validate.js';
@@ -213,37 +218,6 @@ function applyProfileThenConfig(
 }
 
 /**
- * The extensions a globbed rule-set match may have. Character-for-character `LOADABLE_EXTENSION` in
- * `load-user-module.ts`, and case-sensitive for the same reason: the seam normalises a resolved path
- * to its on-disk casing and then tests this same case-sensitive pattern, so an `Upper.Rule.JS` is
- * not loadable there and must not be waved through here either.
- */
-const LOADABLE_RULE_FILE = /\.[cm]?[jt]s$/;
-
-/**
- * Declaration files are never loadable — they contain no runtime code. Case-insensitive like the
- * seam's copy, though only the `d` can ever reach it: a `Types.D.TS` already fails the
- * case-sensitive {@link LOADABLE_RULE_FILE}, so the flag earns its keep on `Types.D.ts` alone.
- */
-const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
-
-/**
- * Whether a globbed match is something the seam can load at all.
- *
- * Declaration files are tested FIRST, the order `load-user-module.ts`'s `unloadableReason` uses and
- * for its stated reason — `.d.ts` also matches the loadable pattern, so a declaration check that ran
- * second would be dead code for any spelling the loadable pattern happens to admit.
- *
- * This duplicates a predicate the seam already composes but does not export. The duplication is
- * deliberate for now (story 34.2 may not edit `load-user-module.ts`) and tracked as deferred work:
- * if the seam ever widens — its `.tsx` exclusion is called deliberate but the export-shape
- * limitation is called follow-up work — this copy silently drops the newly loadable files.
- */
-function isLoadableRuleFile(file: string): boolean {
-  return !DECLARATION_FILE.test(file) && LOADABLE_RULE_FILE.test(file);
-}
-
-/**
  * A rule set that is reachable from itself through pattern globs can never finish loading, so it is
  * reported rather than pursued.
  *
@@ -359,7 +333,24 @@ async function loadRuleSet(
       // neighbouring `types.d.ts` and `**/*` also picks up a `rules.json` or a `README.md`; the seam
       // declines every one of them, so without this the whole rule set dies on `Cannot resolve rule
       // source` naming a file that plainly exists and that the user never meant to load.
-      const files = matched.filter(isLoadableRuleFile);
+      //
+      // The loadability test itself runs on the match's REALPATH, not the raw glob spelling — the
+      // same predicate the seam applies, given the same kind of input the seam gives it (a resolved
+      // path, not a filename) — so a symlink agrees with the seam in both directions instead of
+      // testing one shape here and importing a different one below. A match whose realpath cannot
+      // be resolved (a broken symlink, ENOENT) is treated as not loadable, the same as any other
+      // declined file.
+      const files = matched.filter((file) => {
+        let resolved: string;
+
+        try {
+          resolved = realpathSync.native(path.join(dirname, file));
+        } catch {
+          return false;
+        }
+
+        return unloadableReason(resolved) === undefined;
+      });
 
       // An individual skip is silent — that is the point of the filter. But a pattern that matched
       // files and kept NONE of them is a mistake every time: a typo'd extension, a pattern aimed at

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -14,7 +14,11 @@ import {
   vi,
 } from 'vitest';
 
-import { loadUserModule, resolveUserModule } from '../src/load-user-module.js';
+import {
+  loadUserModule,
+  resolveUserModule,
+  unloadableReason,
+} from '../src/load-user-module.js';
 
 const fixtures = join(import.meta.dirname, 'fixtures', 'user-modules');
 
@@ -328,6 +332,24 @@ describe('load user module', () => {
       await expect(loadUserModule(resolved)).resolves.toMatchObject({
         default: 'plain-ts',
       });
+    });
+  });
+
+  describe('unloadableReason', () => {
+    // Exported for `rule-loader.ts`'s glob filter (#689, #691) — pinning its exact return values
+    // directly, since external code now depends on them, not just on `resolveUserModule` and
+    // `loadUserModule` observing them indirectly.
+    it.each([
+      ['types.d.ts', 'a TypeScript declaration file contains no runtime code'],
+      ['Legacy.D.ts', 'a TypeScript declaration file contains no runtime code'],
+      ['rules.json', 'only JavaScript and TypeScript modules can be loaded'],
+      ['component.tsx', 'only JavaScript and TypeScript modules can be loaded'],
+    ])('reports why %s is unloadable', (fileName, reason) => {
+      expect(unloadableReason(join(fixtures, fileName))).toBe(reason);
+    });
+
+    it('returns undefined for a loadable path', () => {
+      expect(unloadableReason(join(fixtures, 'plain.ts'))).toBeUndefined();
     });
   });
 

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
@@ -378,6 +379,159 @@ describe('load rules from TypeScript sources', () => {
       const rules = await loadRules(join(ruleSetsTs, 'pattern-all.ruleset.ts'));
 
       expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
+    });
+  });
+
+  // The filter used to be a local copy of the seam's own allow-list, tested against the raw glob
+  // spelling rather than a realpath — so it disagreed with the seam in both directions on a
+  // symlink. These pin the fix (#689, #691): the filter now shares `unloadableReason` with the seam
+  // and tests it against each match's `realpathSync.native` result, exactly the input shape the
+  // seam itself uses.
+  describe('symlinked glob matches (realpath-aware filter)', () => {
+    const loadableTarget = join(ruleSetsTs, 'globbed', 'a.rule.ts');
+    const declarationTarget = join(ruleSetsTs, 'globbed', 'types.d.ts');
+
+    /**
+     * Builds a temp rule set whose `pattern` glob reaches into a `rules/` subdirectory of symlinks,
+     * per `entries` (name -> absolute realpath target). The rule-set file itself lives OUTSIDE that
+     * subdirectory so the pattern can never match it and self-recurse — a separate concern (#688).
+     */
+    async function loadFromSymlinkedPattern(
+      entries: Record<string, string>,
+    ): Promise<Awaited<ReturnType<typeof loadRules>>> {
+      const dir = await mkdtemp(join(tmpdir(), 'thymian-glob-symlink-'));
+
+      try {
+        const rulesDir = join(dir, 'rules');
+
+        await mkdir(rulesDir);
+
+        for (const [name, target] of Object.entries(entries)) {
+          await symlink(target, join(rulesDir, name));
+        }
+
+        await writeFile(
+          join(dir, 'symlinks.ruleset.ts'),
+          "export default { name: 'symlinked-ts', pattern: './rules/*.ts' };\n",
+        );
+
+        return await loadRules(join(dir, 'symlinks.ruleset.ts'));
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('keeps a .ts symlink to a loadable .ts file', async () => {
+      const rules = await loadFromSymlinkedPattern({
+        'link.rule.ts': loadableTarget,
+      });
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a']);
+    });
+
+    it("filters out a .ts symlink to a .d.ts file, without throwing (paired with a keeper so it is not the pattern's only match)", async () => {
+      const rules = await loadFromSymlinkedPattern({
+        'link.rule.ts': loadableTarget,
+        'link-to-declaration.rule.ts': declarationTarget,
+      });
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a']);
+    });
+
+    it('keeps a .d.ts symlink to a loadable .ts file (previously dropped silently, the bug this fix corrects)', async () => {
+      const rules = await loadFromSymlinkedPattern({
+        'link.d.ts': loadableTarget,
+      });
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a']);
+    });
+
+    it('throws "none loadable" when every match is an unloadable symlink (declaration-target only)', async () => {
+      // The pre-existing "matched but kept none" throw (see the raw-file case above) must still
+      // fire when EVERY match is filtered out via a symlink's realpath, not just a raw declaration
+      // file — the realpath-aware filter must not accidentally make this throw unreachable.
+      await expect(
+        loadFromSymlinkedPattern({
+          'link-a.rule.ts': declarationTarget,
+          'link-b.rule.ts': declarationTarget,
+        }),
+      ).rejects.toThrow(
+        /Rule set "symlinked-ts" pattern \.\/rules\/\*\.ts matched 2 file\(s\), none of which can be loaded as a rule\./,
+      );
+    });
+
+    /**
+     * Mocks `realpathSync.native` (via `vi.spyOn`, restored with `mockRestore` in `finally`) to
+     * throw for exactly one glob match — by path SUFFIX, not equality: `dirname` inside
+     * `rule-loader.ts` comes from the ruleset's own already-realpath'd resolved path
+     * (`resolveUserModule` normalises it), while `dir` here is the pre-canonicalisation path
+     * `mkdtemp` handed back — on macOS those differ by the `/var` -> `/private/var` symlink, so an
+     * exact-string match would silently never fire and the test would pass for the wrong reason
+     * (nothing filtered, every path resolving through the real implementation regardless).
+     */
+    async function loadWithFailingRealpath(
+      failing: 'ENOENT' | 'EACCES',
+    ): Promise<Awaited<ReturnType<typeof loadRules>>> {
+      const dir = await mkdtemp(join(tmpdir(), 'thymian-glob-symlink-race-'));
+      const original = realpathSync.native;
+      const nativeSpy = vi.spyOn(realpathSync, 'native');
+
+      try {
+        const rulesDir = join(dir, 'rules');
+
+        await mkdir(rulesDir);
+        await symlink(loadableTarget, join(rulesDir, 'keeper.rule.ts'));
+        await symlink(loadableTarget, join(rulesDir, 'vanishes.rule.ts'));
+
+        await writeFile(
+          join(dir, 'symlinks.ruleset.ts'),
+          "export default { name: 'symlinked-ts', pattern: './rules/*.ts' };\n",
+        );
+
+        const vanishingSuffix = join('rules', 'vanishes.rule.ts');
+
+        nativeSpy.mockImplementation((...args: Parameters<typeof original>) => {
+          const [target] = args;
+
+          if (target.toString().endsWith(vanishingSuffix)) {
+            const error = new Error(
+              `${failing}: realpath '${String(target)}'`,
+            ) as NodeJS.ErrnoException;
+
+            error.code = failing;
+
+            throw error;
+          }
+
+          return original(...args);
+        });
+
+        return await loadRules(join(dir, 'symlinks.ruleset.ts'));
+      } finally {
+        nativeSpy.mockRestore();
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('filters out a match whose realpath cannot be resolved (ENOENT), without throwing', async () => {
+      // tinyglobby's own crawl already declines a symlink whose target is missing AT GLOB TIME —
+      // confirmed empirically, and consistent with `followSymbolicLinks: true` needing a successful
+      // stat to admit an entry — so a *dangling-from-the-start* symlink never reaches this filter
+      // through the production call. What the filter's `catch` guards against is the narrower race
+      // that survives that: the target existing when tinyglobby stats it and being gone by the time
+      // this filter re-resolves it moments later (removed, or a flaky mount).
+      const rules = await loadWithFailingRealpath('ENOENT');
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a']);
+    });
+
+    it('filters out a match whose realpath rejects with a non-ENOENT error (EACCES), without throwing', async () => {
+      // The filter's `catch` is deliberately error-code-agnostic (a permissions failure or a
+      // symlink cycle is treated the same as a dangling target) — this pins that as intentional
+      // rather than an artifact of only ever having exercised the ENOENT case.
+      const rules = await loadWithFailingRealpath('EACCES');
+
+      expect(ruleNames(rules)).toEqual(['globbed-ts-a']);
     });
   });
 


### PR DESCRIPTION
## Summary
- Exports `unloadableReason` from `load-user-module.ts` (was private) so `rule-loader.ts`'s glob filter can reuse it instead of hand-copying `LOADABLE_RULE_FILE`/`DECLARATION_FILE`/`isLoadableRuleFile`.
- The glob filter now judges each match by its **realpath** (`realpathSync.native`) rather than its raw glob-matched filename, so a symlinked rule agrees with the rest of the module-loading seam in both directions:
  - a `*.ts` symlink to a `.d.ts` no longer passes the filter only to hard-fail the whole rule-set load moments later.
  - a `*.d.ts` symlink to a loadable `.ts` module is no longer silently dropped.
- A realpath failure (broken symlink, permission error, etc.) is treated as not-loadable, same as any other declined file.

Fixes thymianofficial/thymian-internal#689, thymianofficial/thymian-internal#691.

Stacked on #372 (fix/688) since both touch the same glob-matching loop in `rule-loader.ts` — this branch was rebased on top of its current tip and re-verified against it.

## Test plan
- [x] `nx run core:test` — 460/460 passing, including new symlink cases (loadable-target symlink kept, declaration-target symlink dropped, all-unloadable-via-symlink still throws, ENOENT and EACCES realpath failures both filtered without throwing) and a direct table test pinning `unloadableReason`'s exported return values.
- [x] `nx run core:lint` — clean, confirms no dangling references to the deleted constants.
- [x] `nx run core:build` — clean.
- [x] Reviewed via adversarial (Blind Hunter) + edge-case-hunter passes; 3 coverage gaps they raised were patched into this PR's tests, 4 pre-existing/out-of-scope findings deferred as thymianofficial/thymian-internal#698, #699, #700, #701.