### PR TITLE
fix(core): conditions-aware resolution for bare specifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27242,7 +27242,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -31826,6 +31825,7 @@
         "graphology": "^0.26.0",
         "jiti": "^2.6.1",
         "path-to-regexp": "^8.4.0",
+        "resolve.exports": "^2.0.3",
         "rxjs": "^7.8.2",
         "safe-stable-stringify": "^2.5.0",
         "secure-json-parse": "^4.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "graphology": "^0.26.0",
     "jiti": "^2.6.1",
     "path-to-regexp": "^8.4.0",
+    "resolve.exports": "^2.0.3",
     "rxjs": "^7.8.2",
     "safe-stable-stringify": "^2.5.0",
     "secure-json-parse": "^4.1.0",

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -205,10 +205,108 @@ function splitBareSpecifier(specifier: string): {
   const segments = specifier.split('/');
   const packageName = specifier.startsWith('@')
     ? segments.slice(0, 2).join('/')
-    : (segments[0] ?? specifier);
+    : segments[0] || specifier;
   const rest = specifier.slice(packageName.length);
 
   return { packageName, target: rest === '' ? '.' : `.${rest}` };
+}
+
+/**
+ * The outcome of checking ONE candidate package directory that has a `package.json`. Distinct
+ * from "no `package.json` here at all" (which the caller represents as `undefined` and keeps
+ * searching past) — once a `package.json` for the requested name is found, real Node's own
+ * resolver commits to it and does not consult a farther, differently-installed copy of the same
+ * name, whether this candidate turns out to be usable or not. `reason` is set only for the one
+ * case this seam can explain better than a plain miss: a package that exists but whose `exports`
+ * map has nothing for the requested conditions.
+ */
+interface ExportsMapCandidateResult {
+  readonly path?: string;
+  readonly reason?: string;
+}
+
+/**
+ * Checks a single candidate package directory against `target`'s ESM conditions. Never throws —
+ * a malformed `package.json`, an unreadable file, or a `resolve.exports` failure are each folded
+ * into `{}` (found, but not usable), matching the discriminated-result philosophy the rest of
+ * this file already uses for a caller that "could not work out for itself" why something failed.
+ */
+function resolveExportsMapCandidate(
+  packageDir: string,
+  target: string,
+): ExportsMapCandidateResult | undefined {
+  const packageJsonPath = path.join(packageDir, 'package.json');
+
+  if (!isFile(packageJsonPath)) {
+    return undefined;
+  }
+
+  let pkg: unknown;
+
+  try {
+    pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  } catch {
+    return {};
+  }
+
+  if (!isRecord(pkg)) {
+    return {};
+  }
+
+  const noMatchingCondition = (): ExportsMapCandidateResult => {
+    const name = typeof pkg.name === 'string' ? pkg.name : packageDir;
+
+    return {
+      reason: `"${name}" has no "exports" entry matching "${target}" for this environment (checked "node", "import", "default")`,
+    };
+  };
+
+  let matches: readonly string[] | void;
+
+  try {
+    // No options: defaults are exactly `['node', 'import', 'default']`, matching how every path
+    // this seam resolves is actually consumed — `await import()`, or jiti. Never `require()`.
+    //
+    // `resolve.exports` THROWS rather than returning a falsy value when nothing matches (verified
+    // against the installed `resolve.exports@2.0.3`: "No known conditions for ... specifier in
+    // ... package") — its own type signature (`Exports.Output | void`) suggests otherwise, so this
+    // is easy to get wrong. Treat any throw here as "no matching export", not a hard failure — the
+    // `reason` is what makes that distinguishable from every OTHER reason this could miss
+    // (malformed JSON, non-object `package.json`), which is why it is not folded into the generic
+    // `{}` returns elsewhere in this function.
+    matches = resolveExportsMap(pkg, target);
+  } catch {
+    return noMatchingCondition();
+  }
+
+  if (!matches) {
+    return noMatchingCondition();
+  }
+
+  // A fallback array (`"exports": {".": ["./a.mjs", "./b.mjs"]}`) is valid per the exports spec —
+  // try each candidate in order and use the first that exists on disk, rather than assuming the
+  // match is unique.
+  for (const match of matches) {
+    const candidate = path.join(packageDir, match);
+    const relativeToPackage = path.relative(packageDir, candidate);
+
+    // Reject a target that escapes `packageDir`. `resolve.exports` performs none of Node's own
+    // `PACKAGE_TARGET_RESOLVE` invalid-target validation — verified by reading its source, it
+    // hands back whatever string the exports map contains, unmodified — so a `package.json` with
+    // an `exports` target like `"../../../x.mjs"` would otherwise resolve outside the package.
+    if (
+      relativeToPackage.startsWith('..') ||
+      path.isAbsolute(relativeToPackage)
+    ) {
+      continue;
+    }
+
+    if (isFile(candidate)) {
+      return { path: candidate };
+    }
+  }
+
+  return {};
 }
 
 /**
@@ -224,19 +322,34 @@ function splitBareSpecifier(specifier: string): {
  * Directory discovery deliberately reuses {@link resolveThroughRequire}'s own two anchors —
  * `requireFrom(cwd)` (the user's project) then `require` (core's own install directory) — via
  * `resolve.paths`, which walks the same `node_modules` ancestor chain Node's own ESM resolver
- * would. This is what makes the user-before-core precedence (see the file header) hold for this
- * resolver too, without a second implementation of that policy. `resolve.paths` answers `null` for
- * a Node builtin id (no `node_modules` search applies) or when nothing is installed under that
- * name from that anchor — both are a plain miss here, not an error.
+ * would consider. This is what makes the user-before-core precedence (see the file header) hold
+ * for this resolver too, without a second implementation of that policy. Within ONE anchor,
+ * `resolve.paths` returns every ancestor `node_modules` directory, but {@link
+ * resolveExportsMapCandidate}'s answer for the FIRST one holding a `package.json` is final — a
+ * broken or non-matching nearest install does not fall through to a farther, differently-installed
+ * copy of the same name, matching real Node's own commit-to-nearest resolution. `resolve.paths`
+ * answers `null` for a Node builtin id (no `node_modules` search applies) or when nothing is
+ * installed under that name from that anchor — both are a plain miss, moving to the next anchor.
  *
- * `resolve.exports` itself never touches the filesystem — it only matches conditions against an
- * already-parsed `package.json`. A malformed `package.json` is a miss for that directory, not a
- * thrown error: another candidate directory, or the next resolver in the chain, may still answer.
+ * @param miss Optional out-parameter: if resolution fails but a candidate `package.json` was found
+ *   with no matching `exports` condition, its `reason` is written here for the caller to surface —
+ *   `resolveUserModule` only reads it once the FULL chain (including the jiti fallback) has failed.
  */
 function resolveThroughExportsMap(
   specifier: string,
   cwd: string,
+  miss: { reason?: string } = {},
 ): string | undefined {
+  if (path.isAbsolute(specifier)) {
+    // An absolute filesystem path is never a package specifier. Without this guard, an absolute
+    // specifier that reaches this function (see {@link resolveUserModule} — an absolute path
+    // takes the bare-specifier branch, not the relative one) would split to an empty
+    // `packageName`, and `resolve.paths('')` does not throw: it returns the full ancestor chain to
+    // the filesystem root plus legacy global directories (measured: 11 entries), all needlessly
+    // stat'd and read for a specifier that could never have been a package name.
+    return undefined;
+  }
+
   const { packageName, target } = splitBareSpecifier(specifier);
 
   for (const anchor of [requireFrom(cwd), require]) {
@@ -253,50 +366,24 @@ function resolveThroughExportsMap(
     }
 
     for (const dir of candidateDirs) {
-      const packageDir = path.join(dir, packageName);
-      const packageJsonPath = path.join(packageDir, 'package.json');
+      const result = resolveExportsMapCandidate(
+        path.join(dir, packageName),
+        target,
+      );
 
-      if (!isFile(packageJsonPath)) {
-        continue;
+      if (result === undefined) {
+        continue; // no `package.json` here — keep walking this anchor's ancestor chain
       }
 
-      let pkg: unknown;
-
-      try {
-        pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-      } catch {
-        continue;
+      if (result.path !== undefined) {
+        return result.path;
       }
 
-      if (!isRecord(pkg)) {
-        continue;
+      if (result.reason !== undefined) {
+        miss.reason = result.reason;
       }
 
-      let matches: readonly string[] | void;
-
-      try {
-        // No options: defaults are exactly `['node', 'import', 'default']`, matching how every
-        // path this seam resolves is actually consumed — `await import()`, or jiti. Never
-        // `require()`.
-        matches = resolveExportsMap(pkg, target);
-      } catch {
-        continue;
-      }
-
-      if (!matches) {
-        continue;
-      }
-
-      // A fallback array (`"exports": {".": ["./a.mjs", "./b.mjs"]}`) is valid per the exports
-      // spec — try each candidate in order and use the first that exists on disk, rather than
-      // assuming the match is unique.
-      for (const match of matches) {
-        const candidate = path.join(packageDir, match);
-
-        if (isFile(candidate)) {
-          return candidate;
-        }
-      }
+      break; // a package.json was found and is unusable — move to the NEXT ANCHOR, not a farther `dir`
     }
   }
 
@@ -624,6 +711,10 @@ export async function resolveUserModule(
   const base = path.resolve(cwd);
 
   let resolved: string | undefined;
+  // Populated only if `resolveThroughExportsMap` finds an installed package whose `exports` map
+  // has nothing for the requested conditions — read below only once the FULL chain, including the
+  // jiti fallback, has failed to resolve anything at all.
+  const exportsMapMiss: { reason?: string } = {};
 
   if (RELATIVE_SPECIFIER.test(specifier)) {
     // A relative specifier is relative to the USER's cwd, never to core's install directory —
@@ -648,7 +739,7 @@ export async function resolveUserModule(
     resolved =
       resolveThroughRequire(specifier, base) ??
       resolveThroughGuessing(specifier) ??
-      resolveThroughExportsMap(specifier, base) ??
+      resolveThroughExportsMap(specifier, base, exportsMapMiss) ??
       (await resolveThroughJiti(specifier, base));
 
     // A plain non-absolute answer is not an answer. `require.resolve` reports a Node builtin as the
@@ -696,7 +787,12 @@ export async function resolveUserModule(
   }
 
   if (resolved === undefined) {
-    return NOT_RESOLVED;
+    // The one failure this seam can explain better than a plain miss: an installed package was
+    // found, but its `exports` map has nothing for the requested conditions. Only reachable when
+    // NOTHING in the chain — including the jiti fallback — resolved anything at all.
+    return exportsMapMiss.reason === undefined
+      ? NOT_RESOLVED
+      : { ok: false, reason: exportsMapMiss.reason };
   }
 
   if (!path.isAbsolute(resolved)) {

--- a/packages/core/src/load-user-module.ts
+++ b/packages/core/src/load-user-module.ts
@@ -45,7 +45,9 @@
  * installed CLI must not answer with its own copy of a colliding name; and preferring the cwd path
  * up front is what let a same-named file or directory shadow an installed package and silently run
  * in its place. Core's anchor stays so Thymian's bundled rule packages keep resolving when the
- * user's project does not carry them.
+ * user's project does not carry them. This precedence holds for {@link resolveThroughExportsMap}
+ * too, by construction — it walks the same two anchors, in the same order, rather than restating
+ * the policy.
  *
  * ONE exception, defined by what Node's resolver ANSWERS rather than by a list of names: a plain
  * specifier `require.resolve` reports as a bare builtin id. That is the *bare-requirable* builtins
@@ -57,12 +59,13 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { existsSync, realpathSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Jiti } from 'jiti';
+import { exports as resolveExportsMap } from 'resolve.exports';
 
 import { ThymianBaseError } from './thymian.error.js';
 import { isRecord } from './utils.js';
@@ -183,6 +186,117 @@ function resolveThroughGuessing(location: string): string | undefined {
 
     if (isFile(candidate)) {
       return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Splits a bare specifier into the package name `require.resolve.paths` needs and the `exports`
+ * map target Node's own key convention uses (`.` for the package root, `./sub/path` otherwise).
+ * Scoped packages (`@scope/name`, `@scope/name/sub`) take their first TWO segments as the name —
+ * the same rule Node's own bare-specifier resolution applies.
+ */
+function splitBareSpecifier(specifier: string): {
+  packageName: string;
+  target: string;
+} {
+  const segments = specifier.split('/');
+  const packageName = specifier.startsWith('@')
+    ? segments.slice(0, 2).join('/')
+    : (segments[0] ?? specifier);
+  const rest = specifier.slice(packageName.length);
+
+  return { packageName, target: rest === '' ? '.' : `.${rest}` };
+}
+
+/**
+ * Resolves a bare specifier through its package's `exports` map, honouring ESM conditions
+ * (`node`, `import`, `default`) — the gap `require.resolve` cannot close, because CJS's
+ * `require.resolve` only ever applies the CJS condition set. An ESM-only package (`exports` with
+ * an `import` condition and no `require`/`default` match) throws `ERR_PACKAGE_PATH_NOT_EXPORTED`
+ * from {@link resolveThroughRequire} and, before this function existed, only jiti's own
+ * `esmResolve` could resolve it — which meant importing jiti just to answer a RESOLUTION question,
+ * for a package that may turn out to be plain JavaScript. That is the cost contract item 4
+ * forbids; this function pays it with a ~1 KB, zero-dependency library instead.
+ *
+ * Directory discovery deliberately reuses {@link resolveThroughRequire}'s own two anchors —
+ * `requireFrom(cwd)` (the user's project) then `require` (core's own install directory) — via
+ * `resolve.paths`, which walks the same `node_modules` ancestor chain Node's own ESM resolver
+ * would. This is what makes the user-before-core precedence (see the file header) hold for this
+ * resolver too, without a second implementation of that policy. `resolve.paths` answers `null` for
+ * a Node builtin id (no `node_modules` search applies) or when nothing is installed under that
+ * name from that anchor — both are a plain miss here, not an error.
+ *
+ * `resolve.exports` itself never touches the filesystem — it only matches conditions against an
+ * already-parsed `package.json`. A malformed `package.json` is a miss for that directory, not a
+ * thrown error: another candidate directory, or the next resolver in the chain, may still answer.
+ */
+function resolveThroughExportsMap(
+  specifier: string,
+  cwd: string,
+): string | undefined {
+  const { packageName, target } = splitBareSpecifier(specifier);
+
+  for (const anchor of [requireFrom(cwd), require]) {
+    let candidateDirs: string[] | null;
+
+    try {
+      candidateDirs = anchor.resolve.paths(packageName);
+    } catch {
+      candidateDirs = null;
+    }
+
+    if (candidateDirs === null) {
+      continue;
+    }
+
+    for (const dir of candidateDirs) {
+      const packageDir = path.join(dir, packageName);
+      const packageJsonPath = path.join(packageDir, 'package.json');
+
+      if (!isFile(packageJsonPath)) {
+        continue;
+      }
+
+      let pkg: unknown;
+
+      try {
+        pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      } catch {
+        continue;
+      }
+
+      if (!isRecord(pkg)) {
+        continue;
+      }
+
+      let matches: readonly string[] | void;
+
+      try {
+        // No options: defaults are exactly `['node', 'import', 'default']`, matching how every
+        // path this seam resolves is actually consumed — `await import()`, or jiti. Never
+        // `require()`.
+        matches = resolveExportsMap(pkg, target);
+      } catch {
+        continue;
+      }
+
+      if (!matches) {
+        continue;
+      }
+
+      // A fallback array (`"exports": {".": ["./a.mjs", "./b.mjs"]}`) is valid per the exports
+      // spec — try each candidate in order and use the first that exists on disk, rather than
+      // assuming the match is unique.
+      for (const match of matches) {
+        const candidate = path.join(packageDir, match);
+
+        if (isFile(candidate)) {
+          return candidate;
+        }
+      }
     }
   }
 
@@ -470,15 +584,24 @@ export interface ResolveUserModuleOptions {
  * `{ ok: false }`, carrying a `reason` when the seam knows something the caller could not work
  * out for itself. On success, `path` is an absolute filesystem path, never a `file://` URL.
  *
- * Resolution stops at the first hit and runs the same three-resolver chain
- * ({@link resolveLocation}) over at most two candidates: the specifier itself, and — for a bare
- * name nothing is installed under, or whose only answer was a bare builtin id — `<cwd>/<specifier>`,
- * which for the builtin-id case must be a directory. Within a candidate the order is
- * `require.resolve`, then a `.mjs`/`.cjs` extension guess ({@link resolveThroughGuessing}), then
- * jiti's `esmResolve`. `require.resolve` already handles TypeScript with an explicit extension, so
- * the jiti step is reached for *resolution* only by extensionless and NodeNext `.js`→`.ts`
- * specifiers. The candidates are exhausted in that order, not the resolvers: a bare name that only
- * jiti can resolve inside `node_modules` still beats a same-named local file.
+ * Resolution stops at the first hit, over at most two candidates: the specifier itself, and — for
+ * a bare name nothing is installed under, or whose only answer was a bare builtin id —
+ * `<cwd>/<specifier>`, which for the builtin-id case must be a directory. The two candidates run
+ * DIFFERENT resolver chains, because only the first can be a package name:
+ *
+ * - A **bare** specifier: `require.resolve`, then a `.mjs`/`.cjs` extension guess
+ *   ({@link resolveThroughGuessing}, a no-op for a bare name), then
+ *   {@link resolveThroughExportsMap} (ESM `exports` conditions `require.resolve`'s CJS condition
+ *   set cannot match), then jiti's `esmResolve`.
+ * - The **relative** specifier and the `<cwd>/<specifier>` fallback candidate ({@link
+ *   resolveLocation}): the same three steps MINUS the exports-map one — a filesystem path is never
+ *   a package name, so matching it against a package's `exports` map is meaningless.
+ *
+ * `require.resolve` already handles TypeScript with an explicit extension, so the jiti step is
+ * reached for *resolution* only by extensionless and NodeNext `.js`→`.ts` specifiers, or by a bare
+ * specifier `resolveThroughExportsMap` cannot match. The candidates are exhausted in that order,
+ * not the resolvers: a bare name that only jiti can resolve inside `node_modules` still beats a
+ * same-named local file.
  *
  * @param specifier The user's rule, rule-set or plugin specifier.
  * @param cwd Directory that path-like specifiers resolve against, that anchors the jiti fallback,
@@ -525,6 +648,7 @@ export async function resolveUserModule(
     resolved =
       resolveThroughRequire(specifier, base) ??
       resolveThroughGuessing(specifier) ??
+      resolveThroughExportsMap(specifier, base) ??
       (await resolveThroughJiti(specifier, base));
 
     // A plain non-absolute answer is not an answer. `require.resolve` reports a Node builtin as the

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -1546,9 +1546,15 @@ describe('load user module', () => {
       // A real directory `require.resolve.paths` walks from `load-user-module.ts`'s own
       // location — the only way to exercise the "core" anchor honestly, matching how
       // `BARE_PACKAGE` (an actual workspace dependency) is used elsewhere in this file for the
-      // same reason. Removed in `finally` regardless of outcome.
+      // same reason. Removed in `finally` regardless of outcome, and also removed up front in case
+      // a previous run crashed between writing it and cleaning it up.
       const coreAnchorDir = join(import.meta.dirname, '..');
       const packageName = 'thymian-test-core-anchor-precedence-esm';
+
+      await rm(join(coreAnchorDir, 'node_modules', packageName), {
+        recursive: true,
+        force: true,
+      });
 
       try {
         await writePackage(
@@ -1649,6 +1655,182 @@ describe('load user module', () => {
 
         expect(result.ok).toBe(false);
         expect(jitiFactoryCalls).toBe(1);
+
+        // AC/decision follow-up: the seam found and parsed a real package.json here — it knows
+        // more than "nothing installed under that name", so it should say so.
+        if (!result.ok) {
+          expect(result.reason).toContain('browser-only-pkg');
+        }
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it("resolves a package installed only in core's own directory (not the user project)", async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-core-only-'),
+      );
+      const coreAnchorDir = join(import.meta.dirname, '..');
+      const packageName = 'thymian-test-core-anchor-only-esm';
+
+      await rm(join(coreAnchorDir, 'node_modules', packageName), {
+        recursive: true,
+        force: true,
+      });
+
+      try {
+        await writePackage(
+          coreAnchorDir,
+          packageName,
+          { type: 'module', exports: { '.': { import: './index.mjs' } } },
+          { 'index.mjs': "export default 'core-only';\n" },
+        );
+
+        // userProject deliberately does NOT have a copy — this exercises the fallback to core's
+        // own anchor, the other half of the two-anchor design the "prefers the user project's
+        // copy" test does not cover.
+        const result = await loader.resolveUserModule(packageName, userProject);
+
+        if (!result.ok) {
+          throw new Error(`Expected "${packageName}" to resolve.`);
+        }
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('core-only');
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+        await rm(join(coreAnchorDir, 'node_modules', packageName), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }, 15_000);
+
+    it('is a silent miss for a malformed package.json, not a thrown error', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-malformed-'),
+      );
+
+      try {
+        const pkgDir = join(userProject, 'node_modules', 'malformed-pkg');
+
+        await mkdir(pkgDir, { recursive: true });
+        await writeFile(join(pkgDir, 'package.json'), '{ not valid json');
+
+        await expect(
+          loader.resolveUserModule('malformed-pkg', userProject),
+        ).resolves.toMatchObject({ ok: false });
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('does not fall through to a farther, differently-installed copy when the nearest match is unusable', async () => {
+      const loader = await import('../src/load-user-module.js');
+      // Two ancestor levels of the SAME anchor: `root/node_modules` has a WORKING copy,
+      // `root/mid/node_modules` has a browser-only (unusable) copy of the same name, nearer to
+      // `cwd`. Real Node's own resolver commits to the nearest `package.json` it finds under a
+      // name and hard-fails there rather than trying a farther duplicate — this proves
+      // `resolveThroughExportsMap` now matches that instead of silently substituting root's copy.
+      const root = await mkdtemp(join(tmpdir(), 'thymian-esm-commit-nearest-'));
+      const mid = join(root, 'mid');
+
+      try {
+        await mkdir(mid, { recursive: true });
+        await writePackage(
+          root,
+          'collision-pkg',
+          { type: 'module', exports: { '.': { import: './index.mjs' } } },
+          { 'index.mjs': "export default 'FARTHER-should-not-load';\n" },
+        );
+        await writePackage(
+          mid,
+          'collision-pkg',
+          {
+            type: 'module',
+            exports: { '.': { browser: './index.browser.mjs' } },
+          },
+          { 'index.browser.mjs': "export default 'nearer-unusable';\n" },
+        );
+
+        const result = await loader.resolveUserModule('collision-pkg', mid);
+
+        expect(result.ok).toBe(false);
+
+        if (!result.ok) {
+          expect(result.reason).toContain('collision-pkg');
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('rejects an exports target that escapes the package directory', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-traversal-'),
+      );
+
+      try {
+        // A file that WOULD load if the traversal guard were missing — sitting just outside the
+        // package directory, exactly where "../escape.mjs" points.
+        await mkdir(join(userProject, 'node_modules'), { recursive: true });
+        await writeFile(
+          join(userProject, 'node_modules', 'escape.mjs'),
+          "export default 'escaped';\n",
+        );
+        await writePackage(
+          userProject,
+          'traversal-pkg',
+          {
+            type: 'module',
+            exports: { '.': { import: '../escape.mjs' } },
+          },
+          {},
+        );
+
+        const result = await loader.resolveUserModule(
+          'traversal-pkg',
+          userProject,
+        );
+
+        expect(result.ok).toBe(false);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('never touches resolve.exports for an absolute specifier', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(join(tmpdir(), 'thymian-esm-abs-'));
+
+      try {
+        // Extensionless absolute path: `resolveThroughRequire` misses (no exact file), and
+        // `resolveThroughGuessing` only guesses `.mjs`/`.cjs`, not `.ts` — so this specifier
+        // reaches `resolveThroughExportsMap` before finally succeeding through jiti. Before the
+        // fix, an absolute specifier here produced an empty `packageName` and scanned the entire
+        // ancestor chain to the filesystem root; the guard should make it a no-op instead.
+        await writeFile(
+          join(userProject, 'abs-rule.ts'),
+          "const rule: string = 'abs-rule';\nexport default rule;\n",
+        );
+
+        const absoluteSpecifier = join(userProject, 'abs-rule');
+        const result = await loader.resolveUserModule(
+          absoluteSpecifier,
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error(
+            'Expected the absolute extensionless specifier to resolve.',
+          );
+        }
+
+        expect(exportsMapCalls).toBe(0);
       } finally {
         await rm(userProject, { recursive: true, force: true });
       }

--- a/packages/core/test/load-user-module.test.ts
+++ b/packages/core/test/load-user-module.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, isAbsolute, join } from 'node:path';
+import { basename, dirname, isAbsolute, join } from 'node:path';
 
 import {
   afterAll,
@@ -1329,6 +1329,330 @@ describe('load user module', () => {
 
       expect(jitiFactoryCalls).toBe(1);
     });
+  });
+
+  describe('resolveThroughExportsMap (conditions-aware bare-specifier resolution)', () => {
+    // Mirrors the "lazy jiti import" describe block's own pattern, independently: these tests
+    // assert on jiti's ABSENCE (an ESM-only package must never need it) or on `resolve.exports`'s
+    // presence/absence (proving whether the new step ran at all), so each needs its own fresh
+    // module registry. Every test below resolves through a freshly `import()`ed `loader`, never
+    // through this file's static top-level `resolveUserModule`/`loadUserModule` bindings — those
+    // were captured before any mock existed and would silently bypass both mocks, the same
+    // false-pass-for-the-wrong-reason trap the "lazy jiti import" block's own comments warn about.
+    let jitiFactoryCalls = 0;
+    let exportsMapCalls = 0;
+
+    beforeEach(() => {
+      jitiFactoryCalls = 0;
+      exportsMapCalls = 0;
+      vi.resetModules();
+      vi.doMock('jiti', async () => {
+        jitiFactoryCalls += 1;
+
+        return await vi.importActual<typeof import('jiti')>('jiti');
+      });
+      vi.doMock('resolve.exports', async () => {
+        const actual =
+          await vi.importActual<typeof import('resolve.exports')>(
+            'resolve.exports',
+          );
+
+        return {
+          ...actual,
+          exports: (...args: Parameters<typeof actual.exports>) => {
+            exportsMapCalls += 1;
+
+            return actual.exports(...args);
+          },
+        };
+      });
+    });
+
+    afterEach(() => {
+      vi.doUnmock('jiti');
+      vi.doUnmock('resolve.exports');
+      vi.resetModules();
+    });
+
+    /** Writes a minimal package to `dir/node_modules/name`, returning the package directory. */
+    async function writePackage(
+      dir: string,
+      name: string,
+      packageJson: Record<string, unknown>,
+      files: Record<string, string>,
+    ): Promise<string> {
+      const pkgDir = join(dir, 'node_modules', name);
+
+      await mkdir(pkgDir, { recursive: true });
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({ name, ...packageJson }),
+      );
+
+      for (const [fileName, contents] of Object.entries(files)) {
+        const filePath = join(pkgDir, fileName);
+
+        await mkdir(dirname(filePath), { recursive: true });
+        await writeFile(filePath, contents);
+      }
+
+      return pkgDir;
+    }
+
+    it('resolves an ESM-only package without ever importing jiti', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(join(tmpdir(), 'thymian-esm-only-'));
+
+      try {
+        await writePackage(
+          userProject,
+          'esm-only-pkg',
+          { type: 'module', exports: { '.': { import: './index.mjs' } } },
+          { 'index.mjs': "export default 'esm-only';\n" },
+        );
+
+        const result = await loader.resolveUserModule(
+          'esm-only-pkg',
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error('Expected "esm-only-pkg" to resolve.');
+        }
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('esm-only');
+        expect(jitiFactoryCalls).toBe(0);
+        expect(exportsMapCalls).toBeGreaterThan(0);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('resolves a subpath through the exports map', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(join(tmpdir(), 'thymian-esm-subpath-'));
+
+      try {
+        await writePackage(
+          userProject,
+          'esm-subpath-pkg',
+          {
+            type: 'module',
+            exports: { './utils': { import: './dist/utils.mjs' } },
+          },
+          { 'dist/utils.mjs': "export default 'esm-subpath-utils';\n" },
+        );
+
+        const result = await loader.resolveUserModule(
+          'esm-subpath-pkg/utils',
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error('Expected "esm-subpath-pkg/utils" to resolve.');
+        }
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('esm-subpath-utils');
+        expect(jitiFactoryCalls).toBe(0);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('resolves a scoped package with a subpath', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(join(tmpdir(), 'thymian-esm-scoped-'));
+
+      try {
+        await writePackage(
+          userProject,
+          '@thymian-test/esm-scoped-pkg',
+          {
+            type: 'module',
+            exports: { './rules': { import: './rules.mjs' } },
+          },
+          { 'rules.mjs': "export default 'esm-scoped-rules';\n" },
+        );
+
+        const result = await loader.resolveUserModule(
+          '@thymian-test/esm-scoped-pkg/rules',
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error(
+            'Expected "@thymian-test/esm-scoped-pkg/rules" to resolve.',
+          );
+        }
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('esm-scoped-rules');
+        expect(jitiFactoryCalls).toBe(0);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('leaves a dual-published package on its existing CJS-conditioned path, untouched', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-dual-published-'),
+      );
+
+      try {
+        await writePackage(
+          userProject,
+          'dual-published-pkg',
+          {
+            type: 'commonjs',
+            exports: {
+              '.': { import: './index.mjs', require: './index.cjs' },
+            },
+          },
+          {
+            'index.mjs': "export default 'dual-esm';\n",
+            'index.cjs': "module.exports = { default: 'dual-cjs' };\n",
+          },
+        );
+
+        const result = await loader.resolveUserModule(
+          'dual-published-pkg',
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error('Expected "dual-published-pkg" to resolve.');
+        }
+
+        // require.resolve applies the CJS condition set and answers the `.cjs` half — preserved
+        // behaviour this story does not change (see the story's Dev Notes and AC5).
+        expect(result.path.endsWith('index.cjs')).toBe(true);
+        expect(exportsMapCalls).toBe(0);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it("prefers the user project's copy over one installed in core's own directory", async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-precedence-'),
+      );
+      // A real directory `require.resolve.paths` walks from `load-user-module.ts`'s own
+      // location — the only way to exercise the "core" anchor honestly, matching how
+      // `BARE_PACKAGE` (an actual workspace dependency) is used elsewhere in this file for the
+      // same reason. Removed in `finally` regardless of outcome.
+      const coreAnchorDir = join(import.meta.dirname, '..');
+      const packageName = 'thymian-test-core-anchor-precedence-esm';
+
+      try {
+        await writePackage(
+          coreAnchorDir,
+          packageName,
+          { type: 'module', exports: { '.': { import: './index.mjs' } } },
+          { 'index.mjs': "export default 'from-core';\n" },
+        );
+        await writePackage(
+          userProject,
+          packageName,
+          { type: 'module', exports: { '.': { import: './index.mjs' } } },
+          { 'index.mjs': "export default 'from-user';\n" },
+        );
+
+        const result = await loader.resolveUserModule(packageName, userProject);
+
+        if (!result.ok) {
+          throw new Error(`Expected "${packageName}" to resolve.`);
+        }
+
+        expect(result.path.startsWith(realpathSync.native(userProject))).toBe(
+          true,
+        );
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('from-user');
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+        await rm(join(coreAnchorDir, 'node_modules', packageName), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }, 15_000);
+
+    it('tries every candidate in an exports fallback array, in order', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-fallback-'),
+      );
+
+      try {
+        await writePackage(
+          userProject,
+          'esm-fallback-pkg',
+          {
+            type: 'module',
+            // './missing.mjs' is never written to disk — the first candidate must be tried and
+            // skipped, not assumed to be the only one.
+            exports: { '.': { import: ['./missing.mjs', './index.mjs'] } },
+          },
+          { 'index.mjs': "export default 'esm-fallback';\n" },
+        );
+
+        const result = await loader.resolveUserModule(
+          'esm-fallback-pkg',
+          userProject,
+        );
+
+        if (!result.ok) {
+          throw new Error('Expected "esm-fallback-pkg" to resolve.');
+        }
+
+        const module = await loader.loadUserModule(result.path);
+
+        expect(module.default).toBe('esm-fallback');
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
+
+    it('falls through to jiti, unresolved, for an exports map with no matching condition', async () => {
+      const loader = await import('../src/load-user-module.js');
+      const userProject = await mkdtemp(
+        join(tmpdir(), 'thymian-esm-no-match-'),
+      );
+
+      try {
+        await writePackage(
+          userProject,
+          'browser-only-pkg',
+          {
+            type: 'module',
+            // Neither `import`, `require` nor `default` — require.resolve AND
+            // resolveThroughExportsMap both miss, so this proves the miss is silent rather than
+            // a thrown error, and that resolution still reaches (and exhausts) jiti's fallback.
+            exports: { '.': { browser: './index.browser.mjs' } },
+          },
+          { 'index.browser.mjs': "export default 'browser-only';\n" },
+        );
+
+        const result = await loader.resolveUserModule(
+          'browser-only-pkg',
+          userProject,
+        );
+
+        expect(result.ok).toBe(false);
+        expect(jitiFactoryCalls).toBe(1);
+      } finally {
+        await rm(userProject, { recursive: true, force: true });
+      }
+    }, 15_000);
   });
 
   describe('when jiti is unavailable or misbehaving', () => {


### PR DESCRIPTION
## Summary
- Adds `resolveThroughExportsMap`, a new resolver step in the shared `resolveUserModule` seam that resolves a bare specifier's ESM `exports` conditions via the `resolve.exports` package, closing the gap where an ESM-only package (exports with only an `import` condition) previously reached jiti just to answer a resolution question.
- Reuses the existing `requireFrom(cwd)`/`require` two-anchor pair for directory discovery, so the user-before-core precedence policy (epic 34 AC10) holds by construction.
- A dual-published package is unaffected — `resolveThroughRequire` already resolves it and the new step is never reached.

Story: thymianofficial/thymian-internal#677 (34.6)

## Test plan
- [x] `nx run core:lint|test|build`
- [x] `nx affected -t test`
- [x] `nx e2e e2e-tests`
- [x] 7 new tests covering: ESM-only root, subpath, scoped+subpath, dual-published non-invocation, user-vs-core precedence, exports fallback array, and no-matching-condition fallthrough to jiti