### PR TITLE
feat(thymian): generate rule emits only the loadable set (#732)

### DIFF
--- a/packages/thymian/src/commands/generate/rule.ts
+++ b/packages/thymian/src/commands/generate/rule.ts
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { EOL } from 'node:os';
-import { extname, join, relative } from 'node:path';
+import { basename, extname, join, relative } from 'node:path';
 
 import { ThymianBaseCommand, wrap } from '@thymian/common-cli';
 import { Flags, ux } from '@thymian/common-cli/oclif';
@@ -19,7 +19,7 @@ function capitalizeFirstCharacter(str: string): string {
 }
 
 /**
- * Extensions the default (ESM/TypeScript) template may be written to. This is a
+ * Extensions that the default (ESM/TypeScript) template may be written to. This is a
  * deliberately tiny, local copy of the loader's rule — `@thymian/core`'s
  * `unloadableReason`/`LOADABLE_EXTENSIONS` are intra-package and not on the
  * public surface, so the generator cannot import them. The generator only ever
@@ -44,6 +44,13 @@ export function resolveRuleOutputPath(
   output: string,
   cjs: boolean,
 ): RuleOutputResolution {
+  if (basename(output).endsWith('.d.ts')) {
+    return {
+      ok: false,
+      reason: `"${basename(output)}" is a TypeScript declaration file (.d.ts) — declaration files are never loadable, regardless of contents.`,
+    };
+  }
+
   const ext = extname(output);
 
   // `.mts`/`.cts` are never loadable, in either mode (mirrors the loader).

--- a/packages/thymian/src/commands/generate/rule.ts
+++ b/packages/thymian/src/commands/generate/rule.ts
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { EOL } from 'node:os';
-import { join, relative } from 'node:path';
+import { extname, join, relative } from 'node:path';
 
 import { ThymianBaseCommand, wrap } from '@thymian/common-cli';
 import { Flags, ux } from '@thymian/common-cli/oclif';
@@ -16,6 +16,78 @@ import {
 
 function capitalizeFirstCharacter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Extensions the default (ESM/TypeScript) template may be written to. This is a
+ * deliberately tiny, local copy of the loader's rule — `@thymian/core`'s
+ * `unloadableReason`/`LOADABLE_EXTENSIONS` are intra-package and not on the
+ * public surface, so the generator cannot import them. The generator only ever
+ * emits a subset of the loadable set `{.ts,.js,.mjs,.cjs}`: `.ts` by default
+ * and `.cjs` under `--cjs`; it accepts an explicit `.js`/`.mjs` in default
+ * mode. It never emits `.mts`/`.cts`.
+ */
+const ESM_OUTPUT_EXTENSIONS = new Set(['.ts', '.js', '.mjs']);
+
+export type RuleOutputResolution =
+  { ok: true; output: string } | { ok: false; reason: string };
+
+/**
+ * Resolve the final `--output` path for `generate rule`, enforcing that the
+ * generator only ever emits a file the loader can actually load. On a
+ * conflicting explicit extension it DECLINES with a framed reason rather than
+ * silently rewriting the user's path; the only auto-fill is appending the
+ * mode-correct extension when `--output` carries none. The returned `output` is
+ * still relative to `--cwd` (the caller joins it).
+ */
+export function resolveRuleOutputPath(
+  output: string,
+  cjs: boolean,
+): RuleOutputResolution {
+  const ext = extname(output);
+
+  // `.mts`/`.cts` are never loadable, in either mode (mirrors the loader).
+  if (ext === '.mts' || ext === '.cts') {
+    return {
+      ok: false,
+      reason: `"${ext}" is not a loadable extension — .mts/.cts are not supported for rules, rule sets, or plugins; use .ts instead.`,
+    };
+  }
+
+  if (cjs) {
+    if (ext === '.cjs') {
+      return { ok: true, output };
+    }
+    if (ext === '') {
+      return { ok: true, output: `${output}.cjs` };
+    }
+    return {
+      ok: false,
+      reason:
+        `--cjs emits CommonJS (require/module.exports), which must be written to a .cjs file so a "type": "module" project cannot end up with require in a .js file. ` +
+        `Use --output <name>.cjs (or omit the extension).`,
+    };
+  }
+
+  // Default (ESM/TypeScript) mode.
+  if (ext === '') {
+    return { ok: true, output: `${output}.ts` };
+  }
+  if (ESM_OUTPUT_EXTENSIONS.has(ext)) {
+    return { ok: true, output };
+  }
+  if (ext === '.cjs') {
+    return {
+      ok: false,
+      reason:
+        `"${ext}" cannot hold the generated ESM rule (export default) — a .cjs file is CommonJS. ` +
+        `Use --cjs to emit CommonJS, or choose one of .ts, .js, .mjs.`,
+    };
+  }
+  return {
+    ok: false,
+    reason: `"${ext}" is not a loadable extension for a generated rule — expected one of .ts, .js, .mjs (or .cjs with --cjs).`,
+  };
 }
 
 export function createRuleTemplate(meta: RuleMeta, cjs: boolean): string {
@@ -75,11 +147,13 @@ export default class GenerateRule extends ThymianBaseCommand<
     '<%= config.bin %> generate rule --prefix my-org/',
     '<%= config.bin %> generate rule --cjs',
     '<%= config.bin %> generate rule --output src/rules/my-rule.rule.ts',
+    '<%= config.bin %> generate rule --cjs --output src/rules/my-rule.rule.cjs',
   ];
 
   static override flags = {
     cjs: Flags.boolean({
-      description: 'Generate rule using CommonJS syntax.',
+      description:
+        'Generate rule using CommonJS syntax. With --output, the file is written as .cjs.',
       default: false,
     }),
     prefix: Flags.string({
@@ -188,7 +262,11 @@ export default class GenerateRule extends ThymianBaseCommand<
     const template = createRuleTemplate(ruleMeta, this.flags.cjs);
 
     if (this.flags.output) {
-      const outputPath = join(this.flags.cwd, this.flags.output);
+      const resolved = resolveRuleOutputPath(this.flags.output, this.flags.cjs);
+      if (!resolved.ok) {
+        this.error(resolved.reason, { exit: 1 });
+      }
+      const outputPath = join(this.flags.cwd, resolved.output);
       await writeFile(outputPath, template, { encoding: 'utf-8' });
       this.log(
         wrap(

--- a/packages/thymian/src/commands/generate/rule.ts
+++ b/packages/thymian/src/commands/generate/rule.ts
@@ -37,8 +37,12 @@ export type RuleOutputResolution =
  * generator only ever emits a file the loader can actually load. On a
  * conflicting explicit extension it DECLINES with a framed reason rather than
  * silently rewriting the user's path; the only auto-fill is appending the
- * mode-correct extension when `--output` carries none. The returned `output` is
- * still relative to `--cwd` (the caller joins it).
+ * mode-correct extension when `--output` carries none. The returned `output`
+ * is `output` verbatim (plus the auto-filled extension, if any) — an absolute
+ * `--output` is passed through unchanged, not rejected or normalized. The
+ * caller joins it against `--cwd` with `path.join`, which — unlike
+ * `path.resolve` — does not special-case a leading absolute path, so an
+ * absolute `--output` ends up nested under `--cwd` rather than honored as-is.
  */
 export function resolveRuleOutputPath(
   output: string,

--- a/packages/thymian/test/commands/generate-rule.integration.test.ts
+++ b/packages/thymian/test/commands/generate-rule.integration.test.ts
@@ -78,6 +78,14 @@ describe('generate rule — resolveRuleOutputPath (unit)', () => {
       expect(result.ok === false && result.reason).toContain('use .ts instead');
     });
 
+    it('declines .d.ts (both modes) — extname alone would see it as .ts', () => {
+      const result = resolveRuleOutputPath('my-rule.d.ts', false);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain(
+        'declaration file',
+      );
+    });
+
     it('declines .cjs in default mode (ESM export default cannot live in .cjs)', () => {
       const result = resolveRuleOutputPath('my-rule.cjs', false);
       expect(result.ok).toBe(false);
@@ -123,6 +131,14 @@ describe('generate rule — resolveRuleOutputPath (unit)', () => {
       const result = resolveRuleOutputPath(`my-rule${ext}`, true);
       expect(result.ok).toBe(false);
       expect(result.ok === false && result.reason).toContain('use .ts instead');
+    });
+
+    it('declines .d.ts under --cjs too', () => {
+      const result = resolveRuleOutputPath('my-rule.d.ts', true);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain(
+        'declaration file',
+      );
     });
   });
 });

--- a/packages/thymian/test/commands/generate-rule.integration.test.ts
+++ b/packages/thymian/test/commands/generate-rule.integration.test.ts
@@ -1,0 +1,295 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { captureOutput } from '@oclif/test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+
+process.env.OCLIF_TEST_ROOT = join(import.meta.url, '../../..');
+
+// The command gathers RuleMeta through interactive prompts before it ever
+// reaches the write step under test. Mock the prompt module so the integration
+// tests drive it deterministically; the extension behavior is about the write
+// step, not the prompt flow.
+vi.mock('@thymian/common-cli/prompts', () => ({
+  input: vi.fn(),
+  select: vi.fn(),
+  checkbox: vi.fn(),
+}));
+
+import { checkbox, input, select } from '@thymian/common-cli/prompts';
+
+import GenerateRule, {
+  resolveRuleOutputPath,
+} from '../../src/commands/generate/rule.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Prime the mocked prompts with a minimal valid answer set: name "my-rule",
+ * severity "error", a single "lint" (static) rule type, and empty
+ * url/description/summary/appliesTo. `--url ''` is always passed so the url
+ * prompt is skipped (empty string is not nullish), keeping `input` call order
+ * fixed: name, description, summary.
+ */
+function primePrompts(): void {
+  vi.mocked(input)
+    .mockResolvedValueOnce('my-rule') // name
+    .mockResolvedValue(''); // description, summary
+  vi.mocked(select).mockResolvedValue('error');
+  vi.mocked(checkbox)
+    .mockResolvedValueOnce(['static']) // rule types (required, non-empty)
+    .mockResolvedValue([]); // appliesTo
+}
+
+describe('generate rule — resolveRuleOutputPath (unit)', () => {
+  describe('default (ESM/TypeScript) mode', () => {
+    it('no extension defaults to .ts', () => {
+      expect(resolveRuleOutputPath('my-rule', false)).toEqual({
+        ok: true,
+        output: 'my-rule.ts',
+      });
+    });
+
+    it.each(['.ts', '.js', '.mjs'])(
+      'keeps a loadable ESM extension %s unchanged',
+      (ext) => {
+        expect(resolveRuleOutputPath(`my-rule${ext}`, false)).toEqual({
+          ok: true,
+          output: `my-rule${ext}`,
+        });
+      },
+    );
+
+    it.each(['.mts', '.cts'])('declines %s (both modes)', (ext) => {
+      const result = resolveRuleOutputPath(`my-rule${ext}`, false);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain('use .ts instead');
+    });
+
+    it('declines .cjs in default mode (ESM export default cannot live in .cjs)', () => {
+      const result = resolveRuleOutputPath('my-rule.cjs', false);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain('--cjs');
+    });
+
+    it('declines an out-of-set extension', () => {
+      const result = resolveRuleOutputPath('my-rule.txt', false);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain(
+        'expected one of .ts, .js, .mjs',
+      );
+    });
+  });
+
+  describe('--cjs mode', () => {
+    it('no extension appends .cjs', () => {
+      expect(resolveRuleOutputPath('my-rule', true)).toEqual({
+        ok: true,
+        output: 'my-rule.cjs',
+      });
+    });
+
+    it('keeps an explicit .cjs unchanged', () => {
+      expect(resolveRuleOutputPath('my-rule.cjs', true)).toEqual({
+        ok: true,
+        output: 'my-rule.cjs',
+      });
+    });
+
+    it.each(['.js', '.ts', '.mjs'])(
+      'declines a non-.cjs extension %s under --cjs',
+      (ext) => {
+        const result = resolveRuleOutputPath(`my-rule${ext}`, true);
+        expect(result.ok).toBe(false);
+        expect(result.ok === false && result.reason).toContain(
+          'must be written to a .cjs file',
+        );
+      },
+    );
+
+    it.each(['.mts', '.cts'])('declines %s under --cjs too', (ext) => {
+      const result = resolveRuleOutputPath(`my-rule${ext}`, true);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toContain('use .ts instead');
+    });
+  });
+});
+
+describe('generate rule (integration)', () => {
+  let exitSpy: MockInstance<typeof vi.spyOn>;
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = join(__dirname, '__tmp_generate_rule__');
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true });
+    }
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  beforeEach(() => {
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as () => never);
+    primePrompts();
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('default --output with no extension writes a .ts file', async () => {
+    const testDir = join(tmpDir, 'default-no-ext');
+    mkdirSync(testDir, { recursive: true });
+
+    const { stdout } = await captureOutput(async () => {
+      await GenerateRule.run([
+        '--cwd',
+        testDir,
+        '--url',
+        '',
+        '--output',
+        'foo',
+      ]);
+    });
+
+    expect(stdout).toContain('Rule written to');
+    expect(existsSync(join(testDir, 'foo.ts'))).toBe(true);
+    expect(existsSync(join(testDir, 'foo'))).toBe(false);
+
+    const written = await readFile(join(testDir, 'foo.ts'), 'utf-8');
+    expect(written).toContain('export default');
+  });
+
+  it('default --output .mts declines with a framed error and writes nothing', async () => {
+    const testDir = join(tmpDir, 'default-mts');
+    mkdirSync(testDir, { recursive: true });
+
+    const { error } = await captureOutput(async () => {
+      await GenerateRule.run([
+        '--cwd',
+        testDir,
+        '--url',
+        '',
+        '--output',
+        'foo.mts',
+      ]);
+    });
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('use .ts instead');
+    expect(existsSync(join(testDir, 'foo.mts'))).toBe(false);
+  });
+
+  it('--cjs --output with no extension writes foo.cjs (not foo / foo.js)', async () => {
+    const testDir = join(tmpDir, 'cjs-no-ext');
+    mkdirSync(testDir, { recursive: true });
+
+    const { stdout } = await captureOutput(async () => {
+      await GenerateRule.run([
+        '--cwd',
+        testDir,
+        '--cjs',
+        '--url',
+        '',
+        '--output',
+        'foo',
+      ]);
+    });
+
+    expect(stdout).toContain('Rule written to');
+    expect(existsSync(join(testDir, 'foo.cjs'))).toBe(true);
+    expect(existsSync(join(testDir, 'foo'))).toBe(false);
+    expect(existsSync(join(testDir, 'foo.js'))).toBe(false);
+
+    const written = await readFile(join(testDir, 'foo.cjs'), 'utf-8');
+    expect(written).toContain('require');
+    expect(written).toContain('module.exports');
+  });
+
+  it('--cjs --output foo.cjs is written as-is', async () => {
+    const testDir = join(tmpDir, 'cjs-explicit');
+    mkdirSync(testDir, { recursive: true });
+
+    await captureOutput(async () => {
+      await GenerateRule.run([
+        '--cwd',
+        testDir,
+        '--cjs',
+        '--url',
+        '',
+        '--output',
+        'foo.cjs',
+      ]);
+    });
+
+    expect(existsSync(join(testDir, 'foo.cjs'))).toBe(true);
+  });
+
+  it('--cjs --output foo.js declines and writes nothing', async () => {
+    const testDir = join(tmpDir, 'cjs-js');
+    mkdirSync(testDir, { recursive: true });
+
+    const { error } = await captureOutput(async () => {
+      await GenerateRule.run([
+        '--cwd',
+        testDir,
+        '--cjs',
+        '--url',
+        '',
+        '--output',
+        'foo.js',
+      ]);
+    });
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain('must be written to a .cjs file');
+    expect(existsSync(join(testDir, 'foo.js'))).toBe(false);
+    expect(existsSync(join(testDir, 'foo.cjs'))).toBe(false);
+  });
+
+  it('no --output prints the ESM template to stdout and writes no file', async () => {
+    const testDir = join(tmpDir, 'stdout-esm');
+    mkdirSync(testDir, { recursive: true });
+
+    const { stdout } = await captureOutput(async () => {
+      await GenerateRule.run(['--cwd', testDir, '--url', '']);
+    });
+
+    expect(stdout).toContain("import { httpRule } from '@thymian/core'");
+    expect(stdout).toContain('export default');
+    expect(stdout).not.toContain('Rule written to');
+  });
+
+  it('no --output with --cjs prints the CommonJS template to stdout', async () => {
+    const testDir = join(tmpDir, 'stdout-cjs');
+    mkdirSync(testDir, { recursive: true });
+
+    const { stdout } = await captureOutput(async () => {
+      await GenerateRule.run(['--cwd', testDir, '--cjs', '--url', '']);
+    });
+
+    expect(stdout).toContain("const { httpRule } = require('@thymian/core')");
+    expect(stdout).toContain('module.exports');
+    expect(stdout).not.toContain('Rule written to');
+  });
+});


### PR DESCRIPTION
Closes #732. Stacked on #385 (base branch `story/725-3-…`).

`thymian generate rule` previously wrote `--output` files with whatever extension the user typed and zero validation, so `--cjs --output my-rule.js` produced `require`/`module.exports` in a `.js` file — broken in a `type: module` project. This adds an output-extension guard so the generator can only ever emit a file the loader will accept.

## What changed
- New pure exported `resolveRuleOutputPath(output, cjs)` helper, wired into the `--output` branch of `run()` before `writeFile`. The stdout branch is untouched.
  - **default:** no ext → `.ts`; `.ts`/`.js`/`.mjs` written as-is; `.cjs` and anything else → framed `this.error(…, { exit: 1 })` (ESM `export default` can't live in `.cjs`).
  - **`--cjs`:** no ext → `.cjs`; `.cjs` as-is; any other extension → framed decline.
  - `.mts`/`.cts` never emitted, in either mode (message mirrors the loader's wording).
- On a conflicting explicit extension the command declines rather than silently rewriting the path; the only auto-fill is appending the mode-correct extension when `--output` carries none.
- Loadable-set check is a tiny local copy — `@thymian/core`'s `unloadableReason` is intra-package and not on its public surface.
- Added a `--cjs --output …rule.cjs` example and a one-line note on the `--cjs` flag help.

## Tests
- New `generate-rule.integration.test.ts` — 22 tests (pure-helper units + mocked-prompt integration; declines assert the framed error **and** that no file was written).
- `nx test thymian` green (all files); `nx lint thymian` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)