### PR TITLE
fix(core): blame the casing, not the language, for a mis-cased module (#690)

### DIFF
--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -211,6 +211,19 @@ const TYPESCRIPT_EXTENSION = /\.[cm]?ts$/;
  *   which only exists on much later versions. Measured on 22.19 and 26.7.
  * - `.wasm`: does load on 22 and 26, but needs `--experimental-wasm-modules` on Node 20 (also in
  *   the matrix), and a valid wasm module exports no `default`, so it cannot carry a rule anyway.
+ *
+ * Case-SENSITIVE, and that is a measured decision rather than an oversight (#690). On a
+ * case-insensitive volume an on-disk `Upper.Rule.JS` resolves perfectly well, but nothing this
+ * seam uses can load it: `import()` AND jiti — narrowed to `.ts`/`.mts`/`.cts` above — both answer
+ * `ERR_UNKNOWN_FILE_EXTENSION` for `.JS` and for `.TS`. Measured on v26.7.0 only, unlike the
+ * version-floor claims above; Node's extension lookup is case-sensitive on the 20/22 matrix too,
+ * but that was not re-measured. Relaxing this test to `/i` therefore buys nothing and costs the
+ * framing: the file is waved through to exactly that raw error. {@link miscasedExtension} explains
+ * such a refusal instead of loosening it.
+ *
+ * Scoped to the ESM loader on purpose: `require('./A.JS')` SUCCEEDS, because CommonJS falls back to
+ * the `.js` handler for an unregistered extension. This seam imports, so the refusal is right — but
+ * a user who checks the claim in a `require` REPL must not find it overstated.
  */
 const LOADABLE_EXTENSION = /\.[cm]?[jt]s$/;
 
@@ -220,6 +233,45 @@ const LOADABLE_EXTENSION = /\.[cm]?[jt]s$/;
  * exists to stop. Checked before {@link TYPESCRIPT_EXTENSION}, which `.d.ts` also matches.
  */
 const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
+
+/** The case-insensitive twin of {@link LOADABLE_EXTENSION}. See {@link miscasedExtension}. */
+const MISCASED_EXTENSION = /\.[cm]?[jt]s$/i;
+
+/**
+ * The offending extension when a path is refused ONLY because of how that extension is cased, or
+ * `undefined` when the path is loadable, or unloadable for some other reason.
+ *
+ * {@link LOADABLE_EXTENSION} and {@link MISCASED_EXTENSION} disagree on exactly one input — a real
+ * module whose on-disk extension is not lower-case — and that input is the only one needing its own
+ * sentence. Declaration files are excluded so this agrees with {@link unloadableReason}'s
+ * precedence: an upper-case `Legacy.D.TS` is refused for containing no runtime code, which stays
+ * true whatever its casing, and must not be reported as a casing mistake.
+ *
+ * Returns the MATCHED extension rather than `path.extname`, so a real extension is reported
+ * verbatim — but a STEM-LESS dotfile is excluded for exactly the reason `path.extname` answers `''`
+ * there: a file named a bare `.JS` has no extension at all, and Node loads it through the package
+ * `type` (measured, v26.7.0). Calling that a casing mistake would send the user to rename a file
+ * that already works, and would make the glob filter fatal on it.
+ *
+ * Exported so `rule-loader.ts`'s glob filter can separate "cannot be a module at all" (silently
+ * dropped) from "is a module, refused only for its casing" (fatal) without parsing a sentence.
+ */
+export function miscasedExtension(resolvedPath: string): string | undefined {
+  if (
+    DECLARATION_FILE.test(resolvedPath) ||
+    LOADABLE_EXTENSION.test(resolvedPath)
+  ) {
+    return undefined;
+  }
+
+  const matched = MISCASED_EXTENSION.exec(resolvedPath)?.[0];
+
+  if (matched === undefined || path.basename(resolvedPath) === matched) {
+    return undefined;
+  }
+
+  return matched;
+}
 
 /**
  * Why a resolved path can never be loaded, or `undefined` when it can.
@@ -235,6 +287,14 @@ const DECLARATION_FILE = /\.d\.[cm]?ts$/i;
 export function unloadableReason(resolvedPath: string): string | undefined {
   if (DECLARATION_FILE.test(resolvedPath)) {
     return 'a TypeScript declaration file contains no runtime code';
+  }
+
+  const miscased = miscasedExtension(resolvedPath);
+
+  if (miscased !== undefined) {
+    // Not "only JavaScript and TypeScript modules can be loaded" — the file the user is looking at
+    // plainly IS one, so that sentence reads as a lie and hides the one-word fix (#690).
+    return `its extension "${miscased}" must be lower-case — Node's ESM loader and jiti recognise no other spelling`;
   }
 
   if (!LOADABLE_EXTENSION.test(resolvedPath)) {
@@ -761,10 +821,16 @@ export async function loadUserModule(
       `Cannot load user module ${canonical}: ${reason}.`,
       {
         name: 'UserModuleLoadError',
-        suggestions: [
-          'Point at the implementation file rather than its declarations or a non-module asset.',
-          'Resolve the specifier with resolveUserModule first — it declines paths that cannot be loaded.',
-        ],
+        // Matched to the diagnosis. "Point at the implementation file rather than its declarations"
+        // is FALSE for a mis-cased module — it IS the implementation file, which is the same class
+        // of lie #690 exists to remove.
+        suggestions:
+          miscasedExtension(canonical) === undefined
+            ? [
+                'Point at the implementation file rather than its declarations or a non-module asset.',
+                'Resolve the specifier with resolveUserModule first — it declines paths that cannot be loaded.',
+              ]
+            : ['Rename the file so its extension is lower-case.'],
       },
     );
   }

--- a/packages/core/src/rules/rule-loader.ts
+++ b/packages/core/src/rules/rule-loader.ts
@@ -5,6 +5,7 @@ import { glob } from 'tinyglobby';
 
 import {
   loadUserModule,
+  miscasedExtension,
   resolveUserModule,
   unloadableReason,
 } from '../load-user-module.js';
@@ -340,17 +341,75 @@ async function loadRuleSet(
       // testing one shape here and importing a different one below. A match whose realpath cannot
       // be resolved (a broken symlink, ENOENT) is treated as not loadable, the same as any other
       // declined file.
-      const files = matched.filter((file) => {
+      //
+      // One decline is NOT silent, though. A module refused only for how its extension is cased is
+      // not in the "cannot be a module at all" class this filter exists to drop — nothing this seam
+      // uses can load it, yet it is shaped like code (#690). What makes it worth failing on is not
+      // that assumption on its own, which is unreliable — `.TS` is also MPEG transport stream and
+      // `.MTS` is AVCHD — but the combination below: it disappeared behind siblings that DID load,
+      // so the rule set looks healthy while silently running without it.
+      //
+      // Hence the gate. When NOTHING loaded, the all-declined guard further down is the better
+      // diagnosis and keeps its place; an unconditional throw here would also kill the run over a
+      // file the user cannot rename, since `ignore` matches the GLOB path while tinyglobby follows
+      // symlinked directories into dependencies and build output. Reported offender is the first in
+      // `matched`, which is sorted, so the message is deterministic.
+      const files: string[] = [];
+      const miscased: { file: string; resolved: string; extension: string }[] =
+        [];
+
+      for (const file of matched) {
+        const joined = path.join(dirname, file);
         let resolved: string;
 
         try {
-          resolved = realpathSync.native(path.join(dirname, file));
+          resolved = realpathSync.native(joined);
         } catch {
-          return false;
+          continue;
         }
 
-        return unloadableReason(resolved) === undefined;
-      });
+        const extension = miscasedExtension(resolved);
+
+        if (extension !== undefined) {
+          miscased.push({ file, resolved, extension });
+
+          continue;
+        }
+
+        if (unloadableReason(resolved) === undefined) {
+          files.push(file);
+        }
+      }
+
+      const offender = miscased[0];
+
+      if (offender !== undefined && files.length > 0) {
+        // Sourced from `unloadableReason`, never hand-written: this file already relies on that
+        // being the ONE place a refusal is explained, and a second copy of the sentence would drift
+        // from the seam's with nothing to catch it.
+        const reason = unloadableReason(offender.resolved);
+        // Names the realpath too when it differs, so a symlinked match cannot quote a `.JS` while
+        // naming a `.ts` file — which would make the rename suggestion a no-op.
+        const named =
+          offender.resolved === path.join(dirname, offender.file)
+            ? offender.file
+            : `${offender.file} (${offender.resolved})`;
+
+        throw new ThymianBaseError(
+          `Rule set "${ruleSet.name}" pattern ${pattern} matched ${named}: ${reason}.`,
+          {
+            // Exclusion leads deliberately. The file may be a media asset that must NOT be renamed
+            // — renaming `00000.MTS` makes it a loadable match that then dies on a binary parse —
+            // or it may live inside a dependency the user has no right to touch.
+            suggestions: [
+              `Exclude it from ${pattern}, or narrow the pattern, if the file is not a rule — an upper-case ".TS" or ".MTS" is also a media extension, and a match reached through a symlinked directory may not be yours to rename.`,
+              `If it is a rule, rename it so its extension is lower-case ("${offender.extension.toLowerCase()}").`,
+            ],
+            name: 'RuleLoadError',
+            ref: 'https://thymian.dev/references/errors/rule-load-error/',
+          },
+        );
+      }
 
       // An individual skip is silent — that is the point of the filter. But a pattern that matched
       // files and kept NONE of them is a mistake every time: a typo'd extension, a pattern aimed at
@@ -466,6 +525,14 @@ async function loadRulesInChain(
       {
         name: 'RuleLoadError',
         ref: 'https://thymian.dev/references/errors/rule-load-error/',
+        // Judged from the SPECIFIER, since a declined result carries no path. That covers the case
+        // the user hits — they typed the mis-cased name — but not a lower-case specifier resolving
+        // to a mis-cased file on a case-insensitive volume; there the message still names the
+        // casing, it just goes unaccompanied.
+        suggestions:
+          miscasedExtension(input) === undefined
+            ? []
+            : ['Rename the file so its extension is lower-case.'],
       },
     );
   }

--- a/packages/core/test/fixtures/user-modules/Upper.Decl.D.TS
+++ b/packages/core/test/fixtures/user-modules/Upper.Decl.D.TS
@@ -1,0 +1,6 @@
+// Fixture: a declaration file whose extension is upper-case throughout. Pins the precedence — this
+// is refused for containing no runtime code, which stays true whatever its casing, and must NOT be
+// reported as a casing mistake (#690).
+declare const upperDeclMarker: string;
+
+export default upperDeclMarker;

--- a/packages/core/test/fixtures/user-modules/Upper.Rule.JS
+++ b/packages/core/test/fixtures/user-modules/Upper.Rule.JS
@@ -1,0 +1,7 @@
+// Fixture: a genuine JavaScript module whose extension is UPPER-CASE on disk (#690). It resolves
+// on a case-insensitive volume, and neither Node nor jiti can load it — `ERR_UNKNOWN_FILE_EXTENSION`
+// either way — so the seam must refuse it and say WHY. The file name is literal, so the case holds
+// on case-sensitive filesystems too.
+const marker = 'upper-rule-js';
+
+export default marker;

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -16,6 +16,7 @@ import {
 
 import {
   loadUserModule,
+  miscasedExtension,
   resolveUserModule,
   unloadableReason,
 } from '../src/load-user-module.js';
@@ -307,6 +308,7 @@ describe('load user module', () => {
     it.each([
       ['a declaration file', 'types.d.ts'],
       ['a declaration file spelled with a capital D', 'Legacy.D.ts'],
+      ['a module whose extension is upper-case', 'Upper.Rule.JS'],
       ['a .tsx file', 'component.tsx'],
       ['a .jsx file', 'component.jsx'],
       ['a .json file', 'rules.json'],
@@ -326,6 +328,14 @@ describe('load user module', () => {
       ).rejects.toThrow(/contains no runtime code/);
     });
 
+    it('blames the casing, not the language, for an upper-case extension', async () => {
+      // Both loaders were measured to refuse `.JS` outright (`ERR_UNKNOWN_FILE_EXTENSION`), so the
+      // refusal is right and only its sentence was wrong (#690).
+      await expect(
+        loadUserModule(join(fixtures, 'Upper.Rule.JS')),
+      ).rejects.toThrow(/extension "\.JS" must be lower-case/);
+    });
+
     it('still loads a path the resolver accepts', async () => {
       const resolved = await resolveOrFail(join(fixtures, 'plain.ts'));
 
@@ -342,14 +352,66 @@ describe('load user module', () => {
     it.each([
       ['types.d.ts', 'a TypeScript declaration file contains no runtime code'],
       ['Legacy.D.ts', 'a TypeScript declaration file contains no runtime code'],
+      [
+        'Upper.Decl.D.TS',
+        'a TypeScript declaration file contains no runtime code',
+      ],
       ['rules.json', 'only JavaScript and TypeScript modules can be loaded'],
       ['component.tsx', 'only JavaScript and TypeScript modules can be loaded'],
+      [
+        'Upper.Rule.JS',
+        `its extension ".JS" must be lower-case — Node's ESM loader and jiti recognise no other spelling`,
+      ],
     ])('reports why %s is unloadable', (fileName, reason) => {
       expect(unloadableReason(join(fixtures, fileName))).toBe(reason);
     });
 
     it('returns undefined for a loadable path', () => {
       expect(unloadableReason(join(fixtures, 'plain.ts'))).toBeUndefined();
+    });
+
+    it('never tells the user a JavaScript module is not a JavaScript module', () => {
+      // The #690 regression in one assertion: the old sentence was applied to a file that plainly
+      // IS a JavaScript module, so it read as a lie and hid the one-word fix.
+      const reason = unloadableReason(join(fixtures, 'Upper.Rule.JS'));
+
+      expect(reason).toContain('.JS');
+      expect(reason).not.toContain(
+        'only JavaScript and TypeScript modules can be loaded',
+      );
+    });
+  });
+
+  describe('miscasedExtension', () => {
+    // Exported so the rule-set glob filter can separate "not a module at all" (silently dropped)
+    // from "a module refused only for its casing" (fatal) without parsing a reason sentence.
+    it('names the offending extension', () => {
+      expect(miscasedExtension(join(fixtures, 'Upper.Rule.JS'))).toBe('.JS');
+    });
+
+    it.each([['.JS'], ['.TS'], ['.mjs']])(
+      'returns undefined for the stem-less dotfile %s',
+      (fileName) => {
+        // A bare `.JS` has NO extension — `path.extname` answers `''` — and Node loads it through
+        // the package `type` (measured, v26.7.0). Reporting a casing mistake would send the user to
+        // rename a working file, and would make the glob filter fatal on it. Asserted on synthetic
+        // paths rather than fixtures because `dot: false` keeps dotfiles out of rule-set globs, so
+        // no fixture could exercise it.
+        expect(miscasedExtension(join(fixtures, fileName))).toBeUndefined();
+      },
+    );
+
+    it.each([
+      ['a loadable lower-case module', 'plain.ts'],
+      ['a file that is no module at all', 'rules.json'],
+      ['a .tsx file, excluded whatever its casing', 'component.tsx'],
+      ['an upper-case declaration file', 'Upper.Decl.D.TS'],
+    ])('returns undefined for %s', (_label, fileName) => {
+      // The declaration case pins the precedence AS IT STANDS: `DECLARATION_FILE` claims the path
+      // first, so the casing branch never sees it and the glob filter drops it silently rather than
+      // failing on it. Note this pins the ORDERING, not a verdict on that guard's breadth — it also
+      // claims a `Feature.D.TS` whose basename merely ends in `.D`, which is tracked separately.
+      expect(miscasedExtension(join(fixtures, fileName))).toBeUndefined();
     });
   });
 
@@ -382,6 +444,16 @@ describe('load user module', () => {
 
       expect(declined.reason).toBe(
         'a TypeScript declaration file contains no runtime code',
+      );
+    });
+
+    it('declines a module whose extension is upper-case, naming the casing', async () => {
+      // Reported as `{ ok: false, reason }` so the caller frames it, rather than as a bare
+      // "cannot resolve" for a file the user is looking at.
+      const declined = await expectDeclined(join(fixtures, 'Upper.Rule.JS'));
+
+      expect(declined.reason).toBe(
+        `its extension ".JS" must be lower-case — Node's ESM loader and jiti recognise no other spelling`,
       );
     });
 

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/Notes.TSX
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/Notes.TSX
@@ -1,0 +1,3 @@
+// Fixture: an upper-case JSX file. The JSX family is excluded whatever its casing, so this is a
+// silent drop too, not a casing complaint.
+export default 'notes-tsx';

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/Upper.Decl.D.TS
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/Upper.Decl.D.TS
@@ -1,0 +1,5 @@
+// Fixture: an upper-case declaration file. Declined for containing no runtime code, which stays
+// true whatever its casing, so it must be dropped SILENTLY — never routed into the casing throw.
+declare const upperDeclMarker: string;
+
+export default upperDeclMarker;

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/sibling.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased-clean/sibling.rule.ts
@@ -1,0 +1,11 @@
+// Fixture: the same loadable sibling as `miscased/`, in a directory with NO mis-cased module. Its
+// counterpart proves the fatal path fires; this one proves the sibling genuinely loads, so neither
+// fatal test can pass with a broken or missing sibling.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('miscased-clean-sibling')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased-only/Notes.JS
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased-only/Notes.JS
@@ -1,0 +1,6 @@
+// Fixture: a mis-cased module that is the ONLY thing in its directory that could have loaded.
+// Nothing survives the filter, so the pre-existing all-declined error is the better diagnosis and
+// the casing throw must stand down.
+const marker = 'notes-js';
+
+export default marker;

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased-only/data.json
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased-only/data.json
@@ -1,0 +1,3 @@
+{
+  "note": "a data file, so the pattern matches something unloadable too"
+}

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased/Upper.Rule.JS
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased/Upper.Rule.JS
@@ -1,0 +1,7 @@
+// Fixture: a real rule module whose extension is UPPER-CASE on disk (#690). A `**/*` pattern sweeps
+// it up alongside the loadable sibling below; it must NOT be dropped silently just because that
+// sibling loads fine. Not written as a `httpRule` because it is never actually loaded — the glob
+// filter refuses it first, and the refusal is the behaviour under test.
+const marker = 'miscased-upper-js';
+
+export default marker;

--- a/packages/core/test/rules/fixtures/rule-sets-ts/miscased/sibling.rule.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/miscased/sibling.rule.ts
@@ -1,0 +1,10 @@
+// Fixture: the perfectly loadable sibling. Its presence is the point — it means the rule set has a
+// rule to run, so a silently dropped mis-cased module would leave the set looking healthy.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { constant, httpRule } from '@thymian/core';
+
+export default httpRule('miscased-sibling')
+  .severity('error')
+  .type('test', 'analytics')
+  .rule((ctx) => ctx.validateCommonHttpTransactions(constant(true)))
+  .done();

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased-clean.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased-clean.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: the control for `pattern-miscased`. Sweeps a loadable rule plus an upper-case
+// declaration file and an upper-case JSX file; both non-modules must be dropped silently, so the
+// rule set loads its one rule and throws nothing.
+export default {
+  name: 'pattern-miscased-clean-ts',
+  pattern: './miscased-clean/**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased-only.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased-only.ruleset.ts
@@ -1,0 +1,6 @@
+// Fixture: a pattern whose every match is declined and where one of them is mis-cased. The casing
+// throw is gated on something else having loaded, so this must produce the all-declined error.
+export default {
+  name: 'pattern-miscased-only-ts',
+  pattern: './miscased-only/**/*',
+};

--- a/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased.ruleset.ts
+++ b/packages/core/test/rules/fixtures/rule-sets-ts/pattern-miscased.ruleset.ts
@@ -1,0 +1,7 @@
+// Fixture: a pattern that sweeps up a mis-cased module AND a loadable rule. The mis-cased file is
+// intended code that no loader can reach, so the rule set must fail naming it (#690) rather than
+// quietly running the sibling alone.
+export default {
+  name: 'pattern-miscased-ts',
+  pattern: './miscased/**/*',
+};

--- a/packages/core/test/rules/load-rules-typescript.test.ts
+++ b/packages/core/test/rules/load-rules-typescript.test.ts
@@ -380,6 +380,81 @@ describe('load rules from TypeScript sources', () => {
 
       expect(ruleNames(rules)).toEqual(['globbed-ts-a', 'globbed-ts-b']);
     });
+
+    it('fails on a mis-cased module even though a sibling rule loads fine', async () => {
+      // The one decline that is NOT silent (#690). `./miscased/**/*` sweeps up an `Upper.Rule.JS`
+      // and a perfectly good `sibling.rule.ts`. Nothing this seam uses can load the former, so a
+      // silent drop would leave the rule set looking healthy while running without it — and the
+      // all-declined guard cannot catch it, because the sibling keeps the kept-count above zero.
+      await expect(
+        loadRules(join(ruleSetsTs, 'pattern-miscased.ruleset.ts')),
+      ).rejects.toThrow(
+        /Rule set "pattern-miscased-ts" pattern \.\/miscased\/\*\*\/\* matched miscased[/\\]Upper\.Rule\.JS: its extension "\.JS" must be lower-case/,
+      );
+    });
+
+    it('never blames the language for a mis-cased module', async () => {
+      // The #690 sentence, at the glob surface: the file plainly IS a JavaScript module, so the old
+      // wording read as a lie. Asserted as an ABSENCE, which the message-shape test above cannot do.
+      //
+      // Inspected off the caught error rather than through `rejects.toThrow`, which takes a string,
+      // regex or error shape — handing it `expect.not.stringContaining` type-casts cleanly and then
+      // passes whatever the message says. Verified by mutation: with the casing branch reverted to
+      // the generic sentence, this fails and the cast version did not.
+      const error: unknown = await loadRules(
+        join(ruleSetsTs, 'pattern-miscased.ruleset.ts'),
+      ).then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toContain(
+        'only JavaScript and TypeScript modules can be loaded',
+      );
+      expect((error as Error).message).toContain('.JS');
+    });
+
+    it('leads its suggestions with exclusion, offering the rename second', async () => {
+      // Order matters and is load-bearing. The match may be a media asset that must NOT be renamed
+      // — `00000.MTS` renamed to `.mts` becomes a loadable match that dies on a binary parse — or
+      // it may sit inside a symlinked dependency the user cannot touch.
+      await expect(
+        loadRules(join(ruleSetsTs, 'pattern-miscased.ruleset.ts')),
+      ).rejects.toThrowError(
+        expect.objectContaining({
+          name: 'RuleLoadError',
+          options: expect.objectContaining({
+            suggestions: [
+              expect.stringContaining('Exclude it from'),
+              'If it is a rule, rename it so its extension is lower-case (".js").',
+            ],
+          }),
+        }),
+      );
+    });
+
+    it('stands down when the mis-cased module is the only thing that could have loaded', async () => {
+      // Gated on purpose: with nothing kept, the all-declined error is the better diagnosis, and an
+      // unconditional casing throw would fire on files reached through symlinked dependencies and
+      // build output that the user cannot rename.
+      await expect(
+        loadRules(join(ruleSetsTs, 'pattern-miscased-only.ruleset.ts')),
+      ).rejects.toThrow(
+        /Rule set "pattern-miscased-only-ts" pattern \.\/miscased-only\/\*\*\/\* matched 2 file\(s\), none of which can be loaded as a rule\./,
+      );
+    });
+
+    it('drops an upper-case declaration file and a .TSX silently, loading the sibling', async () => {
+      // The control for the two fatal tests above, and the integration pin for the precedence the
+      // design rests on: only a CASING decline is fatal. It also makes the sibling load-bearing —
+      // without this, both fatal tests would pass with a broken or absent sibling.
+      const rules = await loadRules(
+        join(ruleSetsTs, 'pattern-miscased-clean.ruleset.ts'),
+      );
+
+      expect(ruleNames(rules)).toEqual(['miscased-clean-sibling']);
+    });
   });
 
   // The filter used to be a local copy of the seam's own allow-list, tested against the raw glob


### PR DESCRIPTION
Closes thymianofficial/thymian-internal#690.

> **Stacked** on `fix/689-691-realpath-unloadable-reason` (#373), so this diff is one commit. Sibling of #374, which branches off the same base. Merge order: #369 → #370 → #372 → #373 → this.

## The problem

A module whose **on-disk** extension is upper-case (`Upper.Rule.JS`) was refused with *"only JavaScript and TypeScript modules can be loaded"* — plainly false of a file that is one. Through a rule-set glob it was dropped silently.

## The issue offered two fixes; one of them is wrong

#690 suggested either making the loadable test case-insensitive **or** having the seam report the casing. I measured the first before building it:

| loader | `.JS` | `.TS` |
|---|---|---|
| plain `import()` | `ERR_UNKNOWN_FILE_EXTENSION` | `ERR_UNKNOWN_FILE_EXTENSION` |
| jiti (narrowed to `.ts`/`.mts`/`.cts`, as this seam configures it) | — | `ERR_UNKNOWN_FILE_EXTENSION` |

Measured on v26.7.0 and independently reproduced by two review passes. Relaxing `LOADABLE_EXTENSION` to `/i` only trades a framed refusal for that raw error, so **the case-sensitivity that #690 doubted is correct** and the doc comment now records the evidence rather than asserting it. Only the sentence needed fixing.

Note this is *not* a case-insensitivity fix: `realpathSync.native` already reports on-disk casing, so a mis-cased **specifier** (`PLAIN.TS` → `plain.ts`) resolves and loads. What remains is a file genuinely upper-case on disk, which nothing downstream can load — so the guard keeps refusing and merely explains itself.

## What changed

- **`load-user-module.ts`** — `miscasedExtension()` names the offending extension and is the single seam separating *"cannot be a module at all"* (silently dropped) from *"is a module, refused only for its casing"*, so the glob filter never parses a reason sentence. `unloadableReason` gains a third branch, after declaration precedence. A stem-less dotfile is excluded: it has no extension and Node loads it through the package `type`.
- **`rule-loader.ts`** — a casing-only glob decline is now fatal, **gated on a sibling match having survived the filter**. The message is composed from `unloadableReason`, never hand-written, honouring the file's own "one sentence, one source" invariant.

## Why the fatal path is gated

Adversarial review found an unconditional throw was unshippable:

1. `ignore: ['**/node_modules/**']` matches the **glob** path, not the realpath, and tinyglobby follows symlinked directories — so a run died over a `Polyfill.JS` inside a dependency the user cannot rename, with no escape hatch suggested.
2. `.TS` (MPEG transport stream) and `.MTS` (AVCHD) are real, canonically upper-case **media** extensions. Obeying a lower-case rename there turns the file into a *loadable* match that dies on a binary parse — strictly worse than the starting state.

So the throw is reserved for the harm #690 actually names: a module vanishing behind rules that **do** load. With nothing kept, the pre-existing *"matched N file(s), none of which can be loaded"* error remains the better diagnosis. Suggestions lead with excluding/narrowing the pattern; the rename comes second.

## Verification

`nx build core` clean · **479/479 core tests** · `nx lint core` 0 errors · `format:check` clean · **full workspace 17/17 projects**.

The negative assertion and the sibling gate were both **mutation-tested** — `rejects.toThrow(expect.not.stringContaining(...))` type-casts cleanly and then passes regardless, so the first version of that test was vacuous and was rewritten to inspect the caught error.

Fixtures are literal on disk (`Upper.Rule.JS`, `Upper.Decl.D.TS`), so every case holds on case-sensitive volumes too — no `CASE_INSENSITIVE_FS` gate needed. `miscased-clean/` is the control that makes the sibling load-bearing and pins that declaration and `.TSX` declines stay silent rather than fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)