### PR TITLE
ci(repo): switch CodeQL to advanced setup, excluding test fixtures

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,9 @@ jobs:
         language: [javascript-typescript, actions]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
@@ -40,6 +40,6 @@ jobs:
             paths-ignore:
               - packages/core/test/rules/fixtures/**
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly, matching the cadence of the previous default setup.
+    - cron: '30 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          # Test fixtures contain deliberately invalid JavaScript (e.g. the
+          # glob-syntax-error rule set) that the extractor cannot parse.
+          config: |
+            paths-ignore:
+              - packages/core/test/rules/fixtures/**
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Why

CodeQL's default setup scans every file and offers no path exclusions, so the deliberately invalid test fixture `packages/core/test/rules/fixtures/rule-sets/glob-syntax-error/broken.rule.mjs` produced a permanent **"Could not process some files due to syntax errors"** extraction warning on the tool status page. That warning cannot be dismissed and cannot be avoided on default setup.

## What

- Adds `.github/workflows/codeql.yml` (advanced setup), replicating the previous default-setup configuration: `javascript-typescript` + `actions`, default query suite, weekly schedule, plus scans on pushes/PRs to `main`.
- Excludes `packages/core/test/rules/fixtures/**` from extraction via `paths-ignore`, which removes the syntax-error diagnostic. (ESLint already carries the equivalent ignore for the same fixture in `packages/core/eslint.config.mjs`.)

## Required manual step

Default setup must be **disabled** in Settings → Advanced Security → Code scanning before this workflow can upload results — advanced-setup analyses are rejected while default setup is enabled, so the CodeQL check on this PR will fail until then. Existing alerts are retained across the switch.