### PR TITLE
fix(plugin-openapi): build req.path with a URL joiner instead of node:path

### DIFF
--- a/packages/plugin-openapi/eslint.config.mjs
+++ b/packages/plugin-openapi/eslint.config.mjs
@@ -1,7 +1,24 @@
 import baseConfig from '../../eslint.config.mjs';
 
+const noNodePathMessage =
+  "Only URL paths are handled here, and node:path is platform dependent (it joins with '\\' on Windows) and resolves '.'/'..' segments. Use joinUrlPath from src/url-path.ts instead (see thymian-internal#621).";
+
 export default [
   ...baseConfig,
+  {
+    files: ['**/src/processors/**/*.ts', '**/src/url-path.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'node:path', message: noNodePathMessage },
+            { name: 'path', message: noNodePathMessage },
+          ],
+        },
+      ],
+    },
+  },
   {
     files: ['**/*.json'],
     rules: {

--- a/packages/plugin-openapi/eslint.config.mjs
+++ b/packages/plugin-openapi/eslint.config.mjs
@@ -6,7 +6,11 @@ const noNodePathMessage =
 export default [
   ...baseConfig,
   {
-    files: ['**/src/processors/**/*.ts', '**/src/url-path.ts'],
+    files: [
+      '**/src/processors/**/*.ts',
+      '**/src/url-path.ts',
+      '**/src/http-filter-expression-to-operation-filter.ts',
+    ],
     rules: {
       'no-restricted-imports': [
         'error',

--- a/packages/plugin-openapi/src/http-filter-expression-to-operation-filter.ts
+++ b/packages/plugin-openapi/src/http-filter-expression-to-operation-filter.ts
@@ -9,6 +9,7 @@ import type { OpenAPIV3_1 as OpenApiV31 } from 'openapi-types';
 import type { ServerInfo } from './processors/extract-server-info.js';
 import { resolveOpenApiReference } from './processors/openapi-reference-resolver.js';
 import type { Parameters } from './processors/utils.js';
+import { joinUrlPath } from './url-path.js';
 
 export type OperationObjectFilterFn = (args: {
   operationObject: OpenApiV31.OperationObject;
@@ -18,10 +19,6 @@ export type OperationObjectFilterFn = (args: {
   serverInfo: ServerInfo;
   document: OpenApiV31.Document;
 }) => boolean;
-
-function joinUrls(baseUrl: string, path: string): string {
-  return (baseUrl + path).replace(/\/\//g, '/');
-}
 
 function hasQueryParam(params: Parameters, param: string): boolean {
   return Object.keys(params.queryParameters).some((p) =>
@@ -206,7 +203,7 @@ const visitor = createFilterVisitor<OperationObjectFilterFn>({
     }
 
     return ({ path: p, serverInfo }) =>
-      joinUrls(serverInfo.basePath, p).endsWith(path);
+      joinUrlPath(serverInfo.basePath, p).endsWith(path);
   },
   visitHasResponse({ filter }) {
     const nestedFilter = httpFilterExpressionToOperationFilter(filter);

--- a/packages/plugin-openapi/src/processors/openapi.processor.ts
+++ b/packages/plugin-openapi/src/processors/openapi.processor.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import {
   type HttpFilterExpression,
   isNodeType,
@@ -11,6 +9,7 @@ import type { OpenAPIV3_1 as OpenApiV31 } from 'openapi-types';
 
 import { httpFilterExpressionToOperationFilter } from '../http-filter-expression-to-operation-filter.js';
 import type { LocMapper } from '../loc-mapper/loc-mapper.js';
+import { joinUrlPath } from '../url-path.js';
 import { extractServerInfo, type ServerInfo } from './extract-server-info.js';
 import { processLinkObjectParameters } from './link-object.processor.js';
 import { resolveOpenApiReference } from './openapi-reference-resolver.js';
@@ -130,7 +129,7 @@ export class OpenapiProcessor {
         protocol: operationServerInfo.protocol,
         operationId: operationObject.operationId,
         method,
-        path: join(operationServerInfo.basePath, path),
+        path: joinUrlPath(operationServerInfo.basePath, path),
         sourceName: this.sourceName,
       },
       document,

--- a/packages/plugin-openapi/src/url-path.ts
+++ b/packages/plugin-openapi/src/url-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Joins the base path of a server URL with an OpenAPI path template.
+ *
+ * Both operands are URL path segments: `basePath` comes from the `pathname` of
+ * a server URL (see `extractServerInfo`) and `path` is a key of the OpenAPI
+ * `paths` object. `node:path`'s `join` must never be used for this — its
+ * separator is platform dependent, so it produces `\v1\pets` on Windows, and it
+ * resolves `.` and `..` segments, which silently rewrites a path template into
+ * a different operation.
+ *
+ * Semantics:
+ * - Exactly one `/` separates the two operands, and any run of slashes in the
+ *   result collapses to a single one, so a trailing slash on `basePath` and a
+ *   leading slash on `path` do not double up.
+ * - The result is always rooted: an empty `basePath` means "the server root",
+ *   so `('', 'pets')` yields `/pets`.
+ * - A trailing slash on `path` is preserved — `/pets` and `/pets/` are
+ *   different resources.
+ * - `.` and `..` segments are passed through verbatim. A path template is an
+ *   operation identity, not a file location, and resolving them would change
+ *   which operation a selector or filter names.
+ */
+export function joinUrlPath(basePath: string, path: string): string {
+  return `${basePath}/${path}`.replace(/\/{2,}/g, '/');
+}

--- a/packages/plugin-openapi/test/processors/openapi.processor.test.ts
+++ b/packages/plugin-openapi/test/processors/openapi.processor.test.ts
@@ -1,0 +1,89 @@
+import { constant, NoopLogger, path as pathFilter } from '@thymian/core';
+import type { OpenAPIV3_1 as OpenApiV31 } from 'openapi-types';
+import { describe, expect, it } from 'vitest';
+
+import { NoopLocMapper } from '../../src/loc-mapper/noop-loc-mapper.js';
+import type { ServerInfo } from '../../src/processors/extract-server-info.js';
+import { OpenapiProcessor } from '../../src/processors/openapi.processor.js';
+
+const serverInfoWithBasePath: ServerInfo = {
+  // as produced by extractServerInfo from `servers: [{ url: 'http://localhost:8080/v1' }]`
+  basePath: '/v1',
+  host: 'localhost',
+  port: 8080,
+  protocol: 'http',
+};
+
+const document: OpenApiV31.Document = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Test API',
+    version: '1.0.0',
+  },
+  paths: {
+    '/pets': {
+      get: {
+        responses: {
+          '200': { description: 'OK' },
+        },
+      },
+    },
+    '/pets/{petId}': {
+      get: {
+        parameters: [
+          {
+            name: 'petId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      },
+    },
+  },
+};
+
+function requestPaths(
+  serverInfo: ServerInfo,
+  filter = constant(true),
+): string[] {
+  return new OpenapiProcessor(new NoopLogger(), serverInfo, new NoopLocMapper())
+    .process(document, filter)
+    .getThymianHttpTransactions()
+    .map((transaction) => transaction.thymianReq.path);
+}
+
+describe('OpenapiProcessor', () => {
+  it('prefixes every operation path with the base path of the server', () => {
+    expect(requestPaths(serverInfoWithBasePath)).toStrictEqual([
+      '/v1/pets',
+      '/v1/pets/{petId}',
+    ]);
+  });
+
+  it('keeps the path rooted when the server has no base path', () => {
+    expect(
+      requestPaths({ ...serverInfoWithBasePath, basePath: '' }),
+    ).toStrictEqual(['/pets', '/pets/{petId}']);
+  });
+
+  it('joins the base path the same way the path filter does', () => {
+    // the filter and the graph must agree, otherwise a selector matches an
+    // operation whose req.path reads differently (thymian-internal#621)
+    expect(
+      requestPaths(serverInfoWithBasePath, pathFilter('/v1/pets')),
+    ).toStrictEqual(['/v1/pets']);
+  });
+
+  it('never puts a platform separator into req.path', () => {
+    // Passes on POSIX either way — node:path's join and posix.join are the same
+    // implementation there. This assertion only bites on CI's windows-2022 job,
+    // where the old node:path join produced `\v1\pets` (thymian-internal#621).
+    for (const path of requestPaths(serverInfoWithBasePath)) {
+      expect(path).not.toContain('\\');
+    }
+  });
+});

--- a/packages/plugin-openapi/test/url-path.test.ts
+++ b/packages/plugin-openapi/test/url-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { joinUrlPath } from '../src/url-path.js';
+
+describe('joinUrlPath', () => {
+  it.each([
+    // basePath as produced by `new URL(...).pathname`, path as an OpenAPI key
+    ['', '/pets', '/pets'],
+    ['/', '/pets', '/pets'],
+    ['/v1', '/pets', '/v1/pets'],
+    ['/v1/', '/pets', '/v1/pets'],
+    ['/v1', 'pets', '/v1/pets'],
+    ['/v1/', 'pets', '/v1/pets'],
+    // an empty base path means the server root, so the result stays rooted
+    ['', 'pets', '/pets'],
+    ['', '', '/'],
+    ['/', '/', '/'],
+    // path templates are preserved verbatim
+    ['/v1', '/pet/{petId}', '/v1/pet/{petId}'],
+    ['/v1', '/pet/{petId}/uploadImage', '/v1/pet/{petId}/uploadImage'],
+    // a trailing slash on the path is a different resource and is kept
+    ['/v1', '/pets/', '/v1/pets/'],
+    ['/v1', '/', '/v1/'],
+    // runs of slashes collapse, including three or more
+    ['/v1', '//pets', '/v1/pets'],
+    ['/v1', '///pets', '/v1/pets'],
+    ['/v1//', '//pets', '/v1/pets'],
+    ['/v1', '/a//b', '/v1/a/b'],
+    ['/v1', '/a///b', '/v1/a/b'],
+  ])('joins %o and %o into %o', (basePath, path, expected) => {
+    expect(joinUrlPath(basePath, path)).toBe(expected);
+  });
+
+  it.each([
+    ['/v1', '/a/../b', '/v1/a/../b'],
+    ['/v1', '/a/./b', '/v1/a/./b'],
+    ['/v1', '/..', '/v1/..'],
+    ['/v1/..', '/pets', '/v1/../pets'],
+  ])(
+    'does not resolve dot segments when joining %o and %o',
+    (basePath, path, expected) => {
+      expect(joinUrlPath(basePath, path)).toBe(expected);
+    },
+  );
+
+  it('never emits a platform separator', () => {
+    expect(joinUrlPath('/v1', '/pets')).not.toContain('\\');
+  });
+
+  it('treats a backslash as an ordinary path character, not a separator', () => {
+    expect(joinUrlPath('/v1', '/pets\\dogs')).toBe('/v1/pets\\dogs');
+  });
+});


### PR DESCRIPTION
Fixes thymianofficial/thymian-internal#621.

## The bug

`openapi.processor.ts` built `req.path` with `join` from `node:path`. Both operands are **URL** path segments — `basePath` comes from `new URL(...).pathname` — so on Windows this produced `\v1\pets`.

It surfaces now because epic 575 commits a generated `request-types.d.ts` whose `Path` union is built from these strings, and `sampler sync --check` is a CI gate. A checked-in artifact that differs by platform is not a gate. CI's matrix includes `windows-2022`.

## The real defect was two joiners for one job

The package computed "basePath + path" two different ways — `node:path`'s `join` for the value that goes on the graph, and a private `joinUrls` for filter matching. They disagreed in three ways:

| input | `join` (posix) | `joinUrls` |
|---|---|---|
| `/v1` + `/a/../b` | `/v1/b` (resolves) | `/v1/a/../b` |
| `/v1` + `/pets` on win32 | `\v1\pets` | `/v1/pets` |
| `a` + `///b` | `a/b` | `a//b` (regex doesn't rescan) |

So this adds one `joinUrlPath` helper used at **both** call sites and deletes `joinUrls`. `.` and `..` are deliberately **not** resolved: a spec path is an operation template, not a file location, and rewriting `/a/../b` would change which operation a selector names.

The two genuine filesystem joins (`search-for-openapi-files.ts`, `load-openapi.ts`) are untouched.

## Testing a platform bug from POSIX

On POSIX `join` and `posix.join` are identical, so no local test can fail before the fix. Three layers instead:

1. The extracted helper is unit-tested directly — platform-independent by construction. Run against the two implementations it replaces **and** against `win32.join` as a stand-in: 35 failures across the three legacy joiners, 24/24 passing on the new one.
2. An ESLint `no-restricted-imports` rule blocks `node:path` under `src/processors/**` and in `url-path.ts` itself. Verified it fires.
3. A no-backslash assertion on a produced `req.path` — inert on POSIX, earns its keep on the `windows-2022` job.

## Note

One deliberate canonicalisation: `('', 'pets')` now yields `/pets` where both old joiners returned `pets`. `req.path` is an origin-form request target and now a checked-in identity key, so it should always be rooted; OpenAPI requires `paths` keys to begin with `/`, so no conforming document is affected.

## Verification

`plugin-openapi:test` 119 · `run-many -t test` 17 projects · `run-many -t lint` 18 projects, 0 errors. `packages/core` and `packages/plugin-sampler` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)