### PR TITLE
fix(plugin-openapi): strip x-* schema extensions; report Ajv compile failures distinctly

### DIFF
--- a/packages/core/src/http-testing/validate/validate-body.ts
+++ b/packages/core/src/http-testing/validate/validate-body.ts
@@ -1,3 +1,4 @@
+import type { ValidateFunction } from 'ajv';
 import { parse } from 'secure-json-parse';
 import { is } from 'type-is';
 
@@ -10,43 +11,11 @@ export function validateJsonBody(
   body: string,
   response: ThymianHttpResponse,
 ): HttpTestCaseResult[] {
+  let json: unknown;
+
   try {
-    const json = parse(body);
-
-    if (!response.schema) {
-      return [
-        {
-          type: 'info',
-          message: 'No response schema is provided.',
-          details: '',
-          timestamp: Date.now(),
-        },
-      ];
-    }
-    const validate = ajv.compile(response.schema);
-
-    validate(json);
-
-    if (validate.errors && validate.errors.length > 0) {
-      // Emit one assertion-failure per schema error instead of collapsing all of
-      // them into a single joined message, so each error is reported on its own.
-      return validate.errors.map((err) => ({
-        type: 'assertion-failure',
-        message: describeSchemaError(err, 'response body'),
-        ...schemaErrorDetail(err),
-        timestamp: Date.now(),
-      }));
-    }
-
-    return [
-      {
-        type: 'assertion-success',
-        message: 'Valid response body.',
-        timestamp: Date.now(),
-      },
-    ];
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
+    json = parse(body);
+  } catch {
     return [
       {
         type: 'assertion-failure',
@@ -55,6 +24,55 @@ export function validateJsonBody(
       },
     ];
   }
+
+  if (!response.schema) {
+    return [
+      {
+        type: 'info',
+        message: 'No response schema is provided.',
+        details: '',
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
+  let validate: ValidateFunction;
+
+  try {
+    validate = ajv.compile(response.schema);
+  } catch (err) {
+    // A schema that does not compile is a defect of the API description
+    // document, not of the observed response body.
+    return [
+      {
+        type: 'assertion-failure',
+        assertion: 'schema-compilation',
+        message: `The response schema in the API description document could not be compiled: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
+  validate(json);
+
+  if (validate.errors && validate.errors.length > 0) {
+    // Emit one assertion-failure per schema error instead of collapsing all of
+    // them into a single joined message, so each error is reported on its own.
+    return validate.errors.map((err) => ({
+      type: 'assertion-failure',
+      message: describeSchemaError(err, 'response body'),
+      ...schemaErrorDetail(err),
+      timestamp: Date.now(),
+    }));
+  }
+
+  return [
+    {
+      type: 'assertion-success',
+      message: 'Valid response body.',
+      timestamp: Date.now(),
+    },
+  ];
 }
 
 export function validateBodyForResponse(

--- a/packages/core/src/http-testing/validate/validate-request-body.ts
+++ b/packages/core/src/http-testing/validate/validate-request-body.ts
@@ -1,3 +1,4 @@
+import type { ValidateFunction } from 'ajv';
 import { parse } from 'secure-json-parse';
 
 import type { ThymianHttpRequest } from '../../index.js';
@@ -9,44 +10,11 @@ export function validateJsonRequestBody(
   body: string,
   request: ThymianHttpRequest,
 ): HttpTestCaseResult[] {
+  let json: unknown;
+
   try {
-    const json = parse(body);
-
-    if (!request.body) {
-      return [
-        {
-          type: 'info',
-          message: 'No request body schema is provided.',
-          details: '',
-          timestamp: Date.now(),
-        },
-      ];
-    }
-
-    const validate = ajv.compile(request.body);
-
-    validate(json);
-
-    if (validate.errors && validate.errors.length > 0) {
-      // Emit one assertion-failure per schema error instead of collapsing all of
-      // them into a single joined message, so each error is reported on its own.
-      return validate.errors.map((err) => ({
-        type: 'assertion-failure',
-        message: describeSchemaError(err, 'request body'),
-        ...schemaErrorDetail(err),
-        timestamp: Date.now(),
-      }));
-    }
-
-    return [
-      {
-        type: 'assertion-success',
-        message: 'Valid request body.',
-        timestamp: Date.now(),
-      },
-    ];
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
+    json = parse(body);
+  } catch {
     return [
       {
         type: 'assertion-failure',
@@ -55,6 +23,55 @@ export function validateJsonRequestBody(
       },
     ];
   }
+
+  if (!request.body) {
+    return [
+      {
+        type: 'info',
+        message: 'No request body schema is provided.',
+        details: '',
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
+  let validate: ValidateFunction;
+
+  try {
+    validate = ajv.compile(request.body);
+  } catch (err) {
+    // A schema that does not compile is a defect of the API description
+    // document, not of the observed request body.
+    return [
+      {
+        type: 'assertion-failure',
+        assertion: 'schema-compilation',
+        message: `The request body schema in the API description document could not be compiled: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      },
+    ];
+  }
+
+  validate(json);
+
+  if (validate.errors && validate.errors.length > 0) {
+    // Emit one assertion-failure per schema error instead of collapsing all of
+    // them into a single joined message, so each error is reported on its own.
+    return validate.errors.map((err) => ({
+      type: 'assertion-failure',
+      message: describeSchemaError(err, 'request body'),
+      ...schemaErrorDetail(err),
+      timestamp: Date.now(),
+    }));
+  }
+
+  return [
+    {
+      type: 'assertion-success',
+      message: 'Valid request body.',
+      timestamp: Date.now(),
+    },
+  ];
 }
 
 export function validateBodyForRequest(

--- a/packages/core/test/http-testing/validate/validate-body.test.ts
+++ b/packages/core/test/http-testing/validate/validate-body.test.ts
@@ -170,6 +170,54 @@ describe('validateJsonBody', () => {
       },
     ]);
   });
+
+  it('reports invalid JSON as a single assertion-failure', () => {
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      headers: {},
+      mediaType: 'application/json',
+      statusCode: 200,
+      schema: { type: 'object' },
+    };
+
+    expect(validateJsonBody('{not json', response)).toStrictEqual([
+      {
+        type: 'assertion-failure',
+        message: 'Response body is not valid JSON.',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
+  it('reports a schema that fails to compile as a defect of the API description', () => {
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      headers: {},
+      mediaType: 'application/json',
+      statusCode: 200,
+      schema: {
+        type: 'object',
+        properties: {
+          duration: {
+            type: 'number',
+            'x-precision': 2,
+          },
+        },
+      } as ThymianHttpResponse['schema'],
+    };
+
+    expect(validateJsonBody('{"duration":1.5}', response)).toStrictEqual([
+      {
+        type: 'assertion-failure',
+        assertion: 'schema-compilation',
+        message:
+          'The response schema in the API description document could not be compiled: strict mode: unknown keyword: "x-precision"',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
 });
 
 describe('validateBodyForResponse', () => {

--- a/packages/core/test/http-testing/validate/validate-request-body.test.ts
+++ b/packages/core/test/http-testing/validate/validate-request-body.test.ts
@@ -78,6 +78,25 @@ describe('validateJsonRequestBody', () => {
     ]);
   });
 
+  it('reports a schema that fails to compile as a defect of the API description', () => {
+    const request = createRequest({
+      type: 'object',
+      'x-enumNames': ['Running', 'Stopped'],
+    });
+
+    const results = validateJsonRequestBody('{"name":"Ada"}', request);
+
+    expect(results).toStrictEqual([
+      {
+        type: 'assertion-failure',
+        assertion: 'schema-compilation',
+        message:
+          'The request body schema in the API description document could not be compiled: strict mode: unknown keyword: "x-enumNames"',
+        timestamp: expect.any(Number),
+      },
+    ]);
+  });
+
   it('returns info when no request body schema is provided', () => {
     const request = createRequest(undefined);
 

--- a/packages/plugin-openapi/src/processors/json-schema.processor.ts
+++ b/packages/plugin-openapi/src/processors/json-schema.processor.ts
@@ -11,6 +11,7 @@ const keysToRemove = new Set([
   'externalDocs',
   'readOnly',
   'writeOnly',
+  'xml',
 ]);
 
 const schemaArrayKeys = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
@@ -139,7 +140,9 @@ function normalizeSchemaObject(
   }
 
   for (const [key, value] of Object.entries(schema)) {
-    if (keysToRemove.has(key) || key === 'example') {
+    // Specification Extensions (`x-*`) are OpenAPI metadata, not JSON Schema
+    // keywords — Ajv's strict mode rejects them at compile time.
+    if (keysToRemove.has(key) || key === 'example' || key.startsWith('x-')) {
       continue;
     }
 

--- a/packages/plugin-openapi/test/processors/json-schema.processor.test.ts
+++ b/packages/plugin-openapi/test/processors/json-schema.processor.test.ts
@@ -1,3 +1,4 @@
+import { type ThymianHttpResponse, validateJsonBody } from '@thymian/core';
 import type { OpenAPIV3_1 as OpenApiV31 } from 'openapi-types';
 import { describe, expect, it } from 'vitest';
 
@@ -160,5 +161,182 @@ describe('processSchema', () => {
         },
       },
     });
+  });
+
+  it('should remove the xml keyword', () => {
+    const schema: OpenApiV31.SchemaObject = {
+      type: 'string',
+      xml: { name: 'animal' },
+    };
+
+    expect(
+      processSchema(schema as Draft202012SchemaObject, {
+        document: emptyDocument,
+      }),
+    ).toStrictEqual({
+      type: 'string',
+    });
+  });
+
+  it('should remove specification extensions at every depth', () => {
+    const schema = {
+      type: 'object',
+      'x-error-category': 'validation',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['running', 'stopped'],
+          'x-enumNames': ['Running', 'Stopped'],
+        },
+        entries: {
+          type: 'array',
+          'x-csv-element-schema': { type: 'string' },
+          items: {
+            type: 'number',
+            'x-precision': 2,
+          },
+        },
+      },
+      allOf: [
+        {
+          type: 'object',
+          'x-requires_permission': 'admin',
+        },
+      ],
+    } as Draft202012SchemaObject;
+
+    expect(
+      processSchema(schema, {
+        document: emptyDocument,
+      }),
+    ).toStrictEqual({
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['running', 'stopped'],
+        },
+        entries: {
+          type: 'array',
+          items: {
+            type: 'number',
+          },
+        },
+      },
+      allOf: [
+        {
+          type: 'object',
+        },
+      ],
+    });
+  });
+
+  it('should remove specification extensions inside localized $defs targets', () => {
+    const document: OpenApiV31.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            'x-requires_module': 'users',
+            properties: {
+              name: {
+                type: 'string',
+                'x-feature-flag': 'new-names',
+              },
+            },
+          } as OpenApiV31.SchemaObject,
+        },
+      },
+    };
+
+    const schema: OpenApiV31.SchemaObject = {
+      type: 'object',
+      properties: {
+        user: {
+          $ref: '#/components/schemas/User',
+        },
+      },
+    };
+
+    expect(
+      processSchema(schema as Draft202012SchemaObject, { document }),
+    ).toStrictEqual({
+      type: 'object',
+      properties: {
+        user: {
+          $ref: '#/$defs/User',
+        },
+      },
+      $defs: {
+        User: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('produces schemas that Ajv strict mode can validate despite x-* extensions in the source', () => {
+    const document: OpenApiV31.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          Entry: {
+            type: 'object',
+            'x-requires_module': 'entries',
+            properties: {
+              duration: {
+                type: 'number',
+                'x-precision': 2,
+              },
+            },
+          } as OpenApiV31.SchemaObject,
+        },
+      },
+    };
+
+    const schema = {
+      type: 'object',
+      'x-error-category': 'validation',
+      properties: {
+        entry: {
+          $ref: '#/components/schemas/Entry',
+        },
+      },
+    } as Draft202012SchemaObject;
+
+    const response: ThymianHttpResponse = {
+      type: 'http-response',
+      label: '200 OK',
+      headers: {},
+      mediaType: 'application/json',
+      statusCode: 200,
+      schema: processSchema(schema, { document }),
+    };
+
+    expect(
+      validateJsonBody('{"entry":{"duration":1.25}}', response),
+    ).toStrictEqual([
+      {
+        type: 'assertion-success',
+        message: 'Valid response body.',
+        timestamp: expect.any(Number),
+      },
+    ]);
   });
 });

--- a/packages/rules-api-description-validation/src/rules/request-body-conforms-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/request-body-conforms-to-schema.rule.ts
@@ -62,12 +62,20 @@ export default httpRule('thymian/request-body-must-conform-to-schema')
         const failures = results.filter((r) => r.type === 'assertion-failure');
 
         if (failures.length > 0) {
+          // A schema-compilation failure is a defect of the API description
+          // document, so it must not be blamed on the observed request body.
+          const message = failures.some(
+            (failure) =>
+              failure.type === 'assertion-failure' &&
+              failure.assertion === 'schema-compilation',
+          )
+            ? 'Request body could not be validated: the schema in the API description document failed to compile'
+            : `Request body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`;
+
           return [
             {
               location,
-              violation: {
-                message: `Request body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
-              },
+              violation: { message },
               findings: httpTestResultToRuleFindings(results),
             },
           ];

--- a/packages/rules-api-description-validation/src/rules/response-body-conforms-to-schema.rule.ts
+++ b/packages/rules-api-description-validation/src/rules/response-body-conforms-to-schema.rule.ts
@@ -68,12 +68,20 @@ export default httpRule('thymian/response-body-must-conforms-to-schema')
         const failures = results.filter((r) => r.type === 'assertion-failure');
 
         if (failures.length > 0) {
+          // A schema-compilation failure is a defect of the API description
+          // document, so it must not be blamed on the observed response body.
+          const message = failures.some(
+            (failure) =>
+              failure.type === 'assertion-failure' &&
+              failure.assertion === 'schema-compilation',
+          )
+            ? 'Response body could not be validated: the schema in the API description document failed to compile'
+            : `Response body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`;
+
           return [
             {
               location,
-              violation: {
-                message: `Response body does not conform to the schema (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
-              },
+              violation: { message },
               findings: httpTestResultToRuleFindings(results),
             },
           ];


### PR DESCRIPTION
Fixes thymianofficial/thymian-internal#622

## Problem

`thymian analyze` reported `Response body is not valid JSON.` for responses whose body **is** valid JSON, whenever the OpenAPI document uses Specification Extensions (`x-*`) inside schemas. Two independent defects combined:

1. **Root cause** — `json-schema.processor.ts` stripped OAS-only keywords (`keysToRemove`) but let `x-*` keys fall through into the `ThymianSchema`. `ajv.ts` builds `Ajv2020` with strict mode at its default (`true`), which **throws at compile time** on unknown keywords (`strict mode: unknown keyword: "x-enumNames"`).
2. **Symptom** — `validate-body.ts`/`validate-request-body.ts` wrapped `parse(body)`, `ajv.compile(...)` and `validate(json)` in a single `try`, discarded `err`, and unconditionally blamed the observed body.

## Changes

- **`plugin-openapi`**: `normalizeSchemaObject` now skips `x-*` keys (the existing recursion covers every depth incl. `$defs` and localized `$ref` targets); `xml` added to `keysToRemove` — the last remaining OAS-only keyword Ajv strict mode rejects. Ajv strict mode stays **on**, so genuine schema-authoring typos still surface. Follows the precedent of #634 (`2161395b`), which skips `x-*` at the Responses-Object level.
- **`core`**: the `try` is narrowed to the JSON parse. Schema compilation gets its own failure path (`assertion: 'schema-compilation'`) that carries the Ajv error text and attributes the defect to the API description document. `err` is never discarded. `validate(json)` runs outside any catch-all.
- **`rules-api-description-validation`**: when the failures stem from schema compilation, the umbrella violation message reads "… could not be validated: the schema in the API description document failed to compile" instead of "… does not conform to the schema".

## Acceptance criteria (from the issue)

1. ✅ Bodies validate against schemas carrying `x-*` at any depth (incl. `$defs`/`$ref` targets) — unit tests + Ajv integration test in `json-schema.processor.test.ts`.
2. ✅ "… is not valid JSON." is emitted only when JSON parsing actually fails.
3. ✅ Uncompilable schemas produce a distinct finding including the Ajv error text.
4. ✅ Regression tests cover parse failure, compile failure, and schema violation for both `validate-body.ts` and `validate-request-body.ts`.

## Verification

- `nx run-many -t test lint typecheck --projects=core,plugin-openapi,rules-api-description-validation` — green (388 + 105 + 12 tests).
- End-to-end against the original repro (Clockodo HAR + OpenAPI 3.1 document, 189 `x-*` occurrences): the two false `Response body is not valid JSON.` findings for `GET /api/v2/clock` and `GET /api/v2/entries` are gone (9 → 7 errors); all other findings unchanged. Counter-check with a deliberately tampered body yields a real schema violation (`property "stopped.id" must be integer`), proving body validation is now actually running.

Note (out of scope, observed during verification): Ajv `strictTypes` warnings now print raw to the console because compilation proceeds further than before — a follow-up should route them through the Thymian logger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)