### PR TITLE
fix(common-cli): plugin load failures name the real cause

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,7 @@
 # Test fixture: intentionally invalid YAML for e2e error-handling tests
 /e2e-tests/fixtures/analyze/invalid-spec.yaml
 
+# Test fixture: deliberately unparseable TypeScript for a genuine syntax-error case (story 34.4)
+/packages/common-cli/test/fixtures/plugins/syntax-error-plugin.ts
+
 /.nx/self-healing

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,6 +84,11 @@ export default [
       '**/vitest.config.*.timestamp*',
       'node_modules',
       '**/.astro',
+      // Deliberately unparseable — a fixture for a genuine TypeScript syntax error (story 34.4).
+      // `**/`-prefixed like the other entries here: this array is shared into each package's own
+      // eslint.config.mjs, where ESLint resolves ignore patterns relative to that package's own
+      // cwd, not this file's location — a repo-root-relative path silently never matches there.
+      '**/test/fixtures/plugins/syntax-error-plugin.ts',
     ],
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,11 +84,6 @@ export default [
       '**/vitest.config.*.timestamp*',
       'node_modules',
       '**/.astro',
-      // Deliberately unparseable — a fixture for a genuine TypeScript syntax error (story 34.4).
-      // `**/`-prefixed like the other entries here: this array is shared into each package's own
-      // eslint.config.mjs, where ESLint resolves ignore patterns relative to that package's own
-      // cwd, not this file's location — a repo-root-relative path silently never matches there.
-      '**/test/fixtures/plugins/syntax-error-plugin.ts',
     ],
   },
   {

--- a/packages/common-cli/eslint.config.mjs
+++ b/packages/common-cli/eslint.config.mjs
@@ -3,6 +3,15 @@ import baseConfig from '../../eslint.config.mjs';
 export default [
   ...baseConfig,
   {
+    // Deliberately unparseable — a fixture for a genuine TypeScript syntax error (story 34.4).
+    // Scoped to this package's own config (not the shared root one) since ESLint resolves
+    // `ignores` patterns relative to the cwd `eslint` actually runs from, which for this project
+    // is `packages/common-cli` — a pattern here can be package-relative and unambiguous, where the
+    // same pattern in the shared root config would have to be `**/`-prefixed and would then match
+    // this same relative path in any other package too.
+    ignores: ['test/fixtures/plugins/syntax-error-plugin.ts'],
+  },
+  {
     files: ['**/*.json'],
     rules: {
       '@nx/dependency-checks': [

--- a/packages/common-cli/src/load-plugin-module.ts
+++ b/packages/common-cli/src/load-plugin-module.ts
@@ -4,6 +4,7 @@ import { inspect } from 'node:util';
 import { CLIError } from '@oclif/core/errors';
 import {
   isPlugin,
+  isRecord,
   loadUserModule,
   resolveUserModule,
   ThymianBaseError,
@@ -20,6 +21,82 @@ import type { ThymianConfig } from './thymian-config.js';
 export interface LoadPluginModuleDebugSinks {
   debug?: (message: string, ...args: unknown[]) => void;
   loggerDebug?: (message: string, ...args: unknown[]) => void;
+}
+
+// Node reports a missing import as ERR_MODULE_NOT_FOUND from ESM resolution and MODULE_NOT_FOUND
+// from CJS; jiti can surface either depending on the file it is loading.
+const MODULE_NOT_FOUND_CODES = new Set([
+  'ERR_MODULE_NOT_FOUND',
+  'MODULE_NOT_FOUND',
+]);
+
+// Codes this module attaches itself to the two `resolveUserModule` failure shapes, so
+// `describePluginLoadFailure` can tell them apart from an arbitrary thrown error without
+// re-deriving the distinction `resolveUserModule` already made.
+const PLUGIN_UNRESOLVED_CODE = 'ERR_PLUGIN_UNRESOLVED';
+const PLUGIN_UNLOADABLE_CODE = 'ERR_PLUGIN_UNLOADABLE';
+
+const MODULE_NOT_FOUND_SPECIFIER_PATTERN =
+  /Cannot find (?:module|package) ['"]([^'"]+)['"]/;
+
+export interface DescribePluginLoadFailureResult {
+  reason: string;
+  suggestions: string[];
+}
+
+/**
+ * Turns whatever `loadPluginModule` caught into a user-facing reason and, where the failure is
+ * one we recognise, actionable suggestions. Exported and tested on its own so the mapping from
+ * error to reason/suggestions doesn't have to be exercised only through the full load path.
+ */
+export function describePluginLoadFailure(
+  error: unknown,
+): DescribePluginLoadFailureResult {
+  const reason = pluginLoadFailureReason(error);
+  const code =
+    isRecord(error) && typeof error.code === 'string' ? error.code : undefined;
+
+  if (code !== undefined && MODULE_NOT_FOUND_CODES.has(code)) {
+    return { reason, suggestions: [moduleNotFoundSuggestion(reason)] };
+  }
+
+  if (code === PLUGIN_UNRESOLVED_CODE) {
+    return {
+      reason,
+      suggestions: [
+        'Check the path or package name — .ts, .mts and .cts plugins load directly, with no build step.',
+      ],
+    };
+  }
+
+  if (code === PLUGIN_UNLOADABLE_CODE) {
+    return {
+      reason,
+      suggestions: [
+        'Point at the implementation file rather than its declarations or a non-module asset.',
+      ],
+    };
+  }
+
+  return { reason, suggestions: [] };
+}
+
+function pluginLoadFailureReason(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return inspect(error, { depth: 3 });
+  }
+
+  const message = error.message.trim();
+
+  return message.length > 0 ? message : inspect(error, { depth: 3 });
+}
+
+function moduleNotFoundSuggestion(reason: string): string {
+  const specifier = MODULE_NOT_FOUND_SPECIFIER_PATTERN.exec(reason)?.[1];
+
+  return specifier === undefined
+    ? 'Check that the import resolves and that its package is installed.'
+    : `Check that "${specifier}" resolves and that its package is installed.`;
 }
 
 /**
@@ -55,9 +132,24 @@ export async function loadPluginModule(
     });
 
     if (!resolved.ok) {
-      // 34.4 will surface this cause; today it is flattened into PluginLoadError same as any
-      // other `e`, so the reason must still be carried here rather than discarded.
-      throw new Error(resolved.reason ?? `Cannot resolve plugin ${location}.`);
+      // Mirrors rule-loader.ts's two-sentence split (34.2): a `reason` is present only when the
+      // specifier resolved to a real file that was then refused for what it IS; with no reason
+      // there is genuinely nothing to add beyond "not found".
+      const name = options.path ?? nameOrPath;
+
+      throw Object.assign(
+        new Error(
+          resolved.reason === undefined
+            ? `Cannot resolve plugin "${name}".`
+            : `Cannot load plugin "${name}": ${resolved.reason}.`,
+        ),
+        {
+          code:
+            resolved.reason === undefined
+              ? PLUGIN_UNRESOLVED_CODE
+              : PLUGIN_UNLOADABLE_CODE,
+        },
+      );
     }
 
     const module = await loadUserModule(resolved.path);
@@ -68,11 +160,14 @@ export async function loadPluginModule(
       location,
       inspect(e),
     );
+    const { reason, suggestions } = describePluginLoadFailure(e);
+
     throw new ThymianBaseError(
-      `Failed to load plugin module "${options.path ?? nameOrPath}".`,
+      `Failed to load plugin module "${options.path ?? nameOrPath}": ${reason}`,
       {
         name: 'PluginLoadError',
         cause: e,
+        suggestions,
       },
     );
   }

--- a/packages/common-cli/src/load-plugin-module.ts
+++ b/packages/common-cli/src/load-plugin-module.ts
@@ -5,6 +5,7 @@ import { CLIError } from '@oclif/core/errors';
 import {
   isPlugin,
   isRecord,
+  isThymianError,
   loadUserModule,
   resolveUserModule,
   ThymianBaseError,
@@ -53,6 +54,15 @@ export function describePluginLoadFailure(
   error: unknown,
 ): DescribePluginLoadFailureResult {
   const reason = pluginLoadFailureReason(error);
+
+  // A caught error that is already a framed ThymianError (e.g. loadUserModule's cycle-detection
+  // or mis-cased-extension errors from packages/core) carries its own curated suggestions under
+  // `options`, not under a top-level `.code` — check this first so they aren't discarded in
+  // favour of a generic `[]` just because they don't match the code-based mapping below.
+  if (isThymianError(error) && error.options?.suggestions?.length) {
+    return { reason, suggestions: error.options.suggestions };
+  }
+
   const code =
     isRecord(error) && typeof error.code === 'string' ? error.code : undefined;
 
@@ -81,14 +91,35 @@ export function describePluginLoadFailure(
   return { reason, suggestions: [] };
 }
 
+/**
+ * Only the first line of whatever produced the reason — Node's MODULE_NOT_FOUND message carries a
+ * multi-line "Require stack:" trailer, and a jiti syntax error's second line is an absolute local
+ * path; neither belongs in the default, non-`--debug` message this composes into (the full detail
+ * is still reachable via `cause` and the existing `--debug` dump, both untouched). Punctuation is
+ * normalized so every composed message reads as a finished sentence, regardless of whether the
+ * reason came from a raw `Error.message` (no trailing period) or an already-punctuated one composed
+ * elsewhere in this file.
+ */
 function pluginLoadFailureReason(error: unknown): string {
   if (!(error instanceof Error)) {
-    return inspect(error, { depth: 3 });
+    return normalizeReason(inspect(error, { depth: 3 }));
   }
 
-  const message = error.message.trim();
+  const firstLine = firstLineOf(error.message);
 
-  return message.length > 0 ? message : inspect(error, { depth: 3 });
+  return firstLine.length > 0
+    ? normalizeReason(firstLine)
+    : normalizeReason(inspect(error, { depth: 3 }));
+}
+
+function firstLineOf(text: string): string {
+  return (text.split('\n', 1)[0] ?? '').trim();
+}
+
+function normalizeReason(text: string): string {
+  const line = firstLineOf(text);
+
+  return line.length === 0 || /[.!?]$/.test(line) ? line : `${line}.`;
 }
 
 function moduleNotFoundSuggestion(reason: string): string {

--- a/packages/common-cli/test/fixtures/plugins/missing-import-plugin.ts
+++ b/packages/common-cli/test/fixtures/plugins/missing-import-plugin.ts
@@ -1,9 +1,4 @@
 // Fixture: imports a module that genuinely does not exist, so resolution fails with
 // ERR_MODULE_NOT_FOUND (or MODULE_NOT_FOUND under CJS resolution) instead of resolving to nothing.
-import { helperName } from './does-not-exist.js';
-
-export default {
-  name: helperName('missing-import'),
-  version: '1.0.0',
-  plugin: async () => undefined,
-};
+// A side-effect-only import: nothing after it would ever run, since the import itself throws.
+import './does-not-exist.js';

--- a/packages/common-cli/test/fixtures/plugins/missing-import-plugin.ts
+++ b/packages/common-cli/test/fixtures/plugins/missing-import-plugin.ts
@@ -1,0 +1,9 @@
+// Fixture: imports a module that genuinely does not exist, so resolution fails with
+// ERR_MODULE_NOT_FOUND (or MODULE_NOT_FOUND under CJS resolution) instead of resolving to nothing.
+import { helperName } from './does-not-exist.js';
+
+export default {
+  name: helperName('missing-import'),
+  version: '1.0.0',
+  plugin: async () => undefined,
+};

--- a/packages/common-cli/test/fixtures/plugins/syntax-error-plugin.ts
+++ b/packages/common-cli/test/fixtures/plugins/syntax-error-plugin.ts
@@ -1,0 +1,8 @@
+// Fixture: deliberately unparseable TypeScript, so loading it fails with a genuine
+// jiti/Babel parse error. Excluded from ESLint (eslint.config.mjs) because an unparseable file
+// cannot carry a working eslint-disable comment.
+export default {
+  name: 'syntax-error-plugin'
+  version: '1.0.0',
+  plugin: async () => undefined,
+};

--- a/packages/common-cli/test/fixtures/plugins/throws-non-error-plugin.ts
+++ b/packages/common-cli/test/fixtures/plugins/throws-non-error-plugin.ts
@@ -1,0 +1,3 @@
+// Fixture: throws a non-Error value at module evaluation, exercising the `inspect` fallback in
+// describePluginLoadFailure.
+throw 'boom';

--- a/packages/common-cli/test/fixtures/plugins/throws-on-load-plugin.ts
+++ b/packages/common-cli/test/fixtures/plugins/throws-on-load-plugin.ts
@@ -1,0 +1,2 @@
+// Fixture: throws a real Error at module evaluation, before any export is produced.
+throw new Error('boom');

--- a/packages/common-cli/test/fixtures/plugins/types.d.ts
+++ b/packages/common-cli/test/fixtures/plugins/types.d.ts
@@ -1,0 +1,5 @@
+// Fixture: a TypeScript declaration file, which resolveUserModule declines by design — it
+// contains no runtime code.
+export interface UnusedMarker {
+  readonly value: string;
+}

--- a/packages/common-cli/test/load-plugin-module.test.ts
+++ b/packages/common-cli/test/load-plugin-module.test.ts
@@ -2,7 +2,13 @@ import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { isPlugin, loadUserModule, resolveUserModule } from '@thymian/core';
+import {
+  isPlugin,
+  isThymianError,
+  loadUserModule,
+  resolveUserModule,
+  ThymianBaseError,
+} from '@thymian/core';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -13,9 +19,12 @@ import type { ThymianConfig } from '../src/thymian-config.js';
 
 const FIXTURES_DIR = join(import.meta.dirname, 'fixtures', 'plugins');
 
-function pluginErrorSuggestions(error: Error): string[] {
-  return (error as unknown as { options: { suggestions: string[] } }).options
-    .suggestions;
+function pluginErrorSuggestions(error: unknown): string[] {
+  if (!isThymianError(error)) {
+    throw new Error(`Expected a ThymianError, got: ${String(error)}`);
+  }
+
+  return error.options?.suggestions ?? [];
 }
 
 function configWith(
@@ -342,13 +351,13 @@ describe('loadPluginModule', () => {
     it('uses the message for an Error with content', () => {
       const result = describePluginLoadFailure(new Error('boom'));
 
-      expect(result.reason).toBe('boom');
+      expect(result.reason).toBe('boom.');
     });
 
     it('does not prepend the error name to the message', () => {
       const result = describePluginLoadFailure(new TypeError('boom'));
 
-      expect(result.reason).toBe('boom');
+      expect(result.reason).toBe('boom.');
     });
 
     it('falls back to inspect for a non-Error throw', () => {
@@ -362,6 +371,47 @@ describe('loadPluginModule', () => {
 
       expect(result.reason).not.toBe('');
       expect(result.reason).not.toMatch(/: $/);
+    });
+
+    it('does not leak a multi-line stack trace into the reason for an empty-message Error', () => {
+      const result = describePluginLoadFailure(new Error(''));
+
+      expect(result.reason).not.toContain('\n');
+      expect(result.reason).not.toContain('    at ');
+    });
+
+    it('takes only the first line of a multi-line Error message', () => {
+      const error = new Error(
+        "Cannot find module './helper'\nRequire stack:\n- /abs/path/plugin.ts",
+      );
+      const result = describePluginLoadFailure(error);
+
+      expect(result.reason).toBe("Cannot find module './helper'.");
+    });
+
+    it('does not double a trailing period that is already present', () => {
+      const result = describePluginLoadFailure(
+        new Error('already punctuated.'),
+      );
+
+      expect(result.reason).toBe('already punctuated.');
+    });
+
+    it('propagates suggestions already authored on a caught ThymianError instead of discarding them', () => {
+      const cycleError = new ThymianBaseError(
+        'Cannot load user module /abs/plugin.ts: it is already being evaluated.',
+        {
+          name: 'UserModuleLoadError',
+          suggestions: [
+            'Break the cycle by importing the shared module directly instead of loading it through Thymian.',
+          ],
+        },
+      );
+      const result = describePluginLoadFailure(cycleError);
+
+      expect(result.suggestions).toEqual([
+        'Break the cycle by importing the shared module directly instead of loading it through Thymian.',
+      ]);
     });
 
     it('falls back to inspect when the Error message is whitespace-only', () => {
@@ -447,7 +497,7 @@ describe('loadPluginModule', () => {
       ).catch((e: unknown) => e as Error);
 
       expect(error.message).toBe(
-        'Failed to load plugin module "./fixtures/plugins/throws-on-load-plugin.ts": boom',
+        'Failed to load plugin module "./fixtures/plugins/throws-on-load-plugin.ts": boom.',
       );
     });
 

--- a/packages/common-cli/test/load-plugin-module.test.ts
+++ b/packages/common-cli/test/load-plugin-module.test.ts
@@ -5,10 +5,18 @@ import { join } from 'node:path';
 import { isPlugin, loadUserModule, resolveUserModule } from '@thymian/core';
 import { describe, expect, it, vi } from 'vitest';
 
-import { loadPluginModule } from '../src/load-plugin-module.js';
+import {
+  describePluginLoadFailure,
+  loadPluginModule,
+} from '../src/load-plugin-module.js';
 import type { ThymianConfig } from '../src/thymian-config.js';
 
 const FIXTURES_DIR = join(import.meta.dirname, 'fixtures', 'plugins');
+
+function pluginErrorSuggestions(error: Error): string[] {
+  return (error as unknown as { options: { suggestions: string[] } }).options
+    .suggestions;
+}
 
 function configWith(
   plugins: Record<string, { path?: string; autoload?: boolean }> = {},
@@ -239,7 +247,8 @@ describe('loadPluginModule', () => {
           true,
         ),
       ).rejects.toThrow(
-        'Failed to load plugin module "./fixtures/plugins/does-not-exist.ts".',
+        'Failed to load plugin module "./fixtures/plugins/does-not-exist.ts": ' +
+          'Cannot resolve plugin "./fixtures/plugins/does-not-exist.ts".',
       );
     });
 
@@ -276,7 +285,8 @@ describe('loadPluginModule', () => {
       await expect(
         loadPluginModule('my-plugin', config, import.meta.dirname),
       ).rejects.toThrow(
-        'Failed to load plugin module "./fixtures/plugins/does-not-exist.ts".',
+        'Failed to load plugin module "./fixtures/plugins/does-not-exist.ts": ' +
+          'Cannot resolve plugin "./fixtures/plugins/does-not-exist.ts".',
       );
     });
 
@@ -290,7 +300,8 @@ describe('loadPluginModule', () => {
 
       expect((error as Error).cause).toBeInstanceOf(Error);
       expect(((error as Error).cause as Error).message).toBe(
-        'only JavaScript and TypeScript modules can be loaded',
+        'Cannot load plugin "./fixtures/plugins/not-code.json": only JavaScript ' +
+          'and TypeScript modules can be loaded.',
       );
     });
   });
@@ -324,6 +335,165 @@ describe('loadPluginModule', () => {
       );
 
       expect(plugin.name).toBe('ts-plugin');
+    });
+  });
+
+  describe('describePluginLoadFailure', () => {
+    it('uses the message for an Error with content', () => {
+      const result = describePluginLoadFailure(new Error('boom'));
+
+      expect(result.reason).toBe('boom');
+    });
+
+    it('does not prepend the error name to the message', () => {
+      const result = describePluginLoadFailure(new TypeError('boom'));
+
+      expect(result.reason).toBe('boom');
+    });
+
+    it('falls back to inspect for a non-Error throw', () => {
+      const result = describePluginLoadFailure('boom');
+
+      expect(result.reason).toContain('boom');
+    });
+
+    it('falls back to inspect when the Error message is empty', () => {
+      const result = describePluginLoadFailure(new Error(''));
+
+      expect(result.reason).not.toBe('');
+      expect(result.reason).not.toMatch(/: $/);
+    });
+
+    it('falls back to inspect when the Error message is whitespace-only', () => {
+      const result = describePluginLoadFailure(new Error('   '));
+
+      expect(result.reason.trim()).not.toBe('');
+    });
+
+    it('suggests checking the import for ERR_MODULE_NOT_FOUND', () => {
+      const error = Object.assign(new Error("Cannot find module './helper'"), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+      const result = describePluginLoadFailure(error);
+
+      expect(result.suggestions).toHaveLength(1);
+      expect(result.suggestions[0]).toContain('./helper');
+    });
+
+    it('suggests checking the import for MODULE_NOT_FOUND', () => {
+      const error = Object.assign(new Error("Cannot find module './helper'"), {
+        code: 'MODULE_NOT_FOUND',
+      });
+      const result = describePluginLoadFailure(error);
+
+      expect(result.suggestions).toHaveLength(1);
+    });
+
+    it('degrades to a generic suggestion when the specifier cannot be parsed out', () => {
+      const error = Object.assign(new Error('module resolution failed'), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+      const result = describePluginLoadFailure(error);
+
+      expect(result.suggestions).toEqual([
+        'Check that the import resolves and that its package is installed.',
+      ]);
+    });
+
+    it('invents no suggestion for an unrecognised failure', () => {
+      const result = describePluginLoadFailure(new Error('boom'));
+
+      expect(result.suggestions).toEqual([]);
+    });
+  });
+
+  describe('story 34.4 — the reason and suggestions surface in the message', () => {
+    it('names a missing import (ERR_MODULE_NOT_FOUND/MODULE_NOT_FOUND) as the reason, with a suggestion', async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/missing-import-plugin.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toContain(
+        'Failed to load plugin module "./fixtures/plugins/missing-import-plugin.ts": ',
+      );
+      expect(error.message).toContain('does-not-exist');
+      expect(error.message).not.toMatch(/: $/);
+      expect(pluginErrorSuggestions(error)).not.toHaveLength(0);
+    });
+
+    it('names a genuine TypeScript syntax error as the reason', async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/syntax-error-plugin.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toContain(
+        'Failed to load plugin module "./fixtures/plugins/syntax-error-plugin.ts": ',
+      );
+      expect(error.message).not.toMatch(/: $/);
+    });
+
+    it('names an Error thrown at module evaluation as the reason', async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/throws-on-load-plugin.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toBe(
+        'Failed to load plugin module "./fixtures/plugins/throws-on-load-plugin.ts": boom',
+      );
+    });
+
+    it('names an unresolvable specifier as "Cannot resolve", with a suggestion', async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/does-not-exist.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toBe(
+        'Failed to load plugin module "./fixtures/plugins/does-not-exist.ts": ' +
+          'Cannot resolve plugin "./fixtures/plugins/does-not-exist.ts".',
+      );
+      expect(pluginErrorSuggestions(error)).not.toHaveLength(0);
+    });
+
+    it("renders a *.d.ts specifier's rendered reason, not merely that it failed", async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/types.d.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toBe(
+        'Failed to load plugin module "./fixtures/plugins/types.d.ts": ' +
+          'Cannot load plugin "./fixtures/plugins/types.d.ts": a TypeScript declaration file ' +
+          'contains no runtime code.',
+      );
+    });
+
+    it('falls back to inspect for a non-Error throw, with no bare trailing colon', async () => {
+      const error = await loadPluginModule(
+        './fixtures/plugins/throws-non-error-plugin.ts',
+        configWith(),
+        import.meta.dirname,
+        true,
+      ).catch((e: unknown) => e as Error);
+
+      expect(error.message).toContain(
+        'Failed to load plugin module "./fixtures/plugins/throws-non-error-plugin.ts": ',
+      );
+      expect(error.message).toContain('boom');
+      expect(error.message).not.toMatch(/: $/);
     });
   });
 });


### PR DESCRIPTION
Composes PluginLoadError's message from a new describePluginLoadFailure
helper instead of flattening the cause, and mirrors rule-loader's
not-found/wrong-kind split for an unresolvable plugin specifier.
Suggestions are attached for the failure shapes that have one.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>