### PR TITLE
fix(plugin-openapi): skip x- extensions and reject non-integer status keys

### DIFF
--- a/packages/plugin-openapi/src/processors/responses-object.processor.ts
+++ b/packages/plugin-openapi/src/processors/responses-object.processor.ts
@@ -9,6 +9,22 @@ import {
 } from './response-object.processor.js';
 import type { Parameters } from './utils.js';
 
+/**
+ * OpenAPI Specification Extension field names. Extensions are explicitly
+ * allowed in the Responses Object and carry metadata, not responses, so they
+ * must never be interpreted as status codes.
+ *
+ * @see https://spec.openapis.org/oas/v3.1.0#specification-extensions
+ */
+const specificationExtensionPattern = /^x-/;
+
+/**
+ * A status code range written in a case other than the uppercase form the
+ * OpenAPI Specification requires (e.g. `2xx` instead of `2XX`). Only used to
+ * produce a better error message — such keys are rejected, not accepted.
+ */
+const misCasedStatusCodeRangePattern = /^[1-5]xx$/i;
+
 export function processResponsesObject(
   responsesObject: OpenApiV31.ResponsesObject | undefined,
   parameters: Parameters,
@@ -25,6 +41,12 @@ export function processResponsesObject(
   for (const [statusCode, responseObject] of Object.entries(
     responsesObject ?? {},
   )) {
+    if (specificationExtensionPattern.test(statusCode)) {
+      // Skipped before reference resolution: an extension value is not a
+      // Response Object and must not be resolved or coerced as one.
+      continue;
+    }
+
     const resolvedResponse = resolveOpenApiReference<OpenApiV31.ResponseObject>(
       responseObject,
       document,
@@ -49,9 +71,17 @@ export function processResponsesObject(
     } else {
       const statusCodeNumber = +statusCode;
 
-      if (statusCodeNumber < 100 || statusCodeNumber > 599) {
+      if (
+        !Number.isInteger(statusCodeNumber) ||
+        statusCodeNumber < 100 ||
+        statusCodeNumber > 599
+      ) {
         throw new Error(
-          `Invalid status code. Status code must be a valid http status code or status code range (e.g. 2XX), but is ${statusCode}.`,
+          `Invalid status code. Status code must be a valid http status code or status code range (e.g. 2XX), but is ${statusCode}.${
+            misCasedStatusCodeRangePattern.test(statusCode)
+              ? ` Status code ranges must be uppercase, use '${statusCode.toUpperCase()}' instead.`
+              : ''
+          }`,
         );
       }
 

--- a/packages/plugin-openapi/test/processors/responses-object.processor.test.ts
+++ b/packages/plugin-openapi/test/processors/responses-object.processor.test.ts
@@ -1,0 +1,101 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+import { describe, expect, it } from 'vitest';
+
+import { processResponsesObject } from '../../src/processors/responses-object.processor.js';
+import type { Parameters } from '../../src/processors/utils.js';
+
+const document: OpenAPIV3_1.Document = {
+  openapi: '3.1.1',
+  info: {
+    title: 'test',
+    version: '1.0.0',
+  },
+  paths: {},
+};
+
+const parameters: Parameters = {
+  headers: {},
+  cookies: {},
+  pathParameters: {},
+  queryParameters: {},
+};
+
+const okResponse: OpenAPIV3_1.ResponseObject = { description: 'ok' };
+
+function statusCodesOf(
+  responsesObject: OpenAPIV3_1.ResponsesObject | undefined,
+): number[] {
+  return processResponsesObject(responsesObject, parameters, document)
+    .flatMap(({ responses }) => responses)
+    .map(({ statusCode }) => statusCode);
+}
+
+describe('processResponsesObject', () => {
+  it('should return no responses for an undefined Responses Object', () => {
+    expect(statusCodesOf(undefined)).toStrictEqual([]);
+  });
+
+  it('should process a plain status code', () => {
+    expect(statusCodesOf({ '200': okResponse })).toStrictEqual([200]);
+  });
+
+  it('should ignore the default key', () => {
+    expect(statusCodesOf({ default: okResponse })).toStrictEqual([]);
+  });
+
+  it('should expand an uppercase status code range', () => {
+    const statusCodes = statusCodesOf({ '2XX': okResponse });
+
+    expect(statusCodes.length).toBeGreaterThan(1);
+    expect(statusCodes).toContain(200);
+    expect(statusCodes).toContain(204);
+    expect(
+      statusCodes.every(
+        (code) => Number.isInteger(code) && code >= 200 && code <= 299,
+      ),
+    ).toBe(true);
+  });
+
+  it('should skip specification extension keys instead of coercing them to NaN', () => {
+    const statusCodes = statusCodesOf({
+      '200': okResponse,
+      'x-internal-note': 'reviewed by the API guild',
+    } as unknown as OpenAPIV3_1.ResponsesObject);
+
+    expect(statusCodes).toStrictEqual([200]);
+    expect(statusCodes.some((code) => Number.isNaN(code))).toBe(false);
+  });
+
+  it('should skip an object valued specification extension without resolving it as a response', () => {
+    const statusCodes = statusCodesOf({
+      '200': okResponse,
+      'x-linked-response': { $ref: '#/components/responses/DoesNotExist' },
+    });
+
+    expect(statusCodes).toStrictEqual([200]);
+  });
+
+  it('should reject a non-integer status code', () => {
+    expect(() => statusCodesOf({ '200.5': okResponse })).toThrowError(
+      /Invalid status code/,
+    );
+  });
+
+  it('should reject a key that is neither a status code, a range nor an extension', () => {
+    expect(() => statusCodesOf({ ok: okResponse })).toThrowError(
+      /Invalid status code/,
+    );
+  });
+
+  it('should reject a lowercase status code range and point at the uppercase form', () => {
+    expect(() => statusCodesOf({ '2xx': okResponse })).toThrowError(
+      /Status code ranges must be uppercase, use '2XX' instead\./,
+    );
+  });
+
+  it('should reject an uppercase-prefixed pseudo extension key', () => {
+    expect(() => statusCodesOf({ 'X-Internal-Note': okResponse })).toThrowError(
+      /Invalid status code/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes thymianofficial/thymian-internal#634.

## The bug

OpenAPI 3.x permits Specification Extensions in the Responses Object, so this is a **conforming** document:

```yaml
responses:
  '200': { description: OK, content: {...} }
  x-internal-note: reviewed by the API guild
```

`responses-object.processor.ts` treated every non-`default`, non-range key as a status code:

```ts
const statusCodeNumber = +statusCode;                     // +'x-internal-note' → NaN
if (statusCodeNumber < 100 || statusCodeNumber > 599) { throw ... }
```

The guard never fires, because **both comparisons are false for `NaN`**. A response node is created with `statusCode: NaN`.

Pre-existing: `sampler init` used to write a directory literally named `@GET/NaN` and exit 0. Silent garbage. Epic 575 renders every transaction as a selector, so the same document now aborts the load — a louder and better failure, but it makes the underlying bug worth fixing rather than tolerating. The user-visible symptom is a workspace that `thymian lint`s clean (it loads with `emitFormat: false`) and dies on `thymian test`.

## The fix

1. **Skip `^x-` keys**, with the `continue` placed *before* reference resolution. That also removes a second failure mode on conforming input: `x-linked-response: {$ref: '#/components/responses/DoesNotExist'}` previously threw "Could not resolve internal response reference" — an extension value is not a Response Object and should never have been dereferenced.
2. **`!Number.isInteger(statusCodeNumber)`** added to the range guard, so nothing non-integral reaches a response node whatever the key shape. This also closes `'200.5'`, which passed the old `100..599` check.
3. A mis-cased range key (`2xx`) gets an appended corrective sentence rather than silently becoming `NaN`.

## On lowercase `2xx`: reject, and `packages/core` is untouched

`isHttpStatusCodeRange` stays `/^[12345]XX$/`. Thymian's own bundled `@scalar/openapi-parser` already rejects `2xx` — the OAS 3.1 meta-schema matches response keys as `^[1-5](?:[0-9]{2}|XX)$` plus extensions. Accepting it in the transform would make the transform **more permissive than the validator in the same binary**, which is the same split-brain this issue complains about, pointed the other way. The same schema explicitly allows `x-` keys, so "accept `x-`, reject `2xx`" is one rule — follow the OAS schema — not two ad-hoc choices.

## Verification

New `responses-object.processor.test.ts` — **6 of 10 cases fail against the pre-fix source**, 10/10 after. End-to-end: the `x-internal-note` document went from 3 nodes (one with `statusCode: NaN`, serialising as `"statusCode":null`) to 2.

`plugin-openapi:test` 101 · `run-many -t test` 17 projects / 1440 tests · `run-many -t lint` 18 projects, 0 errors.

Two files changed; `packages/core` and `packages/plugin-sampler` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)